### PR TITLE
Improve UI of group locking (closes #3078)

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6344,14 +6344,6 @@
           <context context-type="linenumber">194</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4348166027193418896" datatype="html">
-        <source>Groups you are a member of</source>
-        <target state="translated">Ryhmät, joihin kuulut</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
-          <context context-type="linenumber">198</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5628156195126648528" datatype="html">
         <source>Other groups (manual search)</source>
         <target state="translated">Muut ryhmät (manuaalihaku)</target>
@@ -6438,6 +6430,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/header/role-info.component.ts</context>
           <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2428405807903733182" datatype="html">
+        <source>Managed groups you are a member of</source>
+        <target state="translated">Hallitut ryhmät, joihin kuulut</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">205</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4723263024869597820" datatype="html">
+        <source>Unmanaged groups you are a member of</source>
+        <target state="translated">Hallitsemattomat ryhmät, joihin kuulut</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6234,14 +6234,6 @@
           <context context-type="linenumber">194</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4348166027193418896" datatype="html">
-        <source>Groups you are a member of</source>
-        <target state="translated">Grupper som du är medlem i</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
-          <context context-type="linenumber">198</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5628156195126648528" datatype="html">
         <source>Other groups (manual search)</source>
         <target state="translated">Andra grupper (manuell sökning)</target>
@@ -6328,6 +6320,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/header/role-info.component.ts</context>
           <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2428405807903733182" datatype="html">
+        <source>Managed groups you are a member of</source>
+        <target state="translated">Hanterade grupper som du är medlem i</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">205</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4723263024869597820" datatype="html">
+        <source>Unmanaged groups you are a member of</source>
+        <target state="translated">Ohanterade grupper som du är medlem i</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
+++ b/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
@@ -19,9 +19,12 @@ import {showMessageDialog} from "../../ui/showMessageDialog";
 import {Users} from "../../user/userService";
 import {TimUtilityModule} from "../../ui/tim-utility.module";
 
+const ANONYMOUS_GROUPNAME = "Anonymous users";
+
 interface GroupInfo {
     id: number;
     name: string;
+    managed: boolean;
     selected?: boolean;
 }
 
@@ -29,7 +32,7 @@ interface GroupInfo {
     selector: "tim-group-select-list",
     template: `
         <div class="item-group">
-            <div class="checkbox">
+            <div class="checkbox" *ngIf="hasMultipleGroups">
                 <label>
                     <input type="checkbox" [indeterminate]="someSelected" [ngModel]="allSelected" (ngModelChange)="toggleAllSelected($event)">
                     {{name}}
@@ -45,7 +48,7 @@ interface GroupInfo {
                     <button class="btn btn-default" [disabled]="searchFilter.trim().length == 0" (click)="tryAddGroup()" i18n>Add</button>
                 </span>
             </div>
-            <div class="item-list" [class.with-searchbar]="hasSearchBar">
+            <div [class.item-list]="hasMultipleGroups" [class.with-searchbar]="hasSearchBar">
                 <div class="checkbox" *ngFor="let group of filteredGroups">
                     <label>
                         <input type="checkbox" [ngModel]="group.selected" (ngModelChange)="onSelectGroupChange(group, $event)"> {{group.name}}
@@ -76,6 +79,10 @@ export class GroupSelectListComponent implements OnInit, OnChanges {
 
     get hasSearchBar() {
         return this.manualAdd || this.selectableGroups.length > 10;
+    }
+
+    get hasMultipleGroups() {
+        return this.hasSearchBar || this.selectableGroups.length > 1;
     }
 
     ngOnInit() {
@@ -234,11 +241,10 @@ export class ActiveGroupLockDialogComponent extends AngularDialogComponent<
 
     async ngOnInit() {
         this.loading = true;
-        await this.initSpecialGroups();
-        this.groupsWithMemberships = Users.getCurrent().groups.map((g) => ({
-            id: g.id,
-            name: g.name,
-        }));
+        await Promise.all([
+            this.initSpecialGroups(),
+            this.initPersonalGroups(),
+        ]);
         this.defaultActiveGroups = new Set([
             ...this.groupsWithMemberships.map((g) => g.id),
             ...this.specialGroups.map((g) => g.id),
@@ -251,12 +257,24 @@ export class ActiveGroupLockDialogComponent extends AngularDialogComponent<
         this.loading = false;
     }
 
+    private async initPersonalGroups() {
+        const r = await toPromise(
+            this.http.get<GroupInfo[]>("/groups/usergroups")
+        );
+        if (r.ok) {
+            this.groupsWithMemberships = r.result;
+        }
+    }
+
     private async initSpecialGroups() {
         const r = await toPromise(
             this.http.get<GroupInfo[]>("/groups/special")
         );
         if (r.ok) {
-            this.specialGroups = r.result;
+            // Remove anonymous group since it's always active
+            this.specialGroups = r.result.filter(
+                (g) => g.name != ANONYMOUS_GROUPNAME
+            );
         }
     }
 

--- a/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
+++ b/timApp/static/scripts/tim/item/active-group-lock-dialog/active-group-lock-dialog.component.ts
@@ -202,8 +202,12 @@ export class GroupSelectListComponent implements OnInit, OnChanges {
                         [selectableGroups]="specialGroups"
                         [(selectedGroups)]="activeGroups"></tim-group-select-list>
                 <tim-group-select-list [class.loading]="loading"
-                        name="Groups you are a member of" i18n-name
-                        [selectableGroups]="groupsWithMemberships"
+                        name="Managed groups you are a member of" i18n-name
+                        [selectableGroups]="groupsWithMembershipsManaged"
+                        [(selectedGroups)]="activeGroups"></tim-group-select-list>
+                <tim-group-select-list [class.loading]="loading"
+                        name="Unmanaged groups you are a member of" i18n-name
+                        [selectableGroups]="groupsWithMembershipsUnmanaged"
                         [(selectedGroups)]="activeGroups"></tim-group-select-list>
                 <tim-group-select-list [class.loading]="loading"
                         name="Other groups (manual search)" i18n-name
@@ -227,7 +231,8 @@ export class ActiveGroupLockDialogComponent extends AngularDialogComponent<
     protected dialogName = "activeGroupLockDialog";
     loading = false;
     activeGroups: number[] = [];
-    groupsWithMemberships: GroupInfo[] = [];
+    groupsWithMembershipsManaged: GroupInfo[] = [];
+    groupsWithMembershipsUnmanaged: GroupInfo[] = [];
     groupsWithAccess: GroupInfo[] = [];
     specialGroups: GroupInfo[] = [];
     private defaultActiveGroups = new Set<number>();
@@ -246,7 +251,8 @@ export class ActiveGroupLockDialogComponent extends AngularDialogComponent<
             this.initPersonalGroups(),
         ]);
         this.defaultActiveGroups = new Set([
-            ...this.groupsWithMemberships.map((g) => g.id),
+            ...this.groupsWithMembershipsManaged.map((g) => g.id),
+            ...this.groupsWithMembershipsUnmanaged.map((g) => g.id),
             ...this.specialGroups.map((g) => g.id),
         ]);
         await this.initSelectedAccessibleGroups();
@@ -262,7 +268,12 @@ export class ActiveGroupLockDialogComponent extends AngularDialogComponent<
             this.http.get<GroupInfo[]>("/groups/usergroups")
         );
         if (r.ok) {
-            this.groupsWithMemberships = r.result;
+            this.groupsWithMembershipsManaged = r.result.filter(
+                (g) => g.managed
+            );
+            this.groupsWithMembershipsUnmanaged = r.result.filter(
+                (g) => !g.managed
+            );
         }
     }
 


### PR DESCRIPTION
Kaksi pientä muutosta aktiivisten ryhmien lukitusdialogiin:

* Anonymous users ei näytetä enää ryhmälukitusdialogissa. Sen sijaan kyseinen ryhmä on aina mukana lukituksessa. Tämä näin, koska käytännössä kaikki käyttäjät perivät aina kyseisen ryhmän oikeudet.
* Omat ryhmät jaetaan nyt erikseen "hallituihin" ja "hallitsemattomiin". Hallitut ryhmät ovat ne, joilla on hallintadokumentti olemassa (esim. käsin tehdyt ryhmät, "aktivoidut" sisuryhmät). 

Tämä PR liittyy korttiin #3078 