### PR TITLE
Add preliminary fix for creating velp groups for ownerless documents

### DIFF
--- a/timApp/static/scripts/tim/velp/velpSelection.ts
+++ b/timApp/static/scripts/tim/velp/velpSelection.ts
@@ -453,6 +453,7 @@ export class VelpSelectionController implements IController {
                 )
             );
             if (!json.ok) {
+                await showMessageDialog(json.result.data.error);
                 return null;
             }
             const newDefaultVelpGroup = json.result.data;
@@ -754,6 +755,7 @@ export class VelpSelectionController implements IController {
             )
         );
         if (!json.ok) {
+            await showMessageDialog(json.result.data.error);
             return;
         }
         const group: IVelpGroupUI = json.result.data;

--- a/timApp/tests/server/test_velp.py
+++ b/timApp/tests/server/test_velp.py
@@ -189,6 +189,7 @@ class VelpTest(TimRouteTest):
                 "id": 18,
                 "location": "users/test-user-1/velp-groups/Personal-default",
                 "name": "Personal-default",
+                "selected": True,
                 "show": True,
                 "target_id": "0",
                 "target_type": 0,

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -712,7 +712,7 @@ def create_velp_group_route(doc_id: int) -> dict:
         )  # Check name so no duplicates are made
         if group_exists is None:
             # Document may not have an owner, we have to account for that
-            if not len(target.owners) < 1:
+            if target.owners:
                 original_owner = target.owners[0]
             else:
                 # TODO Should owner default to folder owner in this case? These groups will not be visible

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -33,11 +33,12 @@ from timApp.timdb.sqa import db
 from timApp.user.user import User
 from timApp.user.users import get_rights_holders
 from timApp.user.userutils import grant_access
-from timApp.util.flask.requesthelper import RouteException
+from timApp.util.flask.requesthelper import RouteException, JSONException
 from timApp.util.flask.responsehelper import (
     json_response,
     no_cache_json_response,
-    ok_response, html_error,
+    ok_response,
+    html_error,
 )
 from timApp.util.logger import log_warning
 from timApp.util.utils import split_location
@@ -723,11 +724,9 @@ def create_velp_group_route(doc_id: int) -> Response:
                 #     raise RouteException(f"Folder not found: {doc_path}")
                 # doc_name = ""
                 # original_owner = target.block.owners[0]
-                resp = {"error": "Cannot create group for document: document has no owner."}
-                return json_response(resp, 500)
-                # raise RouteException(
-                #     f"Cannot create group for document: document has no owner."
-                # )
+                raise RouteException(
+                    f"Cannot create group for document: document has no owner."
+                )
             velp_group = create_velp_group(
                 velp_group_name, original_owner, new_group_path
             )
@@ -739,11 +738,9 @@ def create_velp_group_route(doc_id: int) -> Response:
                         right.usergroup, velp_group.block, right.atype.to_enum()
                     )
         else:
-            resp = {"error": "Velp group with same name and location exists already."}
-            return json_response(resp)
-            # raise RouteException(
-            #     "Velp group with same name and location exists already."
-            # )
+            raise RouteException(
+                "Velp group with same name and location exists already."
+            )
 
     created_velp_group = dict()
     created_velp_group["id"] = velp_group.id
@@ -780,9 +777,9 @@ def create_default_velp_group_route(doc_id: int) -> Response:
     if doc.block.owners:
         user_group = doc.block.owners[0]
     else:
-        # raise RouteException("Cannot create default group for document: document has no owner.")
-        resp = {"error": "Cannot create default group for document: document has no owner."}
-        return json_response(resp, 500)
+        raise RouteException(
+            "Cannot create default group for document: document has no owner."
+        )
 
     verify_edit_access(doc)
     default, default_group_path, default_group_name = get_document_default_velp_group(

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -33,12 +33,11 @@ from timApp.timdb.sqa import db
 from timApp.user.user import User
 from timApp.user.users import get_rights_holders
 from timApp.user.userutils import grant_access
-from timApp.util.flask.requesthelper import RouteException, JSONException
+from timApp.util.flask.requesthelper import RouteException
 from timApp.util.flask.responsehelper import (
     json_response,
     no_cache_json_response,
     ok_response,
-    html_error,
 )
 from timApp.util.logger import log_warning
 from timApp.util.utils import split_location

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -205,17 +205,20 @@ def get_default_personal_velp_group() -> Response:
         group = create_default_velp_group(group_name, user_group, new_group_path)
         created_new = True
 
-    created_velp_group = dict()
-    created_velp_group["id"] = group.id
-    created_velp_group["target_type"] = 0
-    created_velp_group["target_id"] = "0"
-    created_velp_group["name"] = group_name
-    created_velp_group["location"] = new_group_path
-    created_velp_group["show"] = True
-    created_velp_group["default"] = False
-    created_velp_group["edit_access"] = True
-    created_velp_group["default_group"] = True
-    created_velp_group["created_new_group"] = created_new
+    created_velp_group = dict(
+        {
+            "id": group.id,
+            "target_type": 0,
+            "target_id": "0",
+            "name": group_name,
+            "location": new_group_path,
+            "show": True,
+            "default": False,
+            "edit_access": True,
+            "default_group": True,
+            "created_new_group": created_new,
+        }
+    )
     db.session.commit()
 
     return no_cache_json_response(created_velp_group)
@@ -741,16 +744,19 @@ def create_velp_group_route(doc_id: int) -> Response:
                 "Velp group with same name and location exists already."
             )
 
-    created_velp_group = dict()
-    created_velp_group["id"] = velp_group.id
-    created_velp_group["target_type"] = 0
-    created_velp_group["target_id"] = "0"
-    created_velp_group["name"] = velp_group_name
-    created_velp_group["location"] = new_group_path
-    created_velp_group["selected"] = True
-    created_velp_group["show"] = True
-    created_velp_group["edit_access"] = True
-    created_velp_group["default_group"] = False
+    created_velp_group = dict(
+        {
+            "id": velp_group.id,
+            "target_type": 0,
+            "target_id": "0",
+            "name": velp_group_name,
+            "location": new_group_path,
+            "selected": True,
+            "show": True,
+            "edit_access": True,
+            "default_group": False,
+        }
+    )
 
     add_groups_to_document([velp_group], doc, user)
     # TODO Do we want to make just created velp group selected in document immediately?
@@ -797,18 +803,21 @@ def create_default_velp_group_route(doc_id: int) -> Response:
         vg.valid_until = None
         created_new_group = False
 
-    created_velp_group = dict()
-    created_velp_group["id"] = velp_group.id
-    created_velp_group["target_type"] = 0
-    created_velp_group["target_id"] = "0"
-    created_velp_group["name"] = default_group_name
-    created_velp_group["location"] = default_group_path
-    created_velp_group["selected"] = True
-    created_velp_group["show"] = True
-    created_velp_group["default"] = False
-    created_velp_group["edit_access"] = True
-    created_velp_group["default_group"] = True
-    created_velp_group["created_new_group"] = created_new_group
+    created_velp_group = dict(
+        {
+            "id": velp_group.id,
+            "target_type": 0,
+            "target_id": "0",
+            "name": default_group_name,
+            "location": default_group_path,
+            "selected": True,
+            "show": True,
+            "default": False,
+            "edit_access": True,
+            "default_group": True,
+            "created_new_group": created_new_group,
+        }
+    )
 
     add_groups_to_document([velp_group], doc, get_current_user_object())
 

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -91,7 +91,7 @@ velps = Blueprint("velps", __name__, url_prefix="")
 
 
 @velps.get("/<int:doc_id>/get_default_velp_group")
-def get_default_velp_group(doc_id: int):
+def get_default_velp_group(doc_id: int) -> Response:
     """Get default velp group ID and if  velp group doesn't exist yet, create one.
 
     :param doc_id: ID of document
@@ -174,7 +174,7 @@ def get_default_velp_group(doc_id: int):
 
 
 @velps.get("/get_default_personal_velp_group")
-def get_default_personal_velp_group():
+def get_default_personal_velp_group() -> Response:
     """Get default personal velp group ID and if velp group doesn't exist yet, create one.
 
     :return: Dictionary containing personal velp group data.
@@ -222,7 +222,7 @@ def get_default_personal_velp_group():
 
 
 @velps.get("/<int:doc_id>/get_velps")
-def get_velps(doc_id: int):
+def get_velps(doc_id: int) -> Response:
     """Get all velps for document user has access to.
 
     :param doc_id: ID of document
@@ -236,7 +236,7 @@ def get_velps(doc_id: int):
 
 
 @velps.get("/<int:doc_id>/get_velp_groups")
-def get_velp_groups(doc_id: int):
+def get_velp_groups(doc_id: int) -> Response:
     """Gets all velp groups for document user has access to by using VelpGroupSelection table.
 
     :param doc_id: ID of document
@@ -259,7 +259,7 @@ def get_velp_groups(doc_id: int):
 
 
 @velps.get("/<int:doc_id>/get_velp_group_personal_selections")
-def get_velp_group_personal_selections(doc_id: int) -> dict:
+def get_velp_group_personal_selections(doc_id: int) -> Response:
     """Gets default velp group selections for velp groups user has access to in document.
 
     :param doc_id: ID of document
@@ -273,7 +273,7 @@ def get_velp_group_personal_selections(doc_id: int) -> dict:
 
 
 @velps.get("/<int:doc_id>/get_velp_group_default_selections")
-def get_velp_group_default_selections(doc_id: int) -> dict:
+def get_velp_group_default_selections(doc_id: int) -> Response:
     """Gets default velp group selections for velp groups user has access to in document.
 
     :param doc_id: ID of document
@@ -286,7 +286,7 @@ def get_velp_group_default_selections(doc_id: int) -> dict:
 
 
 @velps.get("/<int:doc_id>/get_velp_labels")
-def get_velp_labels(doc_id: int) -> "str":
+def get_velp_labels(doc_id: int) -> Response:
     """Gets all velp labels for document user has access to by using VelpGroupSelection table.
 
     :param doc_id: ID of document
@@ -300,7 +300,7 @@ def get_velp_labels(doc_id: int) -> "str":
 
 
 @velps.post("/add_velp")
-def add_velp() -> int:
+def add_velp() -> Response:
     """Creates a new velp and adds it to velp groups user chose.
 
     Required key(s):
@@ -375,7 +375,7 @@ def add_velp() -> int:
 
 
 @velps.post("/<int:doc_id>/update_velp")
-def update_velp_route(doc_id: int):
+def update_velp_route(doc_id: int) -> Response:
     """Updates the velp's data.
 
     Required key(s):
@@ -466,7 +466,7 @@ def update_velp_route(doc_id: int):
 
 
 @velps.post("/add_velp_label")
-def add_label() -> int:
+def add_label() -> Response:
     """Creates new velp label.
 
     Required key(s):
@@ -494,7 +494,7 @@ def add_label() -> int:
 
 
 @velps.post("/update_velp_label")
-def update_velp_label_route():
+def update_velp_label_route() -> Response:
     """Updates velp label content.
 
     Required key(s):
@@ -526,7 +526,7 @@ def update_velp_label_route():
 
 
 @velps.post("/<int:doc_id>/change_selection")
-def change_selection_route(doc_id: int):
+def change_selection_route(doc_id: int) -> Response:
     """Change selection for velp group in users VelpGroupSelection in current document.
 
     Required key(s):
@@ -571,7 +571,7 @@ def change_selection_route(doc_id: int):
 
 
 @velps.post("/<int:doc_id>/change_all_selections")
-def change_all_selections(doc_id: int):
+def change_all_selections(doc_id: int) -> Response:
     """Change selection for velp group in users VelpGroupSelection in current document.
 
     Required key(s):
@@ -608,7 +608,7 @@ def change_all_selections(doc_id: int):
 
 
 @velps.post("/<int:doc_id>/reset_target_area_selections_to_defaults")
-def reset_target_area_selections_to_defaults(doc_id: int):
+def reset_target_area_selections_to_defaults(doc_id: int) -> Response:
     """Changes user's personal velp group selections in target area to defaults.
 
     Required key(s):
@@ -633,7 +633,7 @@ def reset_target_area_selections_to_defaults(doc_id: int):
 
 
 @velps.post("/<int:doc_id>/reset_all_selections_to_defaults")
-def reset_all_selections_to_defaults(doc_id: int):
+def reset_all_selections_to_defaults(doc_id: int) -> Response:
     """Changes user's all personal velp group selections in document to defaults.
 
     :param doc_id: ID of document
@@ -818,7 +818,7 @@ def create_default_velp_group_route(doc_id: int) -> Response:
     return json_response(created_velp_group)
 
 
-def get_velp_groups_from_tree(doc: DocInfo):
+def get_velp_groups_from_tree(doc: DocInfo) -> list[DocEntry]:
     """Returns all velp groups found from tree from document to root and from users own velp folder.
 
     Checks document's own velp group folder first, then default velp group folders going up all the

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -721,11 +721,6 @@ def create_velp_group_route(doc_id: int) -> Response:
                 # TODO Should owner default to folder owner in this case? These groups will not be visible
                 #      without sufficient folder rights, however. Otherwise we could end up checking for
                 #      owners until the root of the user folder.
-                # target = Folder.find_by_path(doc_path)
-                # if not target:
-                #     raise RouteException(f"Folder not found: {doc_path}")
-                # doc_name = ""
-                # original_owner = target.block.owners[0]
                 raise RouteException(
                     f"Cannot create group for document: document has no owner."
                 )

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -772,7 +772,12 @@ def create_default_velp_group_route(doc_id: int):
 
     doc = get_doc_or_abort(doc_id)
     verify_logged_in()
-    user_group = doc.block.owners[0]
+
+    if doc.block.owners:
+        user_group = doc.block.owners[0]
+    else:
+        raise RouteException("Cannot create default group for document: document has no owner.")
+
     verify_edit_access(doc)
     default, default_group_path, default_group_name = get_document_default_velp_group(
         doc

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -711,7 +711,21 @@ def create_velp_group_route(doc_id: int) -> dict:
             new_group_path
         )  # Check name so no duplicates are made
         if group_exists is None:
-            original_owner = target.owners[0]
+            # Document may not have an owner, we have to account for that
+            if not len(target.owners) < 1:
+                original_owner = target.owners[0]
+            else:
+                # TODO Should owner default to folder owner in this case? These groups will not be visible
+                #      without sufficient folder rights, however. Otherwise we could end up checking for
+                #      owners until the root of the user folder.
+                # target = Folder.find_by_path(doc_path)
+                # if not target:
+                #     raise RouteException(f"Folder not found: {doc_path}")
+                # doc_name = ""
+                # original_owner = target.block.owners[0]
+                raise RouteException(
+                    "Cannot create group for document: document has no owner."
+                )
             velp_group = create_velp_group(
                 velp_group_name, original_owner, new_group_path
             )

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -10,7 +10,7 @@ the document.
 
 """
 
-from flask import Blueprint
+from flask import Blueprint, Response
 from flask import request
 
 from timApp.auth.accesshelper import (
@@ -37,7 +37,7 @@ from timApp.util.flask.requesthelper import RouteException
 from timApp.util.flask.responsehelper import (
     json_response,
     no_cache_json_response,
-    ok_response,
+    ok_response, html_error,
 )
 from timApp.util.logger import log_warning
 from timApp.util.utils import split_location
@@ -647,7 +647,7 @@ def reset_all_selections_to_defaults(doc_id: int):
 
 
 @velps.post("/<int:doc_id>/create_velp_group")
-def create_velp_group_route(doc_id: int) -> dict:
+def create_velp_group_route(doc_id: int) -> Response:
     """Creates a new velp group.
 
     Required key(s):
@@ -723,9 +723,11 @@ def create_velp_group_route(doc_id: int) -> dict:
                 #     raise RouteException(f"Folder not found: {doc_path}")
                 # doc_name = ""
                 # original_owner = target.block.owners[0]
-                raise RouteException(
-                    "Cannot create group for document: document has no owner."
-                )
+                resp = {"error": "Cannot create group for document: document has no owner."}
+                return json_response(resp, 500)
+                # raise RouteException(
+                #     f"Cannot create group for document: document has no owner."
+                # )
             velp_group = create_velp_group(
                 velp_group_name, original_owner, new_group_path
             )
@@ -737,9 +739,11 @@ def create_velp_group_route(doc_id: int) -> dict:
                         right.usergroup, velp_group.block, right.atype.to_enum()
                     )
         else:
-            raise RouteException(
-                "Velp group with same name and location exists already."
-            )
+            resp = {"error": "Velp group with same name and location exists already."}
+            return json_response(resp)
+            # raise RouteException(
+            #     "Velp group with same name and location exists already."
+            # )
 
     created_velp_group = dict()
     created_velp_group["id"] = velp_group.id
@@ -762,7 +766,7 @@ def create_velp_group_route(doc_id: int) -> dict:
 
 
 @velps.post("/<int:doc_id>/create_default_velp_group")
-def create_default_velp_group_route(doc_id: int):
+def create_default_velp_group_route(doc_id: int) -> Response:
     """Creates a default velp group document or changes existing document to default velp group.
 
     :param doc_id: ID of document
@@ -776,7 +780,9 @@ def create_default_velp_group_route(doc_id: int):
     if doc.block.owners:
         user_group = doc.block.owners[0]
     else:
-        raise RouteException("Cannot create default group for document: document has no owner.")
+        # raise RouteException("Cannot create default group for document: document has no owner.")
+        resp = {"error": "Cannot create default group for document: document has no owner."}
+        return json_response(resp, 500)
 
     verify_edit_access(doc)
     default, default_group_path, default_group_name = get_document_default_velp_group(

--- a/timApp/velp/velpgroups.py
+++ b/timApp/velp/velpgroups.py
@@ -11,6 +11,7 @@ selections from the database.
 """
 
 import copy
+from dataclasses import dataclass
 from typing import Union
 
 from timApp.auth.accesstype import AccessType
@@ -31,6 +32,23 @@ from timApp.velp.velp_models import (
     VelpGroupSelection,
     VelpGroupDefaults,
 )
+
+
+@dataclass
+class CreatedVelpGroup:
+    """Represents a velp group. Used for passing velp group data to the user interface."""
+
+    id: int
+    name: str
+    location: str
+    target_type: int = 0
+    target_id: str = "0"
+    edit_access: bool = True
+    show: bool = True
+    selected: bool = True
+    default: bool = False
+    default_group: bool = False
+    created_new_group: bool = True
 
 
 def create_default_velp_group(


### PR DESCRIPTION
Raise a RouteException if trying to create a velp group for the document using the 'Document' option (as opposed to 'Personal' or 'Folder'). <s>A further solution could be to default to the 'Folder' option if the document has no owners (lines 718-725 in velp.py).</s>

Interface will show a message dialog informing the user of the error (document has no owner). At this time, no further action is taken, since most users will never encounter this problem.

Resolves issue #2618.