### PR TITLE
Add group argument to allAnswersPlain and allDocumentAnswersPlain (closes #2637)

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -256,7 +256,11 @@ def get_all_answers(
         raise ValueError("Answer period must be specified.")
 
     q = get_all_answer_initial_query(
-        options.period_from, options.period_to, task_ids, options.valid
+        options.period_from,
+        options.period_to,
+        task_ids,
+        options.valid,
+        options.group,
     )
 
     q = q.options(defaultload(Answer.users).lazyload(User.groups))
@@ -401,6 +405,7 @@ def get_all_answer_initial_query(
     period_to: datetime,
     task_ids: list[TaskId],
     valid: ValidityOptions,
+    group: str | None = None,
 ) -> Query:
     q = Answer.query.filter(
         (period_from <= Answer.answered_on) & (Answer.answered_on < period_to)
@@ -413,6 +418,8 @@ def get_all_answer_initial_query(
         case ValidityOptions.VALID:
             q = q.filter_by(valid=True)
     q = q.join(User, Answer.users)
+    if group:
+        q = q.join(UserGroup, User.groups).filter(UserGroup.name == group)
     return q
 
 

--- a/timApp/answer/feedbackanswer.py
+++ b/timApp/answer/feedbackanswer.py
@@ -7,7 +7,7 @@ from flask import Blueprint, request
 from marshmallow import EXCLUDE
 
 from timApp.answer.answer import Answer
-from timApp.answer.answers import get_all_answer_initial_query
+from timApp.answer.answers import get_all_answer_initial_query, ValidityOptions
 from timApp.auth.accesshelper import verify_teacher_access, AccessDenied
 from timApp.auth.sessioninfo import user_context_with_logged_in
 from timApp.document.docentry import DocEntry, get_documents_in_folder
@@ -49,7 +49,13 @@ def get_all_feedback_answers(
     :return: Compiled list of test results.
     """
 
-    q = get_all_answer_initial_query(period_from, period_to, task_ids, valid)
+    # TODO: Parse using marshmallow (see AllAnswersOptions)
+    try:
+        validity = ValidityOptions(valid)
+    except ValueError:
+        validity = ValidityOptions.ALL
+
+    q = get_all_answer_initial_query(period_from, period_to, task_ids, validity)
 
     # Sorts the answers first with user then by time - for a report of whole test result by one user.
     q = q.order_by(User.name, Answer.answered_on)

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6480,6 +6480,30 @@
           <context context-type="linenumber">1354</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6496645013696097846" datatype="html">
+        <source>Answer group</source>
+        <target state="translated">Vastausryhmä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6224594385004959551" datatype="html">
+        <source>All answerers</source>
+        <target state="translated">Kaikki vastaajat</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8301861427771997270" datatype="html">
+        <source>Document group (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</source>
+        <target state="translated">Dokumenttiryhmä (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6370,6 +6370,30 @@
           <context context-type="linenumber">1354</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6496645013696097846" datatype="html">
+        <source>Answer group</source>
+        <target state="translated">Svarsgrupp</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6224594385004959551" datatype="html">
+        <source>All answerers</source>
+        <target state="translated">Alla svarande</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8301861427771997270" datatype="html">
+        <source>Document group (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</source>
+        <target state="translated">Dokumentgrupp (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -219,7 +219,7 @@ export class ViewCtrl implements IController {
     public item: IDocument;
     public docId: number;
 
-    public group: unknown;
+    public group?: string;
     public scope: IScope;
     public noBrowser: boolean;
     public docVersion: [number, number];

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -118,7 +118,7 @@ export interface IDocumentGlobals extends IItemGlobals {
     curr_item: IDocument;
     noBrowser: boolean;
     allowMove: boolean; // TODO this doesn't come from server and should be removed from globals
-    group: IGroup;
+    group?: string;
     docSettings: IDocSettings;
     memoMinutesSettings?: IMeetingMemoSettings;
     editMode: EditMode | null;


### PR DESCRIPTION
Toteuttaa puuttuvat `group`-argumentin toiminnon poluille `allAnswersPlain` ja `allDocumentAnswersPlain`. Lisää samalla raporttidialogiin radiobuttonin, jolla voi rajata vastaukset kaikkiin vastaajiin tai sitten "dokumenttiryhmään" (eli ryhmä, joka määritelty `group`-dokumenttiasetuksessa).

Katso #2637