### PR TITLE
Add initial ability to add/remove rows in task TimTable

### DIFF
--- a/timApp/plugin/timtable/timTable.py
+++ b/timApp/plugin/timtable/timTable.py
@@ -309,7 +309,7 @@ def tim_table_add_row():
 @timTable_plugin.post("addUserSpecificRow")
 def tim_table_add_user_specific_row():
     """
-    Adds an user-specific row into the table.
+    Adds a user-specific row into the table.
     :return: The entire table's data after the row has been added.
     """
     doc_id, par_id = verify_json_params("docId", "parId")

--- a/timApp/static/scripts/tim/plugin/tim-table-editor-toolbar-dialog.component.ts
+++ b/timApp/static/scripts/tim/plugin/tim-table-editor-toolbar-dialog.component.ts
@@ -41,7 +41,7 @@ const DEFAULT_CELL_BGCOLOR = "#FFFF00";
             <ng-container body>
                 <div class="row">
                     <div class="col-xs-12" style="top: -0.8em;">
-                        <div class="btn-group" role="menuitem" dropdown *ngIf="!hide?.editMenu">
+                        <div class="btn-group" role="menuitem" dropdown *ngIf="canRemoveCells">
                             <button class="timButton btn-xs dropdown-toggle" dropdownToggle>Edit <span class="caret"></span></button>
                             <ul class="dropdown-menu" *dropdownMenu>
                                 <li role="menuitem" (click)="removeRow()"><a>Remove row</a></li>
@@ -49,7 +49,7 @@ const DEFAULT_CELL_BGCOLOR = "#FFFF00";
                             </ul>
                         </div>
                         &ngsp;
-                        <div class="btn-group" role="menuitem" dropdown *ngIf="!hide?.insertMenu">
+                        <div class="btn-group" role="menuitem" dropdown *ngIf="canInsertCells">
                             <button class="timButton btn-xs dropdown-toggle" dropdownToggle>Insert <span class="caret"></span></button>
                             <ul class="dropdown-menu" *dropdownMenu>
                                 <li role="menuitem" (click)="addRow(0)"><a>Row above</a></li>
@@ -146,12 +146,18 @@ export class TimTableEditorToolbarDialogComponent extends AngularDialogComponent
     void
 > {
     protected dialogName = "TableEditorToolbar";
+    canInsertCells = false;
+    canRemoveCells = false;
 
     ngOnInit() {
         setToolbarInstance(this);
         this.callbacks = this.data.callbacks;
         this.activeTable = this.data.activeTable;
         this.hide = this.activeTable.data.hide;
+
+        // TODO: Right now deleting specific rows/columns is not supported for tasks
+        this.canInsertCells = !this.activeTable.task && !this.hide?.insertMenu;
+        this.canRemoveCells = !this.activeTable.task && !this.hide?.editMenu;
     }
 
     public callbacks!: ITimTableToolbarCallbacks; // ngOnInit


### PR DESCRIPTION
Lisää alustavan mahdollisuuden lisätä uusia rivejä/sarakkeida TimTable-tehtäviin. Tämä onnistuu lisäämällä `taskCanModifyTable`-attribuutti. Ominaisuus mahdollistaa esim. ilmoittautumistaulukkoiden tekemistä, jotka voi sitten käsitellä JSRunnerilla.

Tässä alustavassa toteutuksessa sarakkeita ja rivejä ei voi lisätä/poistaa mielivaltaisesta paikasta vielä (vaatii vähän laajemman logiikan, jossa otetaan huomioon markuppiin laitetut solut sekä perusmuodossa että datablock-muodossa). Tämä logiikka kuitenkin ottaa huomioon lukitut sarakkeet sekä markuppiin laitetut rivit ja sarakkeet poiston yhteydessä.

Esimerkki: <https://timdevs01-2.it.jyu.fi/view/users/dz-dz/test-timtable-task-rowadd>