### PR TITLE
Add active group switch dialog (#537)

### DIFF
--- a/timApp/admin/util.py
+++ b/timApp/admin/util.py
@@ -1,7 +1,7 @@
 import sre_constants
 import sys
 from argparse import ArgumentParser
-from typing import Generator, Optional, Callable, Union, TypeVar, Any, Iterable
+from typing import Generator, Callable, TypeVar, Any, Iterable
 
 import attr
 import click
@@ -14,7 +14,7 @@ from timApp.folder.folder import Folder
 from timApp.tim_app import app
 from timApp.timdb.exceptions import TimDbException
 from timApp.timdb.sqa import db
-from timApp.user.usergroup import UserGroup
+from timApp.user.usergroup import get_admin_group_id
 
 
 @attr.s
@@ -37,7 +37,7 @@ class DryrunnableArguments(BasicArguments, DryrunnableOnly):
 
 def enum_docs(folder: Folder | None = None) -> Generator[DocInfo, None, None]:
     visited_docs: set[int] = set()
-    admin_id = UserGroup.get_admin_group().id
+    admin_id = get_admin_group_id()
     if not folder:
         folder = Folder.get_root()
     for d in folder.get_all_documents(include_subdirs=True):
@@ -66,7 +66,7 @@ def enum_pars(
     if isinstance(item, Folder) or item is None:
         collection: Iterable[DocInfo] = enum_docs(item)
     else:
-        item.document.modifier_group_id = UserGroup.get_admin_group().id
+        item.document.modifier_group_id = get_admin_group_id()
         collection = [item]
     for d in collection:
         for p in iterate_pars_skip_exceptions(d):

--- a/timApp/auth/access/routes.py
+++ b/timApp/auth/access/routes.py
@@ -1,3 +1,7 @@
+"""
+Common routes for access management.
+"""
+
 from dataclasses import field
 
 from flask import Response
@@ -6,9 +10,9 @@ from timApp.auth.access.util import set_locked_access_type, set_locked_active_gr
 from timApp.auth.accesshelper import verify_logged_in, AccessDenied
 from timApp.auth.accesstype import AccessType
 from timApp.auth.sessioninfo import get_current_user_object
-from timApp.user.groups import verify_group_edit_access
+from timApp.user.groups import verify_group_edit_access, get_group_or_abort
 from timApp.user.usergroup import UserGroup
-from timApp.util.flask.responsehelper import ok_response
+from timApp.util.flask.responsehelper import ok_response, json_response
 from timApp.util.flask.typedblueprint import TypedBlueprint
 
 access = TypedBlueprint("access", __name__, url_prefix="/access")
@@ -18,6 +22,13 @@ access = TypedBlueprint("access", __name__, url_prefix="/access")
 def lock_access(
     access_type: AccessType | None = field(metadata={"by_value": True}),
 ) -> Response:
+    """
+    Lock user's access level.
+    Users with locked access level can preview documents with lower permissions than their own.
+
+    :param access_type: Access type to limit access to. If None, resets access level.
+    :return: OK response.
+    """
     verify_logged_in()
     set_locked_access_type(access_type)
     return ok_response()
@@ -25,6 +36,14 @@ def lock_access(
 
 @access.post("groups/lock")
 def lock_active_groups(group_ids: list[int] | None) -> Response:
+    """
+    Lock users active group list.
+    Users with locked active group list can preview documents as member of only the specified groups.
+
+    :param group_ids: List of group IDs that the user should be locked to.
+                      The user must be either a member of the group or can have edit access to it.
+    :return: OK response.
+    """
     verify_logged_in()
 
     if group_ids is None:
@@ -32,6 +51,7 @@ def lock_active_groups(group_ids: list[int] | None) -> Response:
         return ok_response()
 
     user = get_current_user_object()
+    user.bypass_access_lock = True
 
     group_ids_set = set(group_ids)
     group_ids_set -= set(ug.id for ug in user.groups)
@@ -51,3 +71,52 @@ def lock_active_groups(group_ids: list[int] | None) -> Response:
 
     set_locked_active_groups(set(group_ids))
     return ok_response()
+
+
+@access.get("/groups/editable/info/<group_name>")
+def show_edit_info(group_name: str) -> Response:
+    """
+    Get basic info about a group if the user has edit access to it.
+
+    :param group_name: Group name.
+    :return: JSON of group ID and group name if the user has edit access to the group.
+    """
+    verify_logged_in()
+    user = get_current_user_object()
+    user.bypass_access_lock = True
+    ug = get_group_or_abort(group_name)
+    verify_group_edit_access(ug)
+    return json_response(
+        {
+            "id": ug.id,
+            "name": ug.name,
+        }
+    )
+
+
+@access.get("/groups/editable/find")
+def find_editable_groups(
+    group_ids: list[int] = field(
+        default_factory=list, metadata={"list_type": "delimited"}
+    )
+) -> Response:
+    """
+    Gets a list of groups that the user has edit access to.
+
+    :param group_ids: List of group IDs to filter by.
+    :return: JSON of group IDs and group names that the user has edit access to.
+    """
+    verify_logged_in()
+    user = get_current_user_object()
+    user.bypass_access_lock = True
+    ugs = UserGroup.query.filter(UserGroup.id.in_(group_ids)).all()
+    visible_ugs = [ug for ug in ugs if verify_group_edit_access(ug, require=False)]
+    return json_response(
+        [
+            {
+                "id": ug.id,
+                "name": ug.name,
+            }
+            for ug in visible_ugs
+        ]
+    )

--- a/timApp/auth/access/routes.py
+++ b/timApp/auth/access/routes.py
@@ -2,9 +2,12 @@ from dataclasses import field
 
 from flask import Response
 
-from timApp.auth.access.util import set_locked_access_type
-from timApp.auth.accesshelper import verify_logged_in
+from timApp.auth.access.util import set_locked_access_type, set_locked_active_groups
+from timApp.auth.accesshelper import verify_logged_in, AccessDenied
 from timApp.auth.accesstype import AccessType
+from timApp.auth.sessioninfo import get_current_user_object
+from timApp.user.groups import verify_group_edit_access
+from timApp.user.usergroup import UserGroup
 from timApp.util.flask.responsehelper import ok_response
 from timApp.util.flask.typedblueprint import TypedBlueprint
 
@@ -17,4 +20,34 @@ def lock_access(
 ) -> Response:
     verify_logged_in()
     set_locked_access_type(access_type)
+    return ok_response()
+
+
+@access.post("groups/lock")
+def lock_active_groups(group_ids: list[int] | None) -> Response:
+    verify_logged_in()
+
+    if group_ids is None:
+        set_locked_active_groups(None)
+        return ok_response()
+
+    user = get_current_user_object()
+
+    group_ids_set = set(group_ids)
+    group_ids_set -= set(ug.id for ug in user.groups)
+    group_ids_set -= {
+        UserGroup.get_logged_in_group().id,
+        UserGroup.get_anonymous_group().id,
+    }
+
+    groups: list[UserGroup] = UserGroup.query.filter(
+        UserGroup.id.in_(group_ids_set)
+    ).all()
+    for ug in groups:
+        if not verify_group_edit_access(ug, user, require=False):
+            raise AccessDenied(
+                f"You must be a member of or have edit access to group {ug.name} in order to lock your role."
+            )
+
+    set_locked_active_groups(set(group_ids))
     return ok_response()

--- a/timApp/auth/access/routes.py
+++ b/timApp/auth/access/routes.py
@@ -11,7 +11,11 @@ from timApp.auth.accesshelper import verify_logged_in, AccessDenied
 from timApp.auth.accesstype import AccessType
 from timApp.auth.sessioninfo import get_current_user_object
 from timApp.user.groups import verify_group_edit_access, get_group_or_abort
-from timApp.user.usergroup import UserGroup
+from timApp.user.usergroup import (
+    UserGroup,
+    get_logged_in_group_id,
+    get_anonymous_group_id,
+)
 from timApp.util.flask.responsehelper import ok_response, json_response
 from timApp.util.flask.typedblueprint import TypedBlueprint
 
@@ -56,8 +60,8 @@ def lock_active_groups(group_ids: list[int] | None) -> Response:
     group_ids_set = set(group_ids)
     group_ids_set -= set(ug.id for ug in user.groups)
     group_ids_set -= {
-        UserGroup.get_logged_in_group().id,
-        UserGroup.get_anonymous_group().id,
+        get_logged_in_group_id(),
+        get_anonymous_group_id(),
     }
 
     if not user.is_admin:

--- a/timApp/auth/access/util.py
+++ b/timApp/auth/access/util.py
@@ -24,3 +24,19 @@ def set_locked_access_type(access_type: AccessType | None) -> None:
         session["locked_access_type"] = access_type.value
 
     clear_doc_cache(None, get_current_user_object())
+
+
+def get_locked_active_groups() -> set[int] | None:
+    res = session.get("locked_active_groups", None)
+    return set(res) if res is not None else None
+
+
+def set_locked_active_groups(active_groups: set[int] | None) -> None:
+    from timApp.auth.sessioninfo import get_current_user_object
+
+    if active_groups is None:
+        session.pop("locked_active_groups", None)
+    else:
+        session["locked_active_groups"] = list(active_groups)
+
+    clear_doc_cache(None, get_current_user_object())

--- a/timApp/auth/access/util.py
+++ b/timApp/auth/access/util.py
@@ -1,3 +1,7 @@
+"""
+Utilities for access control.
+"""
+
 from flask import session
 
 from timApp.auth.accesstype import AccessType
@@ -5,6 +9,11 @@ from timApp.document.caching import clear_doc_cache
 
 
 def get_locked_access_type() -> AccessType | None:
+    """
+    Get the locked access type of the current user.
+
+    :return: Access type or None if access type is not locked.
+    """
     locked_access_value = session.get("locked_access_type", None)
     if locked_access_value is None:
         return None
@@ -16,6 +25,11 @@ def get_locked_access_type() -> AccessType | None:
 
 
 def set_locked_access_type(access_type: AccessType | None) -> None:
+    """
+    Set the locked access type of the current user.
+
+    :param access_type: Access type to lock to. If None, resets access type.
+    """
     from timApp.auth.sessioninfo import get_current_user_object
 
     if access_type is None:
@@ -27,11 +41,21 @@ def set_locked_access_type(access_type: AccessType | None) -> None:
 
 
 def get_locked_active_groups() -> set[int] | None:
+    """
+    Get the locked active groups of the current user.
+
+    :return: Set of group IDs or None if active groups are not locked.
+    """
     res = session.get("locked_active_groups", None)
     return set(res) if res is not None else None
 
 
 def set_locked_active_groups(active_groups: set[int] | None) -> None:
+    """
+    Set the locked active groups of the current user.
+
+    :param active_groups: Set of active group IDs to lock to the user to. If None, resets active groups.
+    """
     from timApp.auth.sessioninfo import get_current_user_object
 
     if active_groups is None:

--- a/timApp/document/docentry.py
+++ b/timApp/document/docentry.py
@@ -12,7 +12,7 @@ from timApp.item.block import BlockType
 from timApp.item.block import insert_block
 from timApp.timdb.exceptions import ItemAlreadyExistsException
 from timApp.timdb.sqa import db
-from timApp.user.usergroup import UserGroup
+from timApp.user.usergroup import UserGroup, get_admin_group_id
 from timApp.util.utils import split_location
 
 if TYPE_CHECKING:
@@ -217,9 +217,7 @@ def create_document_and_block(
     document_id = block.id
     document = Document(
         document_id,
-        modifier_group_id=owner_group.id
-        if owner_group
-        else UserGroup.get_admin_group().id,
+        modifier_group_id=owner_group.id if owner_group else get_admin_group_id(),
     )
     document.create()
     return document

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6424,6 +6424,22 @@
           <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5300093725150016824" datatype="html">
+        <source>You are previewing the page with limited group memberships. This affects your active permissions.</source>
+        <target state="translated">Esikatselet sivua, rajoitetulla ryhmäjäsenyydellä. Tämä vaikuttaa aktiivisiin oikeuksiin.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/header/role-info.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="618974627817361434" datatype="html">
+        <source>Reset group lock</source>
+        <target state="translated">Nollaa ryhmälukitus</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/header/role-info.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6288,12 +6288,140 @@
           <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="336898121996677951" datatype="html">
-        <source>You're logged in (access locked to "<x id="PH" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</source>
-        <target state="translated">Olet kirjautunut sisään (käyttöoikeus lukittu tasolle "<x id="PH" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</target>
+      <trans-unit id="4518320880087467484" datatype="html">
+        <source> Could not find the group. Make sure the group exists and you have at least "edit" permissions to it. Details: <x id="INTERPOLATION" equiv-text="{{searchError}}"/> </source>
+        <target state="translated"> Ryhmää ei löydetty. Varmista, että ryhmä on olemassa ja että sinulla on vähintään muokkausoikeudet siihen. Lisätiedot: <x id="INTERPOLATION" equiv-text="{{searchError}}"/> </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">38,41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="547513919687889104" datatype="html">
+        <source>Add groups by using the search box above and pressing "Add".</source>
+        <target state="translated">Lisää ryhmiä käyttämällä yllä olevaa hakukenttää ja painamalla "Lisää".</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1196729008918170847" datatype="html">
+        <source>Filter groups</source>
+        <target state="translated">Suodata ryhmät</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8565771256009142015" datatype="html">
+        <source>Search groups</source>
+        <target state="translated">Hae ryhmiä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3273397109081134139" datatype="html">
+        <source>Switch active groups</source>
+        <target state="translated">Vaihda aktiiviset ryhmät</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">185</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1661747046706720918" datatype="html">
+        <source> You can change active groups by selecting groups from the lists below. Changing active groups allows you to preview the documents as a member of other groups. </source>
+        <target state="translated"> Voit vaihtaa aktiiviset ryhmät alla olevista luetteloista. Aktiivisten ryhmien vaihtaminen mahdollistaa dokumenttien esikatselun muiden ryhmien jäsenenä. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">188,191</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2871426016872254457" datatype="html">
+        <source>Special groups</source>
+        <target state="translated">Erikoisryhmät</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">194</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4348166027193418896" datatype="html">
+        <source>Groups you are a member of</source>
+        <target state="translated">Ryhmät, joihin kuulut</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">198</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5628156195126648528" datatype="html">
+        <source>Other groups (manual search)</source>
+        <target state="translated">Muut ryhmät (manuaalihaku)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">202</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7808756054397155068" datatype="html">
+        <source>Reset</source>
+        <target state="translated">Resetoi</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">208</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4391289919356861627" datatype="html">
+        <source>Apply</source>
+        <target state="translated">Ota käyttöön</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2964263852977363734" datatype="html">
+        <source>Could not change active groups: <x id="PH" equiv-text="r.result.error.error"/></source>
+        <target state="translated">Aktiivisia ryhmiä ei voitu muuttaa:  <x id="PH" equiv-text="r.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">309</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2125919316179555751" datatype="html">
+        <source>Could not reset active groups: <x id="PH" equiv-text="r.result.error.error"/></source>
+        <target state="translated">Aktiivisia ryhmiä ei voitu muuttaa: <x id="PH" equiv-text="r.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">318</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4571331022425790402" datatype="html">
+        <source>Change active groups</source>
+        <target state="translated">Vaihda aktiiviset ryhmät</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
-          <context context-type="linenumber">107,109</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8066011139730077836" datatype="html">
+        <source><x id="PH" equiv-text="this.buttonTitle"/> (access locked to "<x id="PH_1" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</source>
+        <target state="translated"><x id="PH" equiv-text="this.buttonTitle"/> (käyttöoikeus lukittu tasolle "<x id="PH_1" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">122,126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2023139374168209004" datatype="html">
+        <source><x id="PH" equiv-text="this.buttonTitle"/> (group access locked)</source>
+        <target state="translated"><x id="PH" equiv-text="this.buttonTitle"/> (ryhmät lukittu)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">134</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3249513483374643425" datatype="html">
+        <source>Add</source>
+        <target state="translated">Lisää</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6178,12 +6178,140 @@
           <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="336898121996677951" datatype="html">
-        <source>You're logged in (access locked to "<x id="PH" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</source>
-        <target state="translated">Du är inloggad (tillgång låst till "<x id="PH" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</target>
+      <trans-unit id="4518320880087467484" datatype="html">
+        <source> Could not find the group. Make sure the group exists and you have at least "edit" permissions to it. Details: <x id="INTERPOLATION" equiv-text="{{searchError}}"/> </source>
+        <target state="translated"> Kunde inte hitta gruppen. Kontrollera att gruppen finns och att du åtminstone har "redigeringsbehörighet" för den. Detaljer: <x id="INTERPOLATION" equiv-text="{{searchError}}"/> </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">38,41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="547513919687889104" datatype="html">
+        <source>Add groups by using the search box above and pressing "Add".</source>
+        <target state="translated">Lägg till grupper genom att använda sökrutan ovan och trycka på "Lägg till".</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">55</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1196729008918170847" datatype="html">
+        <source>Filter groups</source>
+        <target state="translated">Filtrera grupper</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8565771256009142015" datatype="html">
+        <source>Search groups</source>
+        <target state="translated">Sök grupper</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">83</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3273397109081134139" datatype="html">
+        <source>Switch active groups</source>
+        <target state="translated">Byt aktiv grupp</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">185</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1661747046706720918" datatype="html">
+        <source> You can change active groups by selecting groups from the lists below. Changing active groups allows you to preview the documents as a member of other groups. </source>
+        <target state="translated"> Du kan ändra aktiva grupper genom att välja grupper från listorna nedan. Om du ändrar aktiva grupper kan du förhandsgranska dokumenten som medlem i andra grupper. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">188,191</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2871426016872254457" datatype="html">
+        <source>Special groups</source>
+        <target state="translated">Speciella grupper</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">194</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4348166027193418896" datatype="html">
+        <source>Groups you are a member of</source>
+        <target state="translated">Grupper som du är medlem i</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">198</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5628156195126648528" datatype="html">
+        <source>Other groups (manual search)</source>
+        <target state="translated">Andra grupper (manuell sökning)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">202</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7808756054397155068" datatype="html">
+        <source>Reset</source>
+        <target state="translated">Återställ</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">208</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4391289919356861627" datatype="html">
+        <source>Apply</source>
+        <target state="translated">Ansök på</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">209</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2964263852977363734" datatype="html">
+        <source>Could not change active groups: <x id="PH" equiv-text="r.result.error.error"/></source>
+        <target state="translated">Kunde inte ändra aktiva grupper: <x id="PH" equiv-text="r.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">309</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2125919316179555751" datatype="html">
+        <source>Could not reset active groups: <x id="PH" equiv-text="r.result.error.error"/></source>
+        <target state="translated">Det gick inte att återställa aktiva grupper: <x id="PH" equiv-text="r.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">318</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4571331022425790402" datatype="html">
+        <source>Change active groups</source>
+        <target state="translated">Ändra aktiva grupper</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
-          <context context-type="linenumber">107,109</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8066011139730077836" datatype="html">
+        <source><x id="PH" equiv-text="this.buttonTitle"/> (access locked to "<x id="PH_1" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</source>
+        <target state="translated"><x id="PH" equiv-text="this.buttonTitle"/> (tillgång låst till "<x id="PH_1" equiv-text="accessTypeDisplayNames[this.currentLockedAccess]"/>")</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">122,126</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2023139374168209004" datatype="html">
+        <source><x id="PH" equiv-text="this.buttonTitle"/> (group access locked)</source>
+        <target state="translated"><x id="PH" equiv-text="this.buttonTitle"/> (gruppåtkomst låst)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">134</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3249513483374643425" datatype="html">
+        <source>Add</source>
+        <target state="translated">Lägg till</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6314,6 +6314,22 @@
           <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5300093725150016824" datatype="html">
+        <source>You are previewing the page with limited group memberships. This affects your active permissions.</source>
+        <target state="translated">Du förhandsgranskar sidan med begränsade gruppmedlemskap. Detta påverkar dina aktiva rättigheter.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/header/role-info.component.ts</context>
+          <context context-type="linenumber">19</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="618974627817361434" datatype="html">
+        <source>Reset group lock</source>
+        <target state="translated">Återställ grupplås</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/header/role-info.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/markdown/markdownconverter.py
+++ b/timApp/markdown/markdownconverter.py
@@ -167,7 +167,9 @@ class Belongs:
         b = self.cache.get(groupname, None)
         if b is not None:
             return b
-        b = any(gr.name == groupname for gr in self.user_ctx.logged_user.groups)
+        b = any(
+            gr.name == groupname for gr in self.user_ctx.logged_user.effective_groups
+        )
         self.cache[groupname] = b
         return b
 

--- a/timApp/messaging/timMessage/routes.py
+++ b/timApp/messaging/timMessage/routes.py
@@ -186,9 +186,11 @@ def get_tim_messages_as_list(item_id: int | None = None) -> list[TimMessageData]
             raise NotExist("No document or folder found")
 
         parent_paths = current_page_obj.parent_paths()  # parent folders
-        group_ids = get_current_user_object().group_ids
+        current_group_ids = get_current_user_object().effective_group_ids
 
-        is_user_specific = (InternalMessageDisplay.usergroup_id.in_(group_ids)) & (
+        is_user_specific = (
+            InternalMessageDisplay.usergroup_id.in_(current_group_ids)
+        ) & (
             (InternalMessageDisplay.display_doc_id == current_page_obj.id)
             | (tuple_(Folder.location, Folder.name).in_(parent_paths))
         )

--- a/timApp/sisu/sisu.py
+++ b/timApp/sisu/sisu.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from json import JSONDecodeError
 from textwrap import dedent
-from typing import Optional, Union, Any, Generator
+from typing import Any, Generator
 
 import requests
 from flask import Blueprint, current_app, request, Response
@@ -44,7 +44,11 @@ from timApp.user.groups import (
     verify_group_view_access,
 )
 from timApp.user.user import User
-from timApp.user.usergroup import UserGroup, get_sisu_groups_by_filter
+from timApp.user.usergroup import (
+    UserGroup,
+    get_sisu_groups_by_filter,
+    get_admin_group_id,
+)
 from timApp.util.flask.requesthelper import use_model, RouteException
 from timApp.util.flask.responsehelper import json_response
 from timApp.util.get_fields import (
@@ -164,7 +168,7 @@ def create_groups_route(args: list[GroupCreateModel]) -> Response:
     }
     created = []
     updated = []
-    admin_id = UserGroup.get_admin_group().id
+    admin_id = get_admin_group_id()
     for r in requested_external_ids:
         g = group_map[r]
         name_m = name_map[r]
@@ -265,7 +269,7 @@ def refresh_sisu_grouplist_doc(ug: UserGroup) -> None:
             d = create_sisu_document(
                 sp, f"Sisu groups for course {gn.coursecode.upper()}", owner_group=ug
             )
-            admin_id = UserGroup.get_admin_group().id
+            admin_id = get_admin_group_id()
             d.document.modifier_group_id = admin_id
             d.document.set_settings(settings_to_set)
         else:
@@ -321,7 +325,7 @@ def refresh_sisu_grouplist_doc(ug: UserGroup) -> None:
                         continue
                     if plug.values.get("sisugroups") == ug.external_id.course_id:
                         return
-                d.document.modifier_group_id = UserGroup.get_admin_group().id
+                d.document.modifier_group_id = get_admin_group_id()
                 d.document.add_text(
                     f"""
 # Sisu groups for course {gn.coursecode_and_time}

--- a/timApp/static/scripts/tim/header/role-info.component.ts
+++ b/timApp/static/scripts/tim/header/role-info.component.ts
@@ -12,52 +12,91 @@ import * as t from "io-ts";
 @Component({
     selector: "tim-role-info",
     template: `
-    <tim-alert severity="info"
-               *ngIf="lockedAccess && !hideAccessLockAlert"
-               (closing)="hideAccessLockAlertMessage()"
-               [closeable]="true">
-        <p i18n>
-            You are previewing the page with access limited to level "<strong>{{lockedAccessName}}</strong>".
-        </p>
-        <p>
-            <strong><a (click)="disableAccessLock()" i18n>Turn off access limit</a></strong>
-        </p>
-    </tim-alert>
-  `,
+        <tim-alert severity="info"
+                    *ngIf="activeGroups !== undefined && activeGroups != null && !hideActiveGroupLockAlert"
+                   (closing)="hideActiveGroupLockAlertMessage()"
+                   [closeable]="true">
+            <p i18n>You are previewing the page with limited group memberships. This affects your active permissions.</p>
+            <p>
+                <strong><a (click)="disableActiveGroupsLock()" i18n>Reset group lock</a></strong>
+            </p>
+        </tim-alert>
+        <tim-alert severity="info"
+                   *ngIf="lockedAccess && !hideAccessLockAlert"
+                   (closing)="hideAccessLockAlertMessage()"
+                   [closeable]="true">
+            <p i18n>
+                You are previewing the page with access limited to level "<strong>{{lockedAccessName}}</strong>".
+            </p>
+            <p>
+                <strong><a (click)="disableAccessLock()" i18n>Turn off access limit</a></strong>
+            </p>
+        </tim-alert>
+    `,
     styleUrls: ["./role-info.component.scss"],
 })
 export class RoleInfoComponent implements OnInit {
+    activeGroups?: number[];
     lockedAccess?: AccessType;
     lockedAccessName?: string;
-    private hideAlert = new TimStorage("hideAccessLockAlert", t.boolean);
+    private hideAccessLockAlertStorage = new TimStorage(
+        "hideAccessLockAlert",
+        t.boolean
+    );
+    private hideActiveGroupLockAlertStorage = new TimStorage(
+        "hideActiveGroupLockAlert",
+        t.boolean
+    );
 
     constructor(private access: AccessRoleService) {}
 
     get hideAccessLockAlert() {
-        return this.hideAlert.get() ?? false;
+        return this.hideAccessLockAlertStorage.get() ?? false;
+    }
+
+    get hideActiveGroupLockAlert() {
+        return this.hideActiveGroupLockAlertStorage.get() ?? false;
+    }
+
+    hideActiveGroupLockAlertMessage() {
+        this.hideActiveGroupLockAlertStorage.set(true);
     }
 
     hideAccessLockAlertMessage() {
-        this.hideAlert.set(true);
+        this.hideAccessLockAlertStorage.set(true);
     }
 
     ngOnInit(): void {
         if (!Users.isLoggedIn()) {
-            this.hideAlert.set(false);
+            this.hideAccessLockAlertStorage.set(false);
+            this.hideActiveGroupLockAlertStorage.set(false);
             return;
         }
         const currentUser = Users.getCurrent();
         this.lockedAccess = currentUser.locked_access;
         if (!this.lockedAccess) {
-            this.hideAlert.set(false);
+            this.hideAccessLockAlertStorage.set(false);
         }
         this.lockedAccessName = this.lockedAccess
             ? accessTypeDisplayNames[this.lockedAccess]
             : undefined;
+        this.activeGroups = currentUser.locked_active_groups;
+        if (this.activeGroups === undefined || this.activeGroups === null) {
+            this.hideActiveGroupLockAlertStorage.set(false);
+        }
     }
 
     async disableAccessLock() {
         const r = await this.access.lockAccess(null);
+        if (!r.ok) {
+            await showMessageDialog(
+                $localize`Could not reset lock: ${r.result.error.error}`
+            );
+        }
+    }
+
+    async disableActiveGroupsLock() {
+        const r = await this.access.lockGroups(null);
         if (!r.ok) {
             await showMessageDialog(
                 $localize`Could not reset lock: ${r.result.error.error}`

--- a/timApp/static/scripts/tim/item/access-role.service.ts
+++ b/timApp/static/scripts/tim/item/access-role.service.ts
@@ -90,4 +90,16 @@ export class AccessRoleService {
         }
         return r;
     }
+
+    async lockGroups(groupIds: number[] | null) {
+        const r = await toPromise(
+            this.http.post("/access/groups/lock", {
+                group_ids: groupIds,
+            })
+        );
+        if (r.ok) {
+            location.reload();
+        }
+        return r;
+    }
 }

--- a/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.scss
+++ b/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.scss
@@ -1,0 +1,43 @@
+:host {
+  display: block;
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+
+.item-group {
+  .item-list {
+    overflow-y: auto;
+    max-height: 200px;
+    min-height: 20px;
+    padding-left: 1em;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+
+    &.with-searchbar {
+      border-top: none;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+  }
+
+  p.small {
+    padding: 1em;
+    margin: 0;
+    color: #999;
+  }
+}
+
+.with-searchbar {
+  .form-control, .btn  {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+}
+
+.loading {
+  opacity: 0;
+
+  * {
+    pointer-events: none;
+  }
+}

--- a/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
+++ b/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
@@ -1,0 +1,334 @@
+import {
+    Component,
+    EventEmitter,
+    Input,
+    NgModule,
+    OnChanges,
+    OnInit,
+    Output,
+    SimpleChanges,
+} from "@angular/core";
+import {BrowserModule} from "@angular/platform-browser";
+import {FormsModule} from "@angular/forms";
+import {HttpClient, HttpClientModule} from "@angular/common/http";
+import {AngularDialogComponent} from "../../ui/angulardialog/angular-dialog-component.directive";
+import {DialogModule} from "../../ui/angulardialog/dialog.module";
+import {AccessRoleService} from "../access-role.service";
+import {to2, toPromise} from "../../util/utils";
+import {showMessageDialog} from "../../ui/showMessageDialog";
+import {Users} from "../../user/userService";
+import {TimUtilityModule} from "../../ui/tim-utility.module";
+
+interface GroupInfo {
+    id: number;
+    name: string;
+    selected?: boolean;
+}
+
+@Component({
+    selector: "tim-group-select-list",
+    template: `
+        <div class="item-group">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" [indeterminate]="someSelected" [ngModel]="allSelected" (ngModelChange)="toggleAllSelected($event)">
+                    {{name}}
+                </label>
+            </div>
+            <tim-alert *ngIf="searchError" i18n>
+                Could not find the group. Make sure the group exists and you have at least "edit" permissions to it.
+                Details: {{searchError}}
+            </tim-alert>
+            <div class="with-searchbar input-group" *ngIf="hasSearchBar">
+                <input class="form-control" type="text" [placeholder]="searchPlaceholder" [ngModel]="searchFilter" (ngModelChange)="onSearchInput($event)">
+                <span class="input-group-btn" *ngIf="manualAdd">
+                    <button class="btn btn-default" [disabled]="searchFilter.trim().length == 0" (click)="tryAddGroup()" i18n>Add</button>
+                </span>
+            </div>
+            <div class="item-list" [class.with-searchbar]="hasSearchBar">
+                <div class="checkbox" *ngFor="let group of filteredGroups">
+                    <label>
+                        <input type="checkbox" [ngModel]="group.selected" (ngModelChange)="onSelectGroupChange(group, $event)"> {{group.name}}
+                    </label>
+                </div>
+                <div *ngIf="selectableGroups.length == 0">
+                    <p class="small" i18n>Add groups by using the search box above and pressing "Add".</p>
+                </div>
+            </div>
+        </div>
+    `,
+    styleUrls: ["./active-group-lock-dialog.component.scss"],
+})
+export class GroupSelectListComponent implements OnInit, OnChanges {
+    @Input() name: string = "";
+    @Input() selectableGroups: GroupInfo[] = [];
+    @Input() selectedGroups: number[] = [];
+    @Input() manualAdd = false;
+    @Output() selectedGroupsChange = new EventEmitter<number[]>();
+    searchPlaceholder = $localize`Filter groups`;
+    someSelected = false;
+    allSelected = false;
+    filteredGroups: GroupInfo[] = [];
+    searchFilter: string = "";
+    searchError?: string;
+
+    constructor(private http: HttpClient) {}
+
+    get hasSearchBar() {
+        return this.manualAdd || this.selectableGroups.length > 10;
+    }
+
+    ngOnInit() {
+        if (this.manualAdd) {
+            this.searchPlaceholder = $localize`Search groups`;
+        }
+
+        this.updateSelectedState();
+        this.filteredGroups = this.selectableGroups.slice();
+    }
+
+    private updateSelectedState() {
+        this.allSelected =
+            this.selectableGroups.length > 0 &&
+            this.selectableGroups.every((g) => g.selected);
+        this.someSelected =
+            this.selectableGroups.some((g) => g.selected) && !this.allSelected;
+    }
+
+    toggleAllSelected(newState: boolean) {
+        this.allSelected = newState;
+        this.someSelected = false;
+        const selected = new Set(this.selectedGroups);
+        if (this.allSelected) {
+            for (const group of this.selectableGroups) {
+                group.selected = true;
+                selected.add(group.id);
+            }
+        } else {
+            for (const group of this.selectableGroups) {
+                group.selected = false;
+                selected.delete(group.id);
+            }
+        }
+        this.selectedGroups = Array.from(selected);
+        this.selectedGroupsChange.emit(this.selectedGroups);
+    }
+
+    onSelectGroupChange(group: GroupInfo, state: boolean) {
+        group.selected = state;
+        this.updateSelectedState();
+        if (state) {
+            const selected = new Set(this.selectedGroups);
+            selected.add(group.id);
+            this.selectedGroups = Array.from(selected);
+        } else {
+            this.selectedGroups = this.selectedGroups.filter(
+                (id) => id !== group.id
+            );
+        }
+        this.selectedGroupsChange.emit(this.selectedGroups);
+    }
+
+    onSearchInput(search: string) {
+        this.searchFilter = search;
+        if (this.manualAdd) {
+            return;
+        }
+        this.filteredGroups = this.selectableGroups.filter((g) =>
+            g.name.toLowerCase().includes(search.toLowerCase())
+        );
+    }
+
+    async tryAddGroup() {
+        this.searchError = undefined;
+        const r = await toPromise(
+            this.http.get<GroupInfo>(
+                `/access/groups/editable/info/${this.searchFilter.trim()}`
+            )
+        );
+        if (r.ok) {
+            this.searchFilter = "";
+            const groupInfo = r.result;
+            groupInfo.selected = true;
+            this.selectableGroups.push(groupInfo);
+            this.filteredGroups = this.selectableGroups.slice();
+            this.updateSelectedState();
+            const selected = new Set(this.selectedGroups);
+            selected.add(groupInfo.id);
+            this.selectedGroups = Array.from(selected);
+            this.selectedGroupsChange.emit(this.selectedGroups);
+        } else {
+            this.searchError = r.result.error.error;
+        }
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.selectableGroups) {
+            this.filteredGroups = this.selectableGroups.slice();
+            this.updateSelectedState();
+        }
+        if (changes.selectedGroups) {
+            const selected = new Set(this.selectedGroups);
+            for (const group of this.selectableGroups) {
+                group.selected = selected.has(group.id);
+            }
+            this.updateSelectedState();
+        }
+    }
+}
+
+@Component({
+    selector: "tim-active-group-lock-dialog",
+    template: `
+        <tim-dialog-frame [minimizable]="false" size="lg">
+            <ng-container header>
+                <ng-container i18n>Switch active groups</ng-container>
+            </ng-container>
+            <ng-container body>
+                <p i18n>
+                    You can change active groups by selecting groups from the lists below.
+                    Changing active groups allows you to preview the documents as a member of other groups.
+                </p>
+                <div *ngIf="loading" class="flex justify-center"><tim-loading></tim-loading></div>
+                <tim-group-select-list [class.loading]="loading"
+                        name="Special groups" i18n-name
+                        [selectableGroups]="specialGroups"
+                        [(selectedGroups)]="activeGroups"></tim-group-select-list>
+                <tim-group-select-list [class.loading]="loading"
+                        name="Groups you are a member of" i18n-name
+                        [selectableGroups]="groupsWithMemberships"
+                        [(selectedGroups)]="activeGroups"></tim-group-select-list>
+                <tim-group-select-list [class.loading]="loading"
+                        name="Other groups (manual search)" i18n-name
+                        [selectableGroups]="groupsWithAccess"
+                        [manualAdd]="true"
+                        [(selectedGroups)]="activeGroups"></tim-group-select-list>
+            </ng-container>
+            <ng-container footer>
+                <button class="timButton" (click)="reset()" i18n>Reset</button>
+                <button class="timButton" (click)="apply()" i18n>Apply</button>
+                <button class="timButton" (click)="dismiss()" i18n>Close</button>
+            </ng-container>
+        </tim-dialog-frame>
+    `,
+    styleUrls: ["./active-group-lock-dialog.component.scss"],
+})
+export class ActiveGroupLockDialogComponent extends AngularDialogComponent<
+    unknown,
+    unknown
+> {
+    protected dialogName = "activeGroupLockDialog";
+    loading = false;
+    activeGroups: number[] = [];
+    groupsWithMemberships: GroupInfo[] = [];
+    groupsWithAccess: GroupInfo[] = [];
+    specialGroups: GroupInfo[] = [];
+    private defaultActiveGroups = new Set<number>();
+
+    constructor(
+        private accessRole: AccessRoleService,
+        private http: HttpClient
+    ) {
+        super();
+    }
+
+    async ngOnInit() {
+        this.loading = true;
+        await this.initSpecialGroups();
+        this.groupsWithMemberships = Users.getCurrent().groups.map((g) => ({
+            id: g.id,
+            name: g.name,
+        }));
+        this.defaultActiveGroups = new Set([
+            ...this.groupsWithMemberships.map((g) => g.id),
+            ...this.specialGroups.map((g) => g.id),
+        ]);
+        await this.initSelectedAccessibleGroups();
+
+        this.activeGroups =
+            Users.getCurrent().locked_active_groups ??
+            Array.from(this.defaultActiveGroups);
+        this.loading = false;
+    }
+
+    private async initSpecialGroups() {
+        const r = await toPromise(
+            this.http.get<GroupInfo[]>("/groups/special")
+        );
+        if (r.ok) {
+            this.specialGroups = r.result;
+        }
+    }
+
+    private async initSelectedAccessibleGroups() {
+        const activeGroups = Users.getCurrent().locked_active_groups;
+        if (activeGroups) {
+            const nonDefaultGroups = activeGroups.filter(
+                (g) => !this.defaultActiveGroups.has(g)
+            );
+            const er = await toPromise(
+                this.http.get<GroupInfo[]>("/access/groups/editable/find", {
+                    params: {
+                        group_ids: nonDefaultGroups.join(","),
+                    },
+                })
+            );
+            if (er.ok) {
+                this.groupsWithAccess = er.result;
+            }
+        }
+    }
+
+    private static areSetsSame(a: Set<number>, b: Set<number>) {
+        if (a.size !== b.size) {
+            return false;
+        }
+        for (const id of a) {
+            if (!b.has(id)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    async apply() {
+        const activeGroups = new Set(this.activeGroups);
+        if (
+            ActiveGroupLockDialogComponent.areSetsSame(
+                activeGroups,
+                this.defaultActiveGroups
+            )
+        ) {
+            await this.reset();
+            return;
+        }
+
+        const r = await to2(this.accessRole.lockGroups(this.activeGroups));
+        if (!r.ok) {
+            await showMessageDialog(
+                $localize`Could not change active groups: ${r.result.error.error}`
+            );
+        }
+    }
+
+    async reset() {
+        const r = await to2(this.accessRole.lockGroups(null));
+        if (!r.ok) {
+            await showMessageDialog(
+                $localize`Could not reset active groups: ${r.result.error.error}`
+            );
+        }
+    }
+}
+
+@NgModule({
+    declarations: [ActiveGroupLockDialogComponent, GroupSelectListComponent],
+    imports: [
+        BrowserModule,
+        DialogModule,
+        FormsModule,
+        HttpClientModule,
+        TimUtilityModule,
+    ],
+})
+export class ActiveGroupLockDialogModule {}

--- a/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
+++ b/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
@@ -39,7 +39,7 @@ interface GroupInfo {
                 Could not find the group. Make sure the group exists and you have at least "edit" permissions to it.
                 Details: {{searchError}}
             </tim-alert>
-            <div class="with-searchbar input-group" *ngIf="hasSearchBar">
+            <div class="with-searchbar" [class.input-group]="manualAdd" *ngIf="hasSearchBar">
                 <input class="form-control" type="text" [placeholder]="searchPlaceholder" [ngModel]="searchFilter" (ngModelChange)="onSearchInput($event)">
                 <span class="input-group-btn" *ngIf="manualAdd">
                     <button class="btn btn-default" [disabled]="searchFilter.trim().length == 0" (click)="tryAddGroup()" i18n>Add</button>

--- a/timApp/static/scripts/tim/item/active-group-lock-dialog/showGroupLockDialog.ts
+++ b/timApp/static/scripts/tim/item/active-group-lock-dialog/showGroupLockDialog.ts
@@ -1,0 +1,10 @@
+import {angularDialog} from "../../ui/angulardialog/dialog.service";
+
+export async function showGroupLockDialog() {
+    const {ActiveGroupLockDialogComponent} = await import(
+        "./active-group-lock-dialog.component"
+    );
+    return await (
+        await angularDialog.open(ActiveGroupLockDialogComponent, {})
+    ).result;
+}

--- a/timApp/static/scripts/tim/user/IUser.ts
+++ b/timApp/static/scripts/tim/user/IUser.ts
@@ -53,6 +53,7 @@ export interface IFullUser extends IUser {
 
 export interface ICurrentUser extends IFullUser {
     locked_access?: AccessType;
+    locked_active_groups?: number[];
 }
 
 export interface IGroup {

--- a/timApp/static/scripts/tim/user/user-menu.component.ts
+++ b/timApp/static/scripts/tim/user/user-menu.component.ts
@@ -34,6 +34,9 @@ import {Users} from "./userService";
                 role="menu"
                 aria-labelledby="single-button">
                 <ng-container *ngIf="!hideOptions.userMenuOptions">
+                    <li role="menuitem">
+                        <a (click)="lockActiveGroups()">Test</a>
+                    </li>
                     <li role="menuitem"><a
                             href="/view/{{ getCurrentUser().folder!.path }}" i18n>My documents</a></li>
 
@@ -137,6 +140,15 @@ export class UserMenuComponent implements OnInit {
         if (!r.ok) {
             await showMessageDialog(
                 $localize`Could not lock access: ${r.result.error.error}`
+            );
+        }
+    }
+
+    async lockActiveGroups() {
+        const r = await this.access.lockGroups([10]);
+        if (!r.ok) {
+            await showMessageDialog(
+                $localize`Could not set groups: ${r.result.error.error}`
             );
         }
     }

--- a/timApp/tests/db/test_users.py
+++ b/timApp/tests/db/test_users.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import timedelta
 
 from timApp.auth.accesstype import AccessType
@@ -181,7 +180,7 @@ class UserTest(TimDbTest):
 
         user.groups.append(UserGroup.get_admin_group())
         db.session.commit()
-        del user.__dict__["is_admin"]
+        user.__dict__.pop("is_admin", None)
         for b in (test_block, test_block_2):
             self.assertTrue(user.has_manage_access(b))
             self.assertTrue(user.has_edit_access(b))

--- a/timApp/tests/server/test_access_lock.py
+++ b/timApp/tests/server/test_access_lock.py
@@ -2,7 +2,11 @@ from timApp.auth.accesstype import AccessType
 from timApp.markdown.markdownconverter import md_to_html
 from timApp.tests.server.timroutetest import TimRouteTest
 from timApp.timdb.sqa import db
-from timApp.user.usergroup import UserGroup
+from timApp.user.usergroup import (
+    UserGroup,
+    get_logged_in_group_id,
+    get_anonymous_group_id,
+)
 from timApp.user.usergroupmember import UserGroupMember
 
 
@@ -200,8 +204,8 @@ Test user 2
             {
                 "group_ids": [
                     ug.id,
-                    UserGroup.get_anonymous_group().id,
-                    UserGroup.get_logged_in_group().id,
+                    get_anonymous_group_id(),
+                    get_logged_in_group_id(),
                 ],
             },
             expect_status=200,
@@ -226,8 +230,8 @@ Test user 2
             {
                 "group_ids": [
                     ug.id,
-                    UserGroup.get_anonymous_group().id,
-                    UserGroup.get_logged_in_group().id,
+                    get_anonymous_group_id(),
+                    get_logged_in_group_id(),
                 ],
             },
             expect_status=200,
@@ -247,8 +251,8 @@ Test user 2
                 "group_ids": [
                     self.test_user_2.get_personal_group().id,
                     ug.id,
-                    UserGroup.get_anonymous_group().id,
-                    UserGroup.get_logged_in_group().id,
+                    get_anonymous_group_id(),
+                    get_logged_in_group_id(),
                 ],
             },
             expect_status=400,
@@ -262,8 +266,8 @@ Test user 2
                 "group_ids": [
                     self.test_user_2.get_personal_group().id,
                     ug.id,
-                    UserGroup.get_anonymous_group().id,
-                    UserGroup.get_logged_in_group().id,
+                    get_anonymous_group_id(),
+                    get_logged_in_group_id(),
                 ],
             },
             expect_status=200,

--- a/timApp/tests/server/test_default_rights.py
+++ b/timApp/tests/server/test_default_rights.py
@@ -11,7 +11,7 @@ from timApp.item.block import BlockType
 from timApp.tests.server.timroutetest import TimRouteTest
 from timApp.tim_app import get_home_organization_group
 from timApp.timdb.sqa import db
-from timApp.user.usergroup import UserGroup
+from timApp.user.usergroup import get_anonymous_group_id
 from timApp.user.users import get_rights_holders, get_default_rights_holders
 from timApp.user.userutils import grant_default_access, default_right_paths
 
@@ -34,7 +34,7 @@ class DefaultRightTest(TimRouteTest):
             [kg], users_folder, AccessType.view, BlockType.Document
         )
         db.session.commit()
-        anon_id = UserGroup.get_anonymous_group().id
+        anon_id = get_anonymous_group_id()
         for obj_type_str in ("document", "folder"):
             obj_type = BlockType.from_str(obj_type_str)
             def_rights = get_default_rights_holders(folder, obj_type)
@@ -147,7 +147,7 @@ class DefaultRightTest(TimRouteTest):
                 {
                     "id": folder.id,
                     "type": AccessType.view.value,
-                    "group": UserGroup.get_anonymous_group().id,
+                    "group": get_anonymous_group_id(),
                     "item_type": obj_type_str,
                 },
                 expect_content=self.ok_resp,

--- a/timApp/tests/server/test_permissions.py
+++ b/timApp/tests/server/test_permissions.py
@@ -10,7 +10,7 @@ from timApp.item.item import Item
 from timApp.tests.server.test_default_rights import convert_to_old_format
 from timApp.tests.server.timroutetest import TimRouteTest
 from timApp.timdb.sqa import db
-from timApp.user.usergroup import UserGroup
+from timApp.user.usergroup import UserGroup, get_logged_in_group_id
 from timApp.user.userutils import grant_access
 from timApp.util.utils import get_current_time
 
@@ -233,7 +233,7 @@ class PermissionTest(TimRouteTest):
             {
                 "id": d.id,
                 "type": AccessType.view.value,
-                "group": UserGroup.get_logged_in_group().id,
+                "group": get_logged_in_group_id(),
             },
         )
         self.login_test2()

--- a/timApp/tests/server/test_scim.py
+++ b/timApp/tests/server/test_scim.py
@@ -1,6 +1,6 @@
 import json
 from operator import itemgetter
-from typing import Any, Optional
+from typing import Any
 from unittest import mock
 from unittest.mock import Mock
 
@@ -20,7 +20,7 @@ from timApp.tim_app import app
 from timApp.timdb.sqa import db
 from timApp.user.user import User, UserOrigin, UserInfo
 from timApp.user.usercontact import ContactOrigin
-from timApp.user.usergroup import UserGroup, DELETED_GROUP_PREFIX
+from timApp.user.usergroup import UserGroup, DELETED_GROUP_PREFIX, get_admin_group_id
 from timApp.util.utils import seq_to_str, get_current_time
 
 a = ("t", "pass")
@@ -969,7 +969,7 @@ class ScimTest(TimRouteTest):
                 for ac in d.block.accesses.values()
             },
         )
-        admin = UserGroup.get_admin_group().id
+        admin = get_admin_group_id()
         self.assertEqual(admin, d.document.get_changelog().entries[0].group_id)
         self.login(username="ut-1")
         self.get(d.url)

--- a/timApp/user/groups.py
+++ b/timApp/user/groups.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from operator import attrgetter
-from typing import Any, Optional
+from typing import Any
 
 from flask import Response
 
@@ -63,6 +63,25 @@ def get_uid_gid(group_name, usernames) -> tuple[UserGroup, list[User]]:
     group = UserGroup.query.filter_by(name=group_name).first()
     raise_group_not_found_if_none(group_name, group)
     return group, users
+
+
+@groups.get("/special")
+def get_special_groups() -> Response:
+    """
+    Gets a list of special public metagroups that can be used to target users.
+
+    :return: A JSON list of common metagroups (logged-in users, anonymous users, etc.)
+    """
+    res = [UserGroup.get_anonymous_group(), UserGroup.get_logged_in_group()]
+    return json_response(
+        [
+            {
+                "id": ug.id,
+                "name": ug.name,
+            }
+            for ug in res
+        ]
+    )
 
 
 @groups.get("/getOrgs")

--- a/timApp/user/user.py
+++ b/timApp/user/user.py
@@ -56,6 +56,9 @@ from timApp.user.usercontact import (
 )
 from timApp.user.usergroup import (
     UserGroup,
+    get_admin_group_id,
+    get_anonymous_group_id,
+    get_logged_in_group_id,
 )
 from timApp.user.usergroupmember import (
     UserGroupMember,
@@ -564,9 +567,9 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
 
         def effective_real_groups():
             res = {g.id for g in self.groups}
-            res.add(UserGroup.get_anonymous_group().id)
+            res.add(get_anonymous_group_id())
             if self.logged_in:
-                res.add(UserGroup.get_logged_in_group().id)
+                res.add(get_logged_in_group_id())
             return res
 
         if not self.is_current_user:
@@ -578,8 +581,7 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
 
     @cached_property
     def is_admin(self):
-        admins_id = UserGroup.get_admin_group().id
-        return admins_id in self.effective_group_ids
+        return get_admin_group_id() in self.effective_group_ids
 
     @property
     def is_email_user(self):
@@ -1145,8 +1147,8 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
         :return: The best access object that user currently has for the given item or block and access types.
         """
         curr_group_ids = self.effective_group_ids
-        admin_group = UserGroup.get_admin_group()
-        if allow_admin and admin_group.id in curr_group_ids:
+        admin_group_id = get_admin_group_id()
+        if allow_admin and admin_group_id in curr_group_ids:
             result = BlockAccess(
                 block_id=i.id,
                 accessible_from=datetime.min.replace(tzinfo=timezone.utc),

--- a/timApp/user/usergroup.py
+++ b/timApp/user/usergroup.py
@@ -284,6 +284,11 @@ def get_anonymous_group_id() -> int:
     return UserGroup.get_anonymous_group().id
 
 
+@lru_cache
+def get_admin_group_id() -> int:
+    return UserGroup.get_admin_group().id
+
+
 def get_usergroup_eager_query():
     from timApp.item.block import Block
 


### PR DESCRIPTION
Lisää käyttäjämenuun oikeuksien lukitus/rajoituspainikkeen (ks #537):

![kuva](https://user-images.githubusercontent.com/5202606/174672911-705dea22-3fac-4394-a1dc-bb4a52bde695.png)

Tämä avaa rajoitusdialogin, jossa oma ryhmäjäsenyys voi väliaikaisesti rajoittaa:

![kuva](https://user-images.githubusercontent.com/5202606/174672994-dc6baeff-fdc5-43db-b60a-c904d23d14a4.png)

Asettamalla ruksit eri tavalla voidaan testata eri dokumenttien toimintaa ja näkyvyyttä erilaisilla ryhmillä. 

Huomiot:

* Ryhmäjäsenyyden rajoittaminen pätee vain oikeuksiin (oikeus nähdä dokumentit, oikeus vastata tehtäviin, oikeus tehdä muita toimintoja). Rajoitus ei muuta todellista jäsenyyden tilaa.
* Ryhmäjäsenyys voi rajoittaa ryhmiin, johon kuulut tai johon sinulla on **vähintään edit-oikeus**
* Tehokkuussyistä **edit**-oikeudelliset ryhmät ei näytetä suoraan. Sen sijaan dialogissa on hakulaatikko, jonka kautta ryhmät voi lisätä listaan.
  * Admin voi hakea ryhmien lisäksi käyttäjien henkilökohtaiset ryhmät

Esimerkki: <https://timdevs01-2.it.jyu.fi/view/users/dz-dz/test-group-switch>  
Esimerkkisivulla käyttäjillä testuser1, testuser2 ja testuser3 on kasvavasti view, copy ja edit-oikeus.
Lisäksi he ovat ryhmän testgroup1-jäsenet, jolla on manage-oikeus.

Käyttäjällä testuser1 on edit-oikeus ryhmään testgroup2, jolla voi testata sen ryhmän haku dialogista.
