### PR TITLE
Answerbrowser globals

### DIFF
--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -16,6 +16,7 @@ from timApp.document.viewcontext import ViewContext, default_view_ctx
 from timApp.document.yamlblock import YamlBlock
 from timApp.markdown.dumboclient import MathType, DumboOptions, InputFormat
 from timApp.timdb.exceptions import TimDbException, InvalidReferenceException
+from tim_common.markupmodels import AnswerBrowserInfo
 from tim_common.marshmallow_dataclass import field_for_schema
 
 if TYPE_CHECKING:
@@ -74,6 +75,7 @@ class DocSettingTypes:
     peer_review_start: datetime
     peer_review_stop: datetime
     anonymize_reviewers: str
+    answerBrowser: AnswerBrowserInfo
 
 
 doc_setting_field_map: dict[str, Field] = {

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -498,6 +498,7 @@ export type AnswerBrowserData =
 
 const DEFAULT_MARKUP_CONFIG: IAnswerBrowserSettings = {
     pointsStep: 0,
+    validOnlyText: "Show valid only",
 };
 
 export class AnswerBrowserController

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -14,7 +14,7 @@ import {showConfirm} from "tim/ui/showConfirmDialog";
 import {isVelpable, ITimComponent, ViewCtrl} from "../document/viewctrl";
 import {compileWithViewctrl, ParCompiler} from "../editor/parCompiler";
 import {
-    IAnswerBrowserMarkupSettings,
+    IAnswerBrowserSettings,
     IGenericPluginMarkup,
     IGenericPluginTopLevelFields,
     IModelAnswerSettings,
@@ -496,7 +496,7 @@ export type AnswerBrowserData =
           answernr: number | undefined;
       };
 
-const DEFAULT_MARKUP_CONFIG: IAnswerBrowserMarkupSettings = {
+const DEFAULT_MARKUP_CONFIG: IAnswerBrowserSettings = {
     pointsStep: 0,
 };
 
@@ -541,8 +541,7 @@ export class AnswerBrowserController
     private reviewHtml?: string;
     private answerLoader?: AnswerLoadCallback;
     private pointsStep: number = 0.01;
-    private markupSettings: IAnswerBrowserMarkupSettings =
-        DEFAULT_MARKUP_CONFIG;
+    private markupSettings: IAnswerBrowserSettings = DEFAULT_MARKUP_CONFIG;
     private modelAnswer?: IModelAnswerSettings;
     private modelAnswerFetched = false;
     private modelAnswerHtml?: string;
@@ -659,6 +658,8 @@ export class AnswerBrowserController
         const markup = this.loader.pluginMarkup();
         if (markup?.answerBrowser) {
             this.markupSettings = markup.answerBrowser;
+        } else if (this.viewctrl?.docSettings.answerBrowser) {
+            this.markupSettings = this.viewctrl.docSettings.answerBrowser;
         }
         if (markup?.modelAnswer) {
             this.modelAnswer = markup.modelAnswer;

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -678,6 +678,9 @@ export class AnswerBrowserController
         if (this.markupSettings.pointsStep) {
             this.pointsStep = this.markupSettings?.pointsStep;
         }
+        if (this.markupSettings.showValidOnly != undefined) {
+            this.onlyValid = this.markupSettings.showValidOnly;
+        }
 
         // noinspection JSUnusedLocalSymbols,JSUnusedLocalSymbols
         this.scope.$watch(

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -655,11 +655,18 @@ export class AnswerBrowserController
         this.feedback = "";
         this.showNewTask = this.isAndSetShowNewTask();
 
+        if (this.viewctrl?.docSettings.answerBrowser) {
+            this.markupSettings = {
+                ...this.markupSettings,
+                ...this.viewctrl.docSettings.answerBrowser,
+            };
+        }
         const markup = this.loader.pluginMarkup();
         if (markup?.answerBrowser) {
-            this.markupSettings = markup.answerBrowser;
-        } else if (this.viewctrl?.docSettings.answerBrowser) {
-            this.markupSettings = this.viewctrl.docSettings.answerBrowser;
+            this.markupSettings = {
+                ...this.markupSettings,
+                ...markup.answerBrowser,
+            };
         }
         if (markup?.modelAnswer) {
             this.modelAnswer = markup.modelAnswer;

--- a/timApp/static/scripts/tim/document/IDocSettings.ts
+++ b/timApp/static/scripts/tim/document/IDocSettings.ts
@@ -1,3 +1,5 @@
+import {IAnswerBrowserSettings} from "tim/plugin/attributes";
+
 export type MeetingDateEntry = [string, string, string];
 
 export interface ITimeLeftSettings {
@@ -41,6 +43,7 @@ export interface IDocSettings {
     description?: string;
     translator?: string;
     sync_answerbrowsers?: boolean;
+    answerBrowser?: IAnswerBrowserSettings;
 }
 
 export interface ISlideDocSettings extends IDocSettings {

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -8,6 +8,7 @@ import * as t from "io-ts";
 export const AnswerBrowserSettings = t.partial({
     pointsStep: nullable(t.number),
     validOnlyText: t.string,
+    showValidOnly: t.boolean,
 });
 
 export interface IAnswerBrowserSettings

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -7,6 +7,7 @@ import * as t from "io-ts";
 
 export const AnswerBrowserSettings = t.partial({
     pointsStep: nullable(t.number),
+    validOnlyText: t.string,
 });
 
 export interface IAnswerBrowserSettings

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -5,11 +5,11 @@ So, do NOT import anything client-side-specific (like AngularJS) in this module 
 
 import * as t from "io-ts";
 
-export const AnswerBrowserSettings = t.type({
+export const AnswerBrowserSettings = t.partial({
     pointsStep: nullable(t.number),
 });
 
-export interface IAnswerBrowserMarkupSettings
+export interface IAnswerBrowserSettings
     extends t.TypeOf<typeof AnswerBrowserSettings> {
     // Empty
 }

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -4,7 +4,7 @@
         <div ng-bind-html="alert.msg"></div>
     </div>
     <label ng-show="$ctrl.hidden && $ctrl.anyInvalid && !$ctrl.formMode" class="checkbox-inline">
-        <input type="checkbox" ng-model="$ctrl.onlyValid">Show valid only</label>
+        <input type="checkbox" ng-model="$ctrl.onlyValid">{{::$ctrl.markupSettings.validOnlyText}}</label>
     <div ng-show="!$ctrl.hidden">
         <div ng-show="$ctrl.viewctrl.teacherMode && $ctrl.users.length > 0" class="flex">
             <div>
@@ -55,7 +55,7 @@
                                                                                                   title="Newest answer"
                                                                                                   ng-click="$ctrl.setNewest()">{{ $ctrl.filteredAnswers.length }}</a></span>
                         <label class="checkbox-inline" ng-show="$ctrl.anyInvalid">
-                            <input type="checkbox" ng-model="$ctrl.onlyValid">Show valid only</label>
+                            <input type="checkbox" ng-model="$ctrl.onlyValid">{{::$ctrl.markupSettings.validOnlyText}}</label>
                         <span ng-show="$ctrl.showTeacher()"> | <a ng-click="$ctrl.getAllAnswers()">All answers</a>
                     </span>
                         <button class="timButton" ng-if="$ctrl.showNewTask" title="Change to new task" ng-click="$ctrl.newTask()">{{ $ctrl.buttonNewTask }}</button>

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -175,6 +175,7 @@ class UndoInfo:
 @dataclass
 class AnswerBrowserInfo:
     pointsStep: float | None | Missing = missing
+    validOnlyText: str | None | Missing = missing
 
 
 @dataclass

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -173,6 +173,11 @@ class UndoInfo:
 
 
 @dataclass
+class AnswerBrowserInfo:
+    pointsStep: float | None | Missing = missing
+
+
+@dataclass
 class GenericMarkupModel(KnownMarkupFields):
     """Specifies which fields the editor can use in the plugin markup.
     This base class defines some fields that are applicable to all plugins.
@@ -199,6 +204,7 @@ class GenericMarkupModel(KnownMarkupFields):
     resetText: str | Missing | None = missing
     connectionErrorMessage: str | Missing = missing
     undo: UndoInfo | Missing | None = missing
+    answerBrowser: AnswerBrowserInfo | Missing | None = missing
 
     def get_visible_data(self) -> dict:
         assert isinstance(self.hidden_keys, list)

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -176,6 +176,7 @@ class UndoInfo:
 class AnswerBrowserInfo:
     pointsStep: float | None | Missing = missing
     validOnlyText: str | None | Missing = missing
+    showValidOnly: bool | None | Missing = missing
 
 
 @dataclass


### PR DESCRIPTION
>Melkein tekisi mieli että olisi dokumenttikohtainen asetus, jolla
voisi antaa oletusarvoja "kaikille" AB:n teksteille/valinnoille.
Esim tuo showValidOnly on sellainen, mikä useimiten tekisi mieli muuttaa
koko dokumentissa.  Ja tietty siksi esim demojen tapauksessa sen preamblessa.

Lisää uuden dokumenttiasetuksen
```
answerBrowser:
 pointsStep: sama kuin lokaali pointsstep
 validOnlyText: Oletusteksti "Show valid only"n tilalle
 showValidOnly: Oletusasetus show valid -ruksille
```
https://timdevs01-3.it.jyu.fi/teacher/answerbrowser-globals

Samat asetukset toimii myös lokaalisti yksittäisellä pluginilla. Käytännössä saman asian voisi antaa global_plugin_attrsina, joten mietityttää vähän onko erillisessä dokuasetuksessa järkeä. 