### PR TITLE
Fix velp typings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,7 +297,6 @@ module = [
     "timApp.util.pdftools",
     "timApp.velp.annotation_model",
     "timApp.velp.annotations",
-    "timApp.velp.velp",
     "timApp.velp.velp_folders",
     "timApp.velp.velp_models",
     "timApp.velp.velpgroups",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,7 +297,5 @@ module = [
     "timApp.util.pdftools",
     "timApp.velp.annotation_model",
     "timApp.velp.annotations",
-    "timApp.velp.velp_models",
-    "timApp.velp.velps"
 ]
 ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,7 +295,5 @@ module = [
     "timApp.util.flask.search",
     "timApp.util.get_fields",
     "timApp.util.pdftools",
-    "timApp.velp.annotation_model",
-    "timApp.velp.annotations",
 ]
 ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -295,5 +295,11 @@ module = [
     "timApp.util.flask.search",
     "timApp.util.get_fields",
     "timApp.util.pdftools",
+    "timApp.velp.annotation_model",
+    "timApp.velp.annotations",
+    "timApp.velp.velp_folders",
+    "timApp.velp.velp_models",
+    "timApp.velp.velpgroups",
+    "timApp.velp.velps"
 ]
 ignore_errors = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,9 +297,7 @@ module = [
     "timApp.util.pdftools",
     "timApp.velp.annotation_model",
     "timApp.velp.annotations",
-    "timApp.velp.velp_folders",
     "timApp.velp.velp_models",
-    "timApp.velp.velpgroups",
     "timApp.velp.velps"
 ]
 ignore_errors = true

--- a/timApp/velp/annotation.py
+++ b/timApp/velp/annotation.py
@@ -254,7 +254,7 @@ def add_comment_route(id: int, content: str) -> Response:
 
 def should_anonymize_annotations(d: DocInfo, u: User) -> bool:
     """
-    Determines whether annotation author and comment authors should be hidden from an user
+    Determines whether annotation author and comment authors should be hidden from a user
     """
     rights = get_user_rights_for_item(d, u)
     return has_no_higher_right(d.document.get_settings().anonymize_reviewers(), rights)

--- a/timApp/velp/annotation_model.py
+++ b/timApp/velp/annotation_model.py
@@ -144,7 +144,7 @@ class Annotation(db.Model):
         primaryjoin="VelpContent.version_id == foreign(Annotation.velp_version_id)",
     )
 
-    def set_position_info(self, coordinates: AnnotationPosition):
+    def set_position_info(self, coordinates: AnnotationPosition) -> None:
         start = coordinates.start
         end = coordinates.end
         self.offset_start = start.offset
@@ -164,7 +164,16 @@ class Annotation(db.Model):
         self.paragraph_id_end = end.par_id
         self.hash_end = end.t
 
-    def to_json(self):
+    def to_json(
+        self,
+    ) -> dict[
+        str,
+        int
+        | str
+        | dict[str, dict[str, int | None | list[int] | str]]
+        | datetime
+        | float,
+    ]:
         if self.element_path_start is not None and self.element_path_end is not None:
             try:
                 start_path = [int(i) for i in self.element_path_start[1:-1].split(",")]

--- a/timApp/velp/annotation_model.py
+++ b/timApp/velp/annotation_model.py
@@ -166,14 +166,7 @@ class Annotation(db.Model):
 
     def to_json(
         self,
-    ) -> dict[
-        str,
-        int
-        | str
-        | dict[str, dict[str, int | None | list[int] | str]]
-        | datetime
-        | float,
-    ]:
+    ) -> dict:
         if self.element_path_start is not None and self.element_path_end is not None:
             try:
                 start_path = [int(i) for i in self.element_path_start[1:-1].split(",")]

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -39,6 +39,7 @@ from timApp.util.flask.responsehelper import (
     no_cache_json_response,
     ok_response,
 )
+from timApp.util.flask.typedblueprint import TypedBlueprint
 from timApp.util.logger import log_warning
 from timApp.util.utils import split_location
 from timApp.velp.velp_folders import (
@@ -82,7 +83,7 @@ from timApp.velp.velps import (
     add_velp_label_translation,
 )
 
-velps = Blueprint("velps", __name__, url_prefix="")
+velps = TypedBlueprint("velps", __name__, url_prefix="")
 
 
 # TODO: Add document handling for all velp group related stuff

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -83,7 +83,7 @@ from timApp.velp.velps import (
     add_velp_label_translation,
 )
 
-velps = TypedBlueprint("velps", __name__, url_prefix="")
+velps = Blueprint("velps", __name__, url_prefix="")
 
 
 # TODO: Add document handling for all velp group related stuff

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -267,7 +267,7 @@ def get_velp_group_personal_selections(doc_id: int) -> Response:
     user_id = get_current_user_id()
     velp_group_selections = get_personal_selections_for_velp_groups(doc_id, user_id)
 
-    return no_cache_json_response(velp_group_selections.to_json())
+    return no_cache_json_response(velp_group_selections)
 
 
 @velps.get("/<int:doc_id>/get_velp_group_default_selections")
@@ -280,7 +280,7 @@ def get_velp_group_default_selections(doc_id: int) -> Response:
     """
     velp_group_defaults = get_default_selections_for_velp_groups(doc_id)
 
-    return no_cache_json_response(velp_group_defaults.to_json())
+    return no_cache_json_response(velp_group_defaults)
 
 
 @velps.get("/<int:doc_id>/get_velp_labels")
@@ -319,26 +319,26 @@ def add_velp() -> Response:
 
     """
     json_data = request.get_json()
-    if json_data is not None:
-        try:
-            velp_content = json_data["content"]
-            velp_group_ids = json_data["velp_groups"]
-        except KeyError as e:
-            raise RouteException("Missing data: " + e.args[0])
-        if not velp_content:
-            raise RouteException("Empty content string.")
-
-        # Optional stuff
-        default_points = json_data.get("points")
-        default_comment = json_data.get("default_comment")
-        language_id = json_data.get("language_id")
-        valid_until = json_data.get("valid_until")
-        velp_labels = json_data.get("labels")
-        visible_to = json_data.get("visible_to")
-        color = json_data.get("color")
-        style = json_data.get("style")
-    else:
+    if not json_data:
         raise RouteException("Unable to access request data")
+
+    try:
+        velp_content = json_data["content"]
+        velp_group_ids = json_data["velp_groups"]
+    except KeyError as e:
+        raise RouteException("Missing data: " + e.args[0])
+    if not velp_content:
+        raise RouteException("Empty content string.")
+
+    # Optional stuff
+    default_points = json_data.get("points")
+    default_comment = json_data.get("default_comment")
+    language_id = json_data.get("language_id")
+    valid_until = json_data.get("valid_until")
+    velp_labels = json_data.get("labels")
+    visible_to = json_data.get("visible_to")
+    color = json_data.get("color")
+    style = json_data.get("style")
 
     default_points = float(default_points) if default_points is not None else None
 
@@ -394,24 +394,24 @@ def update_velp_route(doc_id: int) -> Response:
     """
 
     json_data = request.get_json()
-    if json_data is not None:
-        try:
-            velp_id = json_data.get("id")
-            new_content = json_data.get("content")
-            language_id = json_data.get("language_id")
-            velp_group_ids = json_data["velp_groups"]
-        except KeyError as e:
-            raise RouteException("Missing data " + e.args[0])
-        if not new_content:
-            raise RouteException("Empty content string.")
-        default_points = json_data.get("points")
-        default_comment = json_data.get("default_comment")
-        color = json_data.get("color")
-        new_labels = set(json_data.get("labels") or [])
-        visible_to = json_data.get("visible_to")
-        style = json_data.get("style")
-    else:
+    if not json_data:
         raise RouteException("Unable to access request data")
+
+    try:
+        velp_id = json_data.get("id")
+        new_content = json_data.get("content")
+        language_id = json_data.get("language_id")
+        velp_group_ids = json_data["velp_groups"]
+    except KeyError as e:
+        raise RouteException("Missing data " + e.args[0])
+    if not new_content:
+        raise RouteException("Empty content string.")
+    default_points = json_data.get("points")
+    default_comment = json_data.get("default_comment")
+    color = json_data.get("color")
+    new_labels = set(json_data.get("labels") or [])
+    visible_to = json_data.get("visible_to")
+    style = json_data.get("style")
 
     verify_logged_in()
     user_id = get_current_user_id()
@@ -485,15 +485,15 @@ def add_label() -> Response:
 
     """
     json_data = request.get_json()
-    if json_data is not None:
-        try:
-            content = json_data["content"]
-        except KeyError as e:
-            raise RouteException("Missing data: " + e.args[0])
-        language_id = json_data.get("language_id")
-        language_id = "FI" if language_id is None else language_id
-    else:
+    if not json_data:
         raise RouteException("Unable to access request data")
+
+    try:
+        content = json_data["content"]
+    except KeyError as e:
+        raise RouteException("Missing data: " + e.args[0])
+    language_id = json_data.get("language_id")
+    language_id = "FI" if language_id is None else language_id
 
     label = VelpLabel(creator=get_current_user_object())
     db.session.add(label)
@@ -512,16 +512,16 @@ def update_velp_label_route() -> Response:
 
     """
     json_data = request.get_json()
-    if json_data is not None:
-        try:
-            content = json_data["content"]
-            velp_label_id = json_data["id"]
-        except KeyError as e:
-            raise RouteException("Missing data: " + e.args[0])
-        language_id = json_data.get("language_id")
-        language_id = "FI" if language_id is None else language_id
-    else:
+    if not json_data:
         raise RouteException("Unable to access request data")
+
+    try:
+        content = json_data["content"]
+        velp_label_id = json_data["id"]
+    except KeyError as e:
+        raise RouteException("Missing data: " + e.args[0])
+    language_id = json_data.get("language_id")
+    language_id = "FI" if language_id is None else language_id
 
     vlc: VelpLabelContent | None = VelpLabelContent.query.filter_by(
         language_id=language_id,
@@ -551,35 +551,35 @@ def change_selection_route(doc_id: int) -> Response:
     """
 
     json_data = request.get_json()
-    if json_data is not None:
+    if not json_data:
+        raise RouteException("Unable to access request data")
+
+    try:
+        velp_group_id = json_data["id"]
+        target_type = json_data["target_type"]
+        target_id = json_data["target_id"]
+        selection_type = json_data["selection_type"]
+    except KeyError as e:
+        raise RouteException("Missing data: " + e.args[0])
+    verify_logged_in()
+    user_id = get_current_user_id()
+    d = get_doc_or_abort(doc_id)
+    if selection_type == "show":
         try:
-            velp_group_id = json_data["id"]
-            target_type = json_data["target_type"]
-            target_id = json_data["target_id"]
-            selection_type = json_data["selection_type"]
+            selection = json_data["show"]
         except KeyError as e:
             raise RouteException("Missing data: " + e.args[0])
-        verify_logged_in()
-        user_id = get_current_user_id()
-        d = get_doc_or_abort(doc_id)
-        if selection_type == "show":
-            try:
-                selection = json_data["show"]
-            except KeyError as e:
-                raise RouteException("Missing data: " + e.args[0])
-            change_selection(
-                doc_id, velp_group_id, target_type, target_id, user_id, selection
-            )
-        elif selection_type == "default" and has_manage_access(d):
-            try:
-                selection = json_data["default"]
-            except KeyError as e:
-                raise RouteException("Missing data: " + e.args[0])
-            change_default_selection(
-                doc_id, velp_group_id, target_type, target_id, selection
-            )
-    else:
-        raise RouteException("Unable to access request data")
+        change_selection(
+            doc_id, velp_group_id, target_type, target_id, user_id, selection
+        )
+    elif selection_type == "default" and has_manage_access(d):
+        try:
+            selection = json_data["default"]
+        except KeyError as e:
+            raise RouteException("Missing data: " + e.args[0])
+        change_default_selection(
+            doc_id, velp_group_id, target_type, target_id, selection
+        )
 
     db.session.commit()
     return ok_response()
@@ -599,16 +599,17 @@ def change_all_selections(doc_id: int) -> Response:
     """
 
     json_data = request.get_json()
-    if json_data is not None:
-        try:
-            selection = json_data["selection"]
-            target_type = json_data["target_type"]
-            target_id = json_data["target_id"]
-            selection_type = json_data["selection_type"]
-        except KeyError as e:
-            raise RouteException("Missing data: " + e.args[0])
-    else:
+    if not json_data:
         raise RouteException("Unable to access request data")
+
+    try:
+        selection = json_data["selection"]
+        target_type = json_data["target_type"]
+        target_id = json_data["target_id"]
+        selection_type = json_data["selection_type"]
+    except KeyError as e:
+        raise RouteException("Missing data: " + e.args[0])
+
     verify_logged_in()
     user_id = get_current_user_id()
     d = get_doc_or_abort(doc_id)
@@ -636,13 +637,14 @@ def reset_target_area_selections_to_defaults(doc_id: int) -> Response:
     """
 
     json_data = request.get_json()
-    if json_data is not None:
-        try:
-            target_id = json_data["target_id"]
-        except KeyError as e:
-            raise RouteException("Missing data: " + e.args[0])
-    else:
+    if not json_data:
         raise RouteException("Unable to access request data")
+
+    try:
+        target_id = json_data["target_id"]
+    except KeyError as e:
+        raise RouteException("Missing data: " + e.args[0])
+
     user_id = get_current_user_id()
 
     VelpGroupSelection.query.filter_by(
@@ -680,14 +682,14 @@ def create_velp_group_route(doc_id: int) -> Response:
     """
 
     json_data = request.get_json()
-    if json_data is not None:
-        try:
-            velp_group_name = json_data.get("name")
-            target_type = json_data.get("target_type")
-        except KeyError as e:
-            raise RouteException("Missing data: " + e.args[0])
-    else:
+    if not json_data:
         raise RouteException("Unable to access request data")
+
+    try:
+        velp_group_name = json_data.get("name")
+        target_type = json_data.get("target_type")
+    except KeyError as e:
+        raise RouteException("Missing data: " + e.args[0])
 
     doc = get_doc_or_abort(doc_id)
     full_path = doc.path

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -266,7 +266,7 @@ def get_velp_group_personal_selections(doc_id: int) -> Response:
     user_id = get_current_user_id()
     velp_group_selections = get_personal_selections_for_velp_groups(doc_id, user_id)
 
-    return no_cache_json_response(velp_group_selections)
+    return no_cache_json_response(velp_group_selections.to_json())
 
 
 @velps.get("/<int:doc_id>/get_velp_group_default_selections")
@@ -279,7 +279,7 @@ def get_velp_group_default_selections(doc_id: int) -> Response:
     """
     velp_group_defaults = get_default_selections_for_velp_groups(doc_id)
 
-    return no_cache_json_response(velp_group_defaults)
+    return no_cache_json_response(velp_group_defaults.to_json())
 
 
 @velps.get("/<int:doc_id>/get_velp_labels")
@@ -831,7 +831,7 @@ def create_default_velp_group_route(doc_id: int) -> Response:
     return json_response(created_velp_group)
 
 
-def get_velp_groups_from_tree(doc: DocInfo) -> list[DocEntry]:
+def get_velp_groups_from_tree(doc: DocInfo) -> list[DocInfo]:
     """Returns all velp groups found from tree from document to root and from users own velp folder.
 
     Checks document's own velp group folder first, then default velp group folders going up all the
@@ -881,7 +881,7 @@ def get_velp_groups_from_tree(doc: DocInfo) -> list[DocEntry]:
 
     # remove duplicates
     velp_group_ids = set()
-    results = []
+    results: list[DocInfo] = []
     for v in velp_groups:
         if v.id not in velp_group_ids:
             velp_group_ids.add(v.id)

--- a/timApp/velp/velp_folders.py
+++ b/timApp/velp/velp_folders.py
@@ -3,7 +3,9 @@ from timApp.user.user import User
 from timApp.user.usergroup import UserGroup
 
 
-def check_velp_group_folder_path(root_path: str, owner_group: UserGroup, doc_name: str):
+def check_velp_group_folder_path(
+    root_path: str, owner_group: UserGroup, doc_name: str
+) -> str:
     """Checks if velp group folder path exists and if not, creates it.
 
     :param root_path: Root path where method was called from
@@ -48,7 +50,7 @@ def check_velp_group_folder_path(root_path: str, owner_group: UserGroup, doc_nam
     return doc_folder_path
 
 
-def check_personal_velp_folder(user: User):
+def check_personal_velp_folder(user: User) -> str:
     """Checks if personal velp group folder path exists and if not, creates it.
 
     :param user: Username of current user

--- a/timApp/velp/velp_models.py
+++ b/timApp/velp/velp_models.py
@@ -1,5 +1,6 @@
 """Defines all data models related to velps."""
 from datetime import datetime
+from typing import Dict, Any
 
 from sqlalchemy.orm.collections import attribute_mapped_collection
 
@@ -152,7 +153,7 @@ class VelpGroup(db.Model):
     #     'DocEntry',
     # )
 
-    def to_json(self):
+    def to_json(self) -> dict[str, str | int | Any]:
         return {
             "id": self.id,
             "name": self.name,

--- a/timApp/velp/velp_models.py
+++ b/timApp/velp/velp_models.py
@@ -49,7 +49,7 @@ class AnnotationComment(db.Model):
 
     commenter = db.relationship("User")
 
-    def to_json(self) -> dict[str, int | datetime | str]:
+    def to_json(self):
         return {
             "annotation_id": self.annotation_id,
             "comment_time": self.comment_time,
@@ -108,7 +108,7 @@ class Velp(db.Model):
         "VelpVersion", order_by="VelpVersion.id.desc()"
     )
 
-    def to_json(self) -> dict[str, str | int | list | float | datetime]:
+    def to_json(self):
         vv = self.velp_versions[0]
         vc = vv.content[0]
         return {
@@ -153,7 +153,7 @@ class VelpGroup(db.Model):
     #     'DocEntry',
     # )
 
-    def to_json(self) -> dict[str, str | int]:
+    def to_json(self) -> dict[str, str | int | Any]:
         return {
             "id": self.id,
             "name": self.name,
@@ -238,7 +238,7 @@ class VelpLabelContent(db.Model):
 
     velplabel = db.relationship("VelpLabel")
 
-    def to_json(self) -> dict[str, str | int]:
+    def to_json(self):
         return {
             "id": self.velplabel_id,
             "language_id": self.language_id,

--- a/timApp/velp/velp_models.py
+++ b/timApp/velp/velp_models.py
@@ -49,7 +49,7 @@ class AnnotationComment(db.Model):
 
     commenter = db.relationship("User")
 
-    def to_json(self) -> dict[str, int | datetime | str]:
+    def to_json(self) -> dict:
         return {
             "annotation_id": self.annotation_id,
             "comment_time": self.comment_time,
@@ -108,7 +108,7 @@ class Velp(db.Model):
         "VelpVersion", order_by="VelpVersion.id.desc()"
     )
 
-    def to_json(self) -> dict[str, str | int | list | float | datetime]:
+    def to_json(self) -> dict:
         vv = self.velp_versions[0]
         vc = vv.content[0]
         return {
@@ -153,7 +153,7 @@ class VelpGroup(db.Model):
     #     'DocEntry',
     # )
 
-    def to_json(self) -> dict[str, str | int]:
+    def to_json(self) -> dict:
         return {
             "id": self.id,
             "name": self.name,
@@ -238,7 +238,7 @@ class VelpLabelContent(db.Model):
 
     velplabel = db.relationship("VelpLabel")
 
-    def to_json(self) -> dict[str, str | int]:
+    def to_json(self) -> dict:
         return {
             "id": self.velplabel_id,
             "language_id": self.language_id,

--- a/timApp/velp/velp_models.py
+++ b/timApp/velp/velp_models.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import Dict, Any
 
-from sqlalchemy.orm.collections import attribute_mapped_collection
+from sqlalchemy.orm.collections import attribute_mapped_collection  # type: ignore
 
 from timApp.item.block import Block
 from timApp.timdb.sqa import db

--- a/timApp/velp/velp_models.py
+++ b/timApp/velp/velp_models.py
@@ -49,7 +49,7 @@ class AnnotationComment(db.Model):
 
     commenter = db.relationship("User")
 
-    def to_json(self):
+    def to_json(self) -> dict[str, int | datetime | str]:
         return {
             "annotation_id": self.annotation_id,
             "comment_time": self.comment_time,
@@ -108,7 +108,7 @@ class Velp(db.Model):
         "VelpVersion", order_by="VelpVersion.id.desc()"
     )
 
-    def to_json(self):
+    def to_json(self) -> dict[str, str | int | list | float | datetime]:
         vv = self.velp_versions[0]
         vc = vv.content[0]
         return {
@@ -153,7 +153,7 @@ class VelpGroup(db.Model):
     #     'DocEntry',
     # )
 
-    def to_json(self) -> dict[str, str | int | Any]:
+    def to_json(self) -> dict[str, str | int]:
         return {
             "id": self.id,
             "name": self.name,
@@ -238,7 +238,7 @@ class VelpLabelContent(db.Model):
 
     velplabel = db.relationship("VelpLabel")
 
-    def to_json(self):
+    def to_json(self) -> dict[str, str | int]:
         return {
             "id": self.velplabel_id,
             "language_id": self.language_id,

--- a/timApp/velp/velpgroups.py
+++ b/timApp/velp/velpgroups.py
@@ -74,7 +74,7 @@ def create_default_velp_group(
     return new_group
 
 
-def set_default_velp_group_rights(doc_id: int, velp_group: DocInfo):
+def set_default_velp_group_rights(doc_id: int, velp_group: DocInfo) -> None:
     rights = get_rights_holders(doc_id)
     # Copy all rights but view
     for right in rights:
@@ -82,7 +82,7 @@ def set_default_velp_group_rights(doc_id: int, velp_group: DocInfo):
             grant_access(right.usergroup, velp_group, right.access_type)
 
 
-def get_document_default_velp_group_info(doc_info: DocInfo):
+def get_document_default_velp_group_info(doc_info: DocInfo) -> tuple[str, str]:
     """
     Returns path and name for a document's default group
     """
@@ -94,7 +94,9 @@ def get_document_default_velp_group_info(doc_info: DocInfo):
     return velps_folder_path + "/" + velp_group_name, velp_group_name
 
 
-def get_document_default_velp_group(doc_info: DocInfo):
+def get_document_default_velp_group(
+    doc_info: DocInfo,
+) -> tuple[DocInfo | None, str, str]:
     """
     Returns document default velp group, default velp group path and default name for velp group
     """
@@ -102,7 +104,7 @@ def get_document_default_velp_group(doc_info: DocInfo):
     return DocEntry.find_by_path(velp_group_path), velp_group_path, velp_group_name
 
 
-def set_default_velp_group_selected_and_visible(doc_info: DocInfo):
+def set_default_velp_group_selected_and_visible(doc_info: DocInfo) -> None:
     """
     Makes document's default velp group visible and selected for everyone
     """
@@ -194,7 +196,7 @@ VelpGroupOrDocInfo = Union[VelpGroup, DocInfo]
 
 def add_groups_to_document(
     velp_groups: list[VelpGroupOrDocInfo], doc: DocInfo, user: User
-):
+) -> None:
     """Adds velp groups to VelpGroupsInDocument table."""
     existing: list[VelpGroupsInDocument] = VelpGroupsInDocument.query.filter_by(
         user_id=user.id, doc_id=doc.id
@@ -216,7 +218,7 @@ def change_selection(
     target_id: str,
     user_id: int,
     selected: bool,
-):
+) -> None:
     """Changes selection for velp group in VelpGroupSelection for specific user / document / target combo.
 
     :param doc_id: ID of document
@@ -250,7 +252,7 @@ def change_selection(
 
 def change_all_target_area_default_selections(
     doc_id: int, target_type: int, target_id: str, user_id: int, selected: bool
-):
+) -> None:
     """Change all default selections to True or False for currently chose area (document or paragraph)
 
     :param doc_id: ID of document
@@ -279,7 +281,7 @@ def change_all_target_area_default_selections(
 
 def change_all_target_area_selections(
     doc_id: int, target_type: int, target_id: str, user_id: int, selected: bool
-):
+) -> None:
     """Change all personal selections to True or False for currently chose area (document or paragraph)
 
     :param doc_id: ID of document
@@ -319,7 +321,7 @@ def change_all_target_area_selections(
 
 def change_default_selection(
     doc_id: int, velp_group_id: int, target_type: int, target_id: str, selected: bool
-):
+) -> None:
     """Changes selection for velp group's default selection in target area.
 
     :param doc_id: ID of document
@@ -354,7 +356,7 @@ def add_groups_to_selection_table(
     user_id: int,
     target_type: int,
     target_id: str,
-):
+) -> None:
     """Adds velp groups to VelpGroupSelection table."""
     vgs = VelpGroupSelection.query.filter_by(
         user_id=user_id,
@@ -377,12 +379,14 @@ def add_groups_to_selection_table(
         db.session.add(vgs)
 
 
-def process_selection_info(vgss: list[VelpGroupSelection] | list[VelpGroupDefaults]):
+def process_selection_info(
+    vgss: list[VelpGroupSelection] | list[VelpGroupDefaults],
+) -> dict[str, list | list[dict[str, int | bool]]]:
     if vgss:
         target_id = vgss[0].target_id
-        list_help = []
-        target_dict = dict()
-        group_dict = dict()
+        list_help: list[dict[str, int | bool]] = []
+        target_dict: dict[str, list | list[dict[str, int | bool]]] = dict()
+        group_dict: dict[str, int | bool] = dict()
         if target_id != "0":
             target_dict["0"] = []
         for i in range(len(vgss)):
@@ -413,7 +417,9 @@ def process_selection_info(vgss: list[VelpGroupSelection] | list[VelpGroupDefaul
         return {"0": []}
 
 
-def get_personal_selections_for_velp_groups(doc_id: int, user_id: int):
+def get_personal_selections_for_velp_groups(
+    doc_id: int, user_id: int
+) -> dict[str, list | list[dict[str, int | bool]]]:
     """Gets all velp group personal selections for document.
 
     :param doc_id: ID of document
@@ -429,7 +435,9 @@ def get_personal_selections_for_velp_groups(doc_id: int, user_id: int):
     return process_selection_info(vgss)
 
 
-def get_default_selections_for_velp_groups(doc_id: int):
+def get_default_selections_for_velp_groups(
+    doc_id: int,
+) -> dict[str, list | list[dict[str, int | bool]]]:
     """Gets all velp group default selections for document.
 
     :param doc_id: ID of document

--- a/timApp/velp/velpgroups.py
+++ b/timApp/velp/velpgroups.py
@@ -83,7 +83,7 @@ class VelpGroupSelectionInfo:
         self.selections[index].append(gs)
 
     def to_json(self) -> dict:
-        if len(self.target_ids) == 0:
+        if not self.target_ids:
             return {"0": []}
         result = dict()
         for t_id, selects in zip(self.target_ids, self.selections):

--- a/timApp/velp/velpgroups.py
+++ b/timApp/velp/velpgroups.py
@@ -11,8 +11,7 @@ selections from the database.
 """
 
 import copy
-from dataclasses import dataclass
-from typing import Union
+from typing import Union, Any
 
 from timApp.auth.accesstype import AccessType
 from timApp.document.docentry import DocEntry
@@ -32,23 +31,6 @@ from timApp.velp.velp_models import (
     VelpGroupSelection,
     VelpGroupDefaults,
 )
-
-
-@dataclass
-class CreatedVelpGroup:
-    """Represents a velp group. Used for passing velp group data to the user interface."""
-
-    id: int
-    name: str
-    location: str
-    target_type: int = 0
-    target_id: str = "0"
-    edit_access: bool = True
-    show: bool = True
-    selected: bool = True
-    default: bool = False
-    default_group: bool = False
-    created_new_group: bool = True
 
 
 def create_default_velp_group(

--- a/timApp/velp/velpgroups.py
+++ b/timApp/velp/velpgroups.py
@@ -448,7 +448,6 @@ def process_selection_info(
 
             if i > len(vgss) - 1:
                 break
-        print(groups.to_json())
         return groups
     return VelpGroupSelectionInfo(target_ids=[], selections=[])
 

--- a/timApp/velp/velps.py
+++ b/timApp/velp/velps.py
@@ -69,7 +69,9 @@ def create_velp_version(velp: Velp) -> VelpVersion:
     return vv
 
 
-def add_velp_label_translation(label: VelpLabel, language_id: str, content: str):
+def add_velp_label_translation(
+    label: VelpLabel, language_id: str, content: str
+) -> None:
     """Adds new translation to an existing label.
 
     :param label: Label
@@ -82,8 +84,8 @@ def add_velp_label_translation(label: VelpLabel, language_id: str, content: str)
 
 
 def create_velp_content(
-    version: VelpVersion, language_id: str, content: str, default_comment: str
-):
+    version: VelpVersion, language_id: str, content: str, default_comment: str | None
+) -> None:
     """Method to create content (text) for velp.
 
     :param version: The VelpVersion
@@ -109,7 +111,7 @@ def create_new_velp(
     valid_until: str | None = None,
     language_id: str = "FI",
     visible_to: int | None = None,
-    color: int | None = None,
+    color: str | None = None,
     style: int | None = None,
 ) -> tuple[Velp, VelpVersion]:
     """Creates a new velp with all information.
@@ -138,7 +140,7 @@ def create_new_velp(
 
 def update_velp(
     velp_id: int, default_points: str, color: str, visible_to: int, style: int
-):
+) -> None:
     """Changes the non-versioned properties of a velp. Does not update labels.
 
     :param velp_id: ID of velp that's being updated
@@ -158,7 +160,7 @@ def update_velp(
         v.style = style
 
 
-def add_labels_to_velp(velp_id: int, labels: Iterable[int]):
+def add_labels_to_velp(velp_id: int, labels: Iterable[int]) -> None:
     """Associates a set of labels to a velp. (Appends to existing labels)
 
     Do note that update_velp_labels depends on this method
@@ -173,7 +175,7 @@ def add_labels_to_velp(velp_id: int, labels: Iterable[int]):
             db.session.add(LabelInVelp(label_id=label_id, velp_id=velp_id))
 
 
-def update_velp_labels(velp_id: int, labels: Iterable[int]):
+def update_velp_labels(velp_id: int, labels: Iterable[int]) -> None:
     """Replaces the labels of a velp with new ones.
 
     :param velp_id: velp ID


### PR DESCRIPTION
Fix typings/type annotations for velp source files (timApp/velp/*.py).


TODO:

- [x] MyPy reports an import error in `velp_models.py` (sqlalchemy.orm.collections).
   **Ignored for now, no type hints available.**

- [x] Remaining errors reported by MyPy.
   **Mostly fixed in #3093.**

- [x] `get_velp_groups_from_tree(doc: DocInfo) -> list[DocEntry]` when expected to return list[VelpGroup | DocInfo]. 
   **Refactored.**

- [x] Refactor velp group selections to use dataclasses.
   **Refactored, still uses dicts for json_responses for now because of UI code dependencies.**

- <s>Convert Blueprints to TypedBlueprints (and refactor remaining dicts into TypedDicts or dataclasses?)</s> Move into its own PR.