### PR TITLE
Fix JSON answer reports not respecting output options (closes #2591)

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -390,10 +390,41 @@ def get_all_answers(
 
                 result.append(res)
             case FormatOptions.JSON:
-                user_data = u if not anon_name else name
-                result_json.append(
-                    dict(user=user_data, answer=a, count=int(n), resolved_content=answ)
-                )
+                user_json = u.to_json() if print_header else {}
+                user_json["name"] = name
+                if options.name != NameOptions.BOTH:
+                    user_json.pop("real_name", None)
+                if anon_name:
+                    user_json.pop("id", None)
+                    user_json.pop("student_id", None)
+                    user_json.pop("email", None)
+                answer_json = a.to_json()
+
+                if not print_answers:
+                    answer_json.pop("content", None)
+                    answer_json.pop("origin_doc_id", None)
+                if not print_header:
+                    answer_json.pop("id", None)
+                    answer_json.pop("answered_on", None)
+                    answer_json.pop("valid", None)
+                    answer_json.pop("last_points_modifier", None)
+                    answer_json.pop("points", None)
+                    answer_json.pop("task_id", None)
+                    answer_json.pop("origin_doc_id", None)
+                    answer_json.pop("plugin", None)
+
+                result_json_item: dict[str, Any] = {
+                    "answer": answer_json,
+                }
+                if print_header:
+                    result_json_item |= {
+                        "count": int(n),
+                        "user": user_json,
+                    }
+                if print_answers:
+                    result_json_item |= {"resolved_content": answ}
+
+                result_json.append(result_json_item)
     if options.format == FormatOptions.TEXT:
         return result
     else:


### PR DESCRIPTION
Korjaa #2591. JSON-muotoinen tuloste tottelee samoja asetuksia kuin tekstimuotoinen tuloste.

Lisäksi muokkaa JSON-muotoa siten, että kaikkien kenttien tyyppi on aina sama riippumatta asetuksista. Eli esim. pseudonymisointi ei muuta `user`-objektin tyyppiä `object`:sta `string`:ksi. Tämä helpottaa jatkossa JSONin parsimista ulkoisissa ohjelmissa.