### PR TITLE
Accessfield

### DIFF
--- a/timApp/auth/accesshelper.py
+++ b/timApp/auth/accesshelper.py
@@ -45,6 +45,7 @@ from timApp.user.userutils import grant_access
 from timApp.util.flask.requesthelper import get_option, RouteException, NotExist
 from timApp.util.logger import log_warning
 from timApp.util.utils import get_current_time
+from tim_common.markupmodels import AccessField
 
 
 def get_doc_or_abort(doc_id: int, msg: str | None = None) -> DocInfo:
@@ -605,7 +606,10 @@ def verify_task_access(
             context_user, found_plugin.known.accessField, found_plugin.task_id
         )
         if is_invalid:
-            invalidate_reason = "You have expired your access to this task."
+            invalidate_reason = (
+                found_plugin.known.accessField.error
+                or "You have expired your access to this task."
+            )
 
     return TaskAccessVerification(
         plugin=found_plugin,
@@ -617,9 +621,10 @@ def verify_task_access(
 
 
 def check_access_from_field(
-    context_user: UserContext, field_to_check: str, task_id: TaskId
+    context_user: UserContext, access_field: AccessField, task_id: TaskId
 ):
     current_user = context_user.logged_user
+    field_to_check = access_field.field
     tid = TaskId.parse(field_to_check, require_doc_id=False)
     if not tid.doc_id:
         tid = TaskId.parse(str(task_id.doc_id) + "." + field_to_check)
@@ -627,11 +632,11 @@ def check_access_from_field(
     if not prev:
         return True
     try:
-        value = json.loads(prev.content)["c"]
-        if value == "1" or value == 1:
+        value = int(json.loads(prev.content)["c"])
+        if value >= access_field.limit:
             return False
-    except json.decoder.JSONDecodeError:
-        return True
+    except (json.decoder.JSONDecodeError, ValueError):
+        pass
     return True
 
 

--- a/timApp/auth/accesshelper.py
+++ b/timApp/auth/accesshelper.py
@@ -1,4 +1,5 @@
 import ipaddress
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
@@ -595,6 +596,16 @@ def verify_task_access(
         else:
             is_invalid = True
             invalidate_reason = "You haven't started this task yet."
+    if (
+        not is_invalid
+        and found_plugin.known.accessField
+        and required_task_access_level == TaskIdAccess.ReadWrite
+    ):
+        is_invalid = not check_access_from_field(
+            context_user, found_plugin.known.accessField, found_plugin.task_id
+        )
+        if is_invalid:
+            invalidate_reason = "You have expired your access to this task."
 
     return TaskAccessVerification(
         plugin=found_plugin,
@@ -603,6 +614,25 @@ def verify_task_access(
         is_invalid=is_invalid,
         invalidate_reason=invalidate_reason,
     )
+
+
+def check_access_from_field(
+    context_user: UserContext, field_to_check: str, task_id: TaskId
+):
+    current_user = context_user.logged_user
+    tid = TaskId.parse(field_to_check, require_doc_id=False)
+    if not tid.doc_id:
+        tid = TaskId.parse(str(task_id.doc_id) + "." + field_to_check)
+    prev = current_user.get_answers_for_task(tid.doc_task).first()
+    if not prev:
+        return True
+    try:
+        value = json.loads(prev.content)["c"]
+        if value == "1" or value == 1:
+            return False
+    except json.decoder.JSONDecodeError:
+        return True
+    return True
 
 
 def grant_access_to_session_users(i: ItemOrBlock):

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -11,7 +11,7 @@ from lxml.html import HtmlElement
 
 from timApp.answer.answer import Answer
 from timApp.answer.answer_models import AnswerUpload
-from timApp.answer.answers import get_points_by_rule
+from timApp.answer.answers import get_points_by_rule, save_answer
 from timApp.answer.pointsumrule import PointSumRule, PointType
 from timApp.auth.accesstype import AccessType
 from timApp.auth.sessioninfo import user_context_with_logged_in
@@ -2310,3 +2310,69 @@ useCurrentUser: true
 
         self.assertEqual(0, len(self.get_task_answers(f"{d.id}.b")))
         self.assertEqual(0, len(self.get_task_answers(f"{d.id}.GLO_d")))
+
+    def test_accessfield(self):
+        """Invalidate answer if accessField target has answer c: 1"""
+        self.login_test1()
+        d_ext = self.create_doc(
+            initial_par="""
+#- {#access_ext plugin=cbfield}
+        """
+        )
+        d = self.create_doc(
+            initial_par=(
+                """
+#- {#access plugin=cbfield}
+
+#- {#question plugin=textfield}
+accessField: access
+
+#- {#question_ext_accessfield plugin=textfield}
+        """
+                f"accessField: {d_ext.id}.access_ext"
+            )
+        )
+        self.test_user_2.grant_access(d, AccessType.view)
+        self.test_user_2.grant_access(d_ext, AccessType.view)
+        db.session.commit()
+        self.login_test2()
+        access_error = "You have expired your access to this task."
+        resp = self.post_answer(
+            "textfield", f"{d.id}.question", user_input={"c": "testuser2@d"}
+        )
+        self.assertNotIn("error", resp)
+        self.post_answer("cbfield", f"{d.id}.access", user_input={"c": "1"})
+        # int 1 is not valid answer via cbfield answer route, but might be set by jsrunner
+        save_answer(
+            [self.test_user_2],
+            TaskId.parse(f"{d_ext.id}.access_ext"),
+            content={"c": 1},
+            points=None,
+        )
+        db.session.commit()
+        resp = self.post_answer(
+            "textfield", f"{d.id}.question", user_input={"c": "testuser2@d.2"}
+        )
+        self.assertEqual(
+            {
+                "web": {"result": "saved"},
+                "savedNew": 4,
+                "valid": False,
+                "error": access_error,
+            },
+            resp,
+        )
+        resp = self.post_answer(
+            "textfield",
+            f"{d.id}.question_ext_accessfield",
+            user_input={"c": "testuser2@d_ext"},
+        )
+        self.assertEqual(
+            {
+                "web": {"result": "saved"},
+                "savedNew": 5,
+                "valid": False,
+                "error": access_error,
+            },
+            resp,
+        )

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -73,6 +73,7 @@ class KnownMarkupFields(HiddenFieldsMixin):
 
     accessDuration: int | None | Missing = missing
     accessEndText: str | None | Missing = missing
+    accessField: str | None | Missing = missing
     anonymous: bool | None | Missing = missing
     answerLimit: int | None | Missing = missing
     automd: bool | None | Missing = missing

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -68,12 +68,19 @@ class HiddenFieldsMixin:
 
 
 @dataclass
+class AccessField:
+    field: str
+    limit: int
+    error: str | None | Missing = missing
+
+
+@dataclass
 class KnownMarkupFields(HiddenFieldsMixin):
     """Represents the plugin markup fields that are known and used by TIM."""
 
     accessDuration: int | None | Missing = missing
     accessEndText: str | None | Missing = missing
-    accessField: str | None | Missing = missing
+    accessField: AccessField | None | Missing = missing
     anonymous: bool | None | Missing = missing
     answerLimit: int | None | Missing = missing
     automd: bool | None | Missing = missing


### PR DESCRIPTION
#2638 https://timdevs01-3.it.jyu.fi/view/accesfield
 - tehtävä voi katsoa oman laillisuutensa fieldistä
 
Lisää yleisen attribuutin accesField:

accessField:
 field: kenttä jota katsotaan
 limit: minimi numeroarvo, jolla estetään vastaaminen
 error: Oma virheviesti

Oli pohdintaa myös siitä että pitäisikö tuossa olla enemmän mahdollisia sääntöjä: https://github.com/TIM-JYU/TIM/issues/2638#issuecomment-1159405099
Tuota pitäisi periaatteessa voida laajentaa vaihtamalla limit vapaaehtoiseksi attribuutiksi ja lisäämällä muita aliattribuutteja, mutta jos tuohon lukitsevaan fieldiin kirjoitetaan kuitenkin alkuun jsrunnerin tai vastaavan arvosteluskriptin kautta, niin minusta tähän ei kannata ainakaan alkuun laittaa heti alkuun kovin monimutkaista logiikkaa.