### PR TITLE
Fix annotation size

### DIFF
--- a/timApp/static/stylesheets/velpSelection.scss
+++ b/timApp/static/stylesheets/velpSelection.scss
@@ -18,6 +18,10 @@
     }
 }
 
+annotation .fulldiv {
+    min-height: unset;
+}
+
 .velp-groups-resize {
     resize: vertical;
 }


### PR DESCRIPTION
Small fix to annotation pop-ups being too big because of .fulldiv-style used in the template.