### PR TITLE
Modelanswer

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2321,7 +2321,6 @@ def get_model_answer(task_id: str) -> Response:
             )
 
     if model_answer_info.lock:
-        # def add_task_block(start_time, expire_time)
         b = TaskBlock.get_by_task(tid.doc_task)
         ba = None
         if not b:

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2426,7 +2426,6 @@ def get_state(
             deref(),
             user_ctx,
             view_ctx,
-            view_ctx,
             custom_answer=answer,
             task_id=task_id,
             do_lazy=NEVERLAZY,

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2320,7 +2320,7 @@ def get_model_answer(task_id: str) -> Response:
                 f"You need to attempt at least {model_answer_info.count} times before viewing the model answer"
             )
 
-    if model_answer_info.lock:
+    if model_answer_info.lock and not has_teacher_access(d):
         b = TaskBlock.get_by_task(tid.doc_task)
         ba = None
         if not b:

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -78,6 +78,7 @@ from timApp.document.viewcontext import (
 from timApp.item.block import Block, BlockType
 from timApp.item.taskblock import insert_task_block, TaskBlock
 from timApp.markdown.dumboclient import call_dumbo
+from timApp.markdown.markdownconverter import md_to_html
 from timApp.messaging.messagelist.messagelist_utils import (
     UserGroupDiff,
     sync_usergroup_messagelist_members,
@@ -2290,6 +2291,56 @@ def get_jsframe_data(task_id: str, user_id: str) -> Response:
         # return json_response({})
 
 
+@answers.get("/getModelAnswer/<task_id>")
+def get_model_answer(task_id: str) -> Response:
+    tid = TaskId.parse(task_id)
+    d = get_doc_or_abort(tid.doc_id)
+    verify_view_access(d)
+    doc = d.document
+    doc.insert_preamble_pars()
+    current_user = get_current_user_object()
+    view_ctx = ViewContext(ViewRoute.View, False, origin=get_origin_from_request())
+    user_ctx = user_context_with_logged_in(current_user)
+    try:
+        doc, plug = get_plugin_from_request(
+            doc, task_id=tid, u=user_ctx, view_ctx=view_ctx
+        )
+    except PluginException as e:
+        raise RouteException(str(e))
+    model_answer_info = plug.known.modelAnswer
+    if not model_answer_info:
+        raise RouteException(f"No model answer for task {task_id}")
+    if model_answer_info.count:
+        current_count = current_user.get_answers_for_task(tid.doc_task).count()
+        if current_count < model_answer_info.count:
+            raise RouteException(
+                f"You need to attempt at least {model_answer_info.count} times before viewing the model answer"
+            )
+
+    if model_answer_info.lock:
+        # def add_task_block(start_time, expire_time)
+        b = TaskBlock.get_by_task(tid.doc_task)
+        ba = None
+        if not b:
+            b = insert_task_block(task_id=tid.doc_task, owner_groups=d.owners)
+        else:
+            ba = BlockAccess.query.filter_by(
+                block_id=b.id,
+                type=AccessType.view.value,
+                usergroup_id=current_user.get_personal_group().id,
+            ).first()
+        if not ba:
+            grant_access(
+                current_user.get_personal_group(),
+                b.block,
+                AccessType.view,
+                accessible_to=get_current_time(),
+            )
+            db.session.commit()
+    answer_html = md_to_html(model_answer_info.answer)
+    return json_response({"answer": answer_html})
+
+
 @answers.get("/getState")
 def get_state(
     user_id: int,
@@ -2374,6 +2425,7 @@ def get_state(
             doc,
             deref(),
             user_ctx,
+            view_ctx,
             view_ctx,
             custom_answer=answer,
             task_id=task_id,

--- a/timApp/auth/accesshelper.py
+++ b/timApp/auth/accesshelper.py
@@ -599,6 +599,16 @@ def verify_task_access(
             invalidate_reason = "You haven't started this task yet."
     if (
         not is_invalid
+        and (found_plugin.known.modelAnswer and found_plugin.known.modelAnswer.lock)
+        and required_task_access_level == TaskIdAccess.ReadWrite
+    ):
+        found_plugin.set_access_end_for_user(user=context_user.logged_user)
+        if found_plugin.access_end_for_user:
+            if found_plugin.access_end_for_user < get_current_time():
+                is_invalid = True
+                invalidate_reason = "You have already downloaded the model answer and can not save new answers anymore."
+    if (
+        not is_invalid
         and found_plugin.known.accessField
         and required_task_access_level == TaskIdAccess.ReadWrite
     ):

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6456,6 +6456,22 @@
           <context context-type="linenumber">155</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4677361144671545016" datatype="html">
+        <source>You need to attempt at least <x id="PH" equiv-text="this.modelAnswer.count"/> times before viewing the model answer</source>
+        <target state="translated">Sinun täytyy yrittää ainakin <x id="PH" equiv-text="this.modelAnswer.count"/> kertaa ennen mallivastauksen katsomista</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">1358</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="195293465269339079" datatype="html">
+        <source>Lock the task and view the model answer?</source>
+        <target state="translated">Lukitse tehtävä ja näytä mallivastaus?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">1364</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6346,6 +6346,22 @@
           <context context-type="linenumber">155</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4677361144671545016" datatype="html">
+        <source>You need to attempt at least <x id="PH" equiv-text="this.modelAnswer.count"/> times before viewing the model answer</source>
+        <target state="translated">Du måste försöka minst <x id="PH" equiv-text="this.modelAnswer.count"/> gånger innan du får se modellsvaret</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">1358</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="195293465269339079" datatype="html">
+        <source>Lock the task and view the model answer?</source>
+        <target state="translated">Låsa uppgiften och se modellsvaret?</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">1364</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/item/manage.py
+++ b/timApp/item/manage.py
@@ -306,6 +306,11 @@ def log_right(s: str):
     log_info(f"RIGHTS: {u.name} {s}")
 
 
+def log_task_block(s: str):
+    u = get_current_user_object()
+    log_info(f"TASKBLOCK: {u.name} {s}")
+
+
 def get_group_and_doc(doc_id: int, username: str) -> tuple[UserGroup, DocInfo]:
     i = get_item_or_abort(doc_id)
     verify_permission_edit_access(i, AccessType.view)

--- a/timApp/item/taskblock.py
+++ b/timApp/item/taskblock.py
@@ -28,6 +28,7 @@ class TaskBlock(db.Model):
 
 
 def insert_task_block(task_id: str, owner_groups: list[UserGroup]) -> TaskBlock:
+    # owner_groups may be redundant, would need to be kept up-to-date with task doc owners
     b = insert_block(BlockType.Task, description=task_id, owner_groups=owner_groups)
     task_block = TaskBlock(id=b.id, task_id=task_id, block=b)
     db.session.add(task_block)

--- a/timApp/plugin/plugin.py
+++ b/timApp/plugin/plugin.py
@@ -579,19 +579,18 @@ class Plugin:
         """
         if self.task_id:
             current_user = user if user else self.options.user_ctx.logged_user
-            if not current_user.has_teacher_access(self.par.doc.get_docinfo()):
-                # TODO: unlockable plugin shouldn't be a "placed" plugin in pluginify
-                b = TaskBlock.get_by_task(self.task_id.doc_task)
-                if not b:
-                    return
-                ba = BlockAccess.query.filter_by(
-                    block_id=b.id,
-                    type=AccessType.view.value,
-                    usergroup_id=current_user.get_personal_group().id,
-                ).first()
-                if not ba:
-                    return
-                self.access_end_for_user = ba.accessible_to
+            # TODO: unlockable plugin shouldn't be a "placed" plugin in pluginify
+            b = TaskBlock.get_by_task(self.task_id.doc_task)
+            if not b:
+                return
+            ba = BlockAccess.query.filter_by(
+                block_id=b.id,
+                type=AccessType.view.value,
+                usergroup_id=current_user.get_personal_group().id,
+            ).first()
+            if not ba:
+                return
+            self.access_end_for_user = ba.accessible_to
 
     # TODO: Instead of using AngularJS draggable, define dragging on Angular side
     def wrap_draggable(self, html_str: str, doc_task_id: str) -> str:

--- a/timApp/plugin/plugin.py
+++ b/timApp/plugin/plugin.py
@@ -579,18 +579,19 @@ class Plugin:
         """
         if self.task_id:
             current_user = user if user else self.options.user_ctx.logged_user
-            # TODO: unlockable plugin shouldn't be a "placed" plugin in pluginify
-            b = TaskBlock.get_by_task(self.task_id.doc_task)
-            if not b:
-                return
-            ba = BlockAccess.query.filter_by(
-                block_id=b.id,
-                type=AccessType.view.value,
-                usergroup_id=current_user.get_personal_group().id,
-            ).first()
-            if not ba:
-                return
-            self.access_end_for_user = ba.accessible_to
+            if not current_user.has_teacher_access(self.par.doc.get_docinfo()):
+                # TODO: unlockable plugin shouldn't be a "placed" plugin in pluginify
+                b = TaskBlock.get_by_task(self.task_id.doc_task)
+                if not b:
+                    return
+                ba = BlockAccess.query.filter_by(
+                    block_id=b.id,
+                    type=AccessType.view.value,
+                    usergroup_id=current_user.get_personal_group().id,
+                ).first()
+                if not ba:
+                    return
+                self.access_end_for_user = ba.accessible_to
 
     # TODO: Instead of using AngularJS draggable, define dragging on Angular side
     def wrap_draggable(self, html_str: str, doc_task_id: str) -> str:

--- a/timApp/plugin/pluginControl.py
+++ b/timApp/plugin/pluginControl.py
@@ -50,7 +50,13 @@ from timApp.util.get_fields import (
 )
 from timApp.util.rndutils import SeedClass
 from timApp.util.timtiming import taketime
-from timApp.util.utils import get_error_tex, Range, get_error_html_block, get_error_html
+from timApp.util.utils import (
+    get_error_tex,
+    Range,
+    get_error_html_block,
+    get_error_html,
+    get_current_time,
+)
 from tim_common.html_sanitize import sanitize_html
 
 
@@ -409,6 +415,18 @@ class PluginifyResult:
     has_errors: bool
 
 
+def set_model_answer_info(
+    model_answer_info: dict, context_user: UserContext, plugin: Plugin
+):
+    model_answer_info.pop("answer", None)
+    lock = model_answer_info.get("lock", True)
+    if lock:
+        plugin.set_access_end_for_user(user=context_user.logged_user)
+        if plugin.access_end_for_user:
+            if plugin.access_end_for_user < get_current_time():
+                model_answer_info["alreadyLocked"] = True
+
+
 def pluginify(
     doc: Document,
     pars: list[DocParagraph],
@@ -572,8 +590,11 @@ def pluginify(
         for _, plugin in plugin_block_map.items():
             plugin.values.pop("postprogram", None)
             plugin.values.pop("preprogram", None)
+            model_answer = plugin.values.get("modelAnswer", None)
             if not plugin.task_id:
                 continue
+            if model_answer:
+                set_model_answer_info(model_answer, user_ctx, plugin)
             if plugin.task_id.is_global:
                 glb_task_ids.append(plugin.task_id)
                 glb_plugins_to_change.append(plugin)

--- a/timApp/plugin/pluginControl.py
+++ b/timApp/plugin/pluginControl.py
@@ -591,10 +591,10 @@ def pluginify(
             plugin.values.pop("postprogram", None)
             plugin.values.pop("preprogram", None)
             model_answer = plugin.values.get("modelAnswer", None)
-            if not plugin.task_id:
-                continue
             if model_answer:
                 set_model_answer_info(model_answer, user_ctx, plugin)
+            if not plugin.task_id:
+                continue
             if plugin.task_id.is_global:
                 glb_task_ids.append(plugin.task_id)
                 glb_plugins_to_change.append(plugin)

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -1355,18 +1355,17 @@ export class AnswerBrowserController
             Math.max(this.modelAnswer?.count - this.answers.length, 0) > 0
         ) {
             this.alerts.push({
-                msg: `You need to attempt at least ${this.modelAnswer.count} times before viewing the model answer`,
+                msg: $localize`You need to attempt at least ${this.modelAnswer.count} times before viewing the model answer`,
                 type: "warning",
             });
             return;
         }
         if (this.modelAnswer?.lock && !this.modelAnswer?.alreadyLocked) {
+            const defaultLockText = $localize`Lock the task and view the model answer?`;
             if (
                 !(await showConfirm(
-                    this.modelAnswer?.lockText ??
-                        "Lock the task and view the model answer?",
-                    this.modelAnswer?.lockText ??
-                        "Lock the task and view the model answer?"
+                    this.modelAnswer?.lockText ?? defaultLockText,
+                    this.modelAnswer?.lockText ?? defaultLockText
                 ))
             ) {
                 return;

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -10,12 +10,14 @@ import {tryCreateParContextOrHelp} from "tim/document/structure/create";
 import {ParContext} from "tim/document/structure/parContext";
 import {ReadonlyMoment} from "tim/util/readonlymoment";
 import moment from "moment";
+import {showConfirm} from "tim/ui/showConfirmDialog";
 import {isVelpable, ITimComponent, ViewCtrl} from "../document/viewctrl";
 import {compileWithViewctrl, ParCompiler} from "../editor/parCompiler";
 import {
     IAnswerBrowserMarkupSettings,
     IGenericPluginMarkup,
     IGenericPluginTopLevelFields,
+    IModelAnswerSettings,
 } from "../plugin/attributes";
 import {DestroyScope} from "../ui/destroyScope";
 import {IUser, sortByRealName} from "../user/IUser";
@@ -541,6 +543,9 @@ export class AnswerBrowserController
     private pointsStep: number = 0.01;
     private markupSettings: IAnswerBrowserMarkupSettings =
         DEFAULT_MARKUP_CONFIG;
+    private modelAnswer?: IModelAnswerSettings;
+    private modelAnswerFetched = false;
+    private modelAnswerHtml?: string;
     private isValidAnswer = false;
     private hidden: boolean = false;
     private showDelete = false;
@@ -653,6 +658,9 @@ export class AnswerBrowserController
         const markup = this.loader.pluginMarkup();
         if (markup?.answerBrowser) {
             this.markupSettings = markup.answerBrowser;
+        }
+        if (markup?.modelAnswer) {
+            this.modelAnswer = markup.modelAnswer;
         }
 
         // Ensure the point step is never zero because some browsers don't like step="0" value in number inputs.
@@ -1335,6 +1343,50 @@ export class AnswerBrowserController
             size: 1,
             group: getUrlParams().get("group"),
         })}`;
+    }
+
+    getModelAnswerLink() {
+        return `/getModelAnswer/${this.taskId.docTask().toString()}`;
+    }
+
+    async showModelAnswer() {
+        if (
+            this.modelAnswer?.count &&
+            Math.max(this.modelAnswer?.count - this.answers.length, 0) > 0
+        ) {
+            this.alerts.push({
+                msg: `You need to attempt at least ${this.modelAnswer.count} times before viewing the model answer`,
+                type: "warning",
+            });
+            return;
+        }
+        if (this.modelAnswer?.lock && !this.modelAnswer?.alreadyLocked) {
+            if (
+                !(await showConfirm(
+                    this.modelAnswer?.lockText ??
+                        "Lock the task and view the model answer?",
+                    this.modelAnswer?.lockText ??
+                        "Lock the task and view the model answer?"
+                ))
+            ) {
+                return;
+            }
+        }
+        this.loading++;
+        const r = await to(
+            $http.get<{answer: string}>(this.getModelAnswerLink())
+        );
+        this.loading--;
+        console.log(r);
+        if (!r.ok) {
+            this.showError(r.result);
+            return;
+        }
+        if (this.modelAnswer?.lock) {
+            this.modelAnswer.alreadyLocked = true;
+        }
+        this.modelAnswerFetched = true;
+        this.modelAnswerHtml = r.result.data.answer;
     }
 
     updateAnswerFromURL() {

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -1360,7 +1360,11 @@ export class AnswerBrowserController
             });
             return;
         }
-        if (this.modelAnswer?.lock && !this.modelAnswer?.alreadyLocked) {
+        if (
+            this.modelAnswer?.lock &&
+            !this.modelAnswer?.alreadyLocked &&
+            !this.viewctrl?.item.rights.teacher
+        ) {
             const defaultLockText = $localize`Lock the task and view the model answer?`;
             if (
                 !(await showConfirm(

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -1376,7 +1376,6 @@ export class AnswerBrowserController
             $http.get<{answer: string}>(this.getModelAnswerLink())
         );
         this.loading--;
-        console.log(r);
         if (!r.ok) {
             this.showError(r.result);
             return;

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -21,6 +21,24 @@ export const undoType = t.partial({
     confirmationTitle: nullable(t.string),
 });
 
+export const modelAnswerType = t.intersection([
+    t.type({
+        linkText: t.string,
+        lock: withDefault(t.boolean, true),
+        // need full info dynamically instead of strict markupmodel (use taskInfo?)
+        // - already locked or not
+        // - answer maybe already present
+    }),
+    t.partial({
+        count: nullable(t.number),
+        lockText: t.string,
+        alreadyLocked: t.boolean,
+    }),
+]);
+
+export interface IModelAnswerSettings
+    extends t.TypeOf<typeof modelAnswerType> {}
+
 // Attributes that are valid for all plugins.
 export const GenericPluginMarkup = t.partial({
     answerLimit: nullable(t.Integer),
@@ -43,6 +61,7 @@ export const GenericPluginMarkup = t.partial({
     connectionErrorMessage: nullable(t.string),
     answerBrowser: nullable(AnswerBrowserSettings),
     warningFilter: nullable(t.string),
+    modelAnswer: nullable(modelAnswerType),
 });
 
 export const Info = nullable(

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -210,4 +210,12 @@
         <span ng-show="$ctrl.viewctrl.teacherMode && $ctrl.hasUserChanged() && !$ctrl.loading">(hover/click to update)</span>
         <!-- <img style="display: inline" src="/static/images/loading.gif" ng-show="$ctrl.loading"> -->
     </div>
+    <div ng-if="$ctrl.modelAnswer">
+        <a ng-if="$ctrl.modelAnswer"
+           title="Show model answer"
+           ng-click="$ctrl.showModelAnswer()">{{$ctrl.modelAnswer.linkText}}</a>
+        <div ng-if="$ctrl.modelAnswerFetched" ng-bind-html="$ctrl.modelAnswerHtml">
+
+        </div>
+    </div>
 </div>

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -1,7 +1,7 @@
 from copy import copy
 from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import datetime, timezone
-from typing import Any, Mapping, NewType
+from typing import Any, Mapping, NewType, Literal
 
 import marshmallow
 from marshmallow import missing, pre_load, EXCLUDE
@@ -75,6 +75,15 @@ class AccessField:
 
 
 @dataclass
+class ModelAnswerInfo:
+    answer: str
+    linkText: str | None | Missing = missing
+    count: int | None | Missing = missing
+    lock: bool = True
+    lockText: str | None | Missing = missing
+
+
+@dataclass
 class KnownMarkupFields(HiddenFieldsMixin):
     """Represents the plugin markup fields that are known and used by TIM."""
 
@@ -101,6 +110,7 @@ class KnownMarkupFields(HiddenFieldsMixin):
     minHeight: str | None | Missing = field(
         metadata={"data_key": "min-height"}, default=missing
     )
+    modelAnswer: ModelAnswerInfo | None | Missing = missing
     pointsRule: PointsRule | None | Missing = missing
     pointsText: str | None | Missing = missing
     postprogram: str | Missing = missing


### PR DESCRIPTION
https://timdevs01-3.it.jyu.fi/view/modelanswer_mr

Ensimmäinen versio mallivastauksesta. Lisää uuden yleisen pluginattribuutin

```
modelAnswer:
 answer: Mallivastaus tekstinä (tukee md)
 linkText: Mallivastauksen linkki
 lock: true # (oletus, mallin katsomisen jälkeen vastaukset ovat invalid)
 lockText: varmistus ennen vastauksen lukitsemista
 count: 2 # yritysten vähimmäismäärä, valinnainnen
```

Tällä hetkellä käytetään taskBlock-taulua ja blockAccess-taulua tarkistamaan onko vastausta lukittu. Tässä on huonona puolena se että kantaan ei jää selkeää infoa siitä miksi tehtävä on lukittu. Jos käyttää accessDuration-attribuuttia (tai tulevaisuudessa tulee muita tapoja lukita yksittäinen tehtävä), ei ole mitään tapaa tutkia kannasta että tämä lukitus tuli mallivastauksen katsomisen vuoksi tms