### PR TITLE
Modelanswer lazy

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2367,7 +2367,7 @@ def get_model_answer(task_id: str) -> Response:
                 )
                 db.session.commit()
                 log_task_block(
-                    f"set task {tid.doc_task} access_end at {current_time} via modelAnswer"
+                    f"set task {tid.doc_task} accessible_to at {current_time} via modelAnswer"
                 )
     answer_html = md_to_html(model_answer_info.answer)
     return json_response({"answer": answer_html})
@@ -2626,7 +2626,7 @@ def unlock_task(task_id: str) -> Response:
         )
         db.session.commit()
         log_task_block(
-            f"set task {tid.doc_task} access_end at {expire_time} via accessDuration"
+            f"set task {tid.doc_task} accessible_to at {expire_time} via accessDuration"
         )
 
     else:

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -148,7 +148,7 @@ from timApp.util.utils import (
 from timApp.util.utils import local_timezone
 from timApp.util.utils import try_load_json, seq_to_str, is_valid_email
 from timApp.velp.annotations import get_annotations_with_comments_in_document
-from tim_common.markupmodels import GenericMarkupModel
+from tim_common.markupmodels import GenericMarkupModel, asdict_skip_missing
 from tim_common.marshmallow_dataclass import class_schema
 from tim_common.pluginserver_flask import value_or_default
 from tim_common.utils import Missing
@@ -1917,6 +1917,22 @@ def maybe_hide_name(d: DocInfo, u: User, model_u: User | None) -> None:
         u.hide_name = True
 
 
+def set_model_answer_info(tim_vars: dict, context_user: UserContext, plugin: Plugin):
+    model_answer_info = tim_vars.get("modelAnswer")
+    if not model_answer_info:
+        return
+    if not model_answer_info.get("answer"):
+        tim_vars.pop("modelAnswer", None)
+        return
+    model_answer_info.pop("answer", None)
+    lock = model_answer_info.get("lock", True)
+    if lock:
+        plugin.set_access_end_for_user(user=context_user.logged_user)
+        if plugin.access_end_for_user:
+            if plugin.access_end_for_user < get_current_time():
+                model_answer_info["alreadyLocked"] = True
+
+
 @answers.get("/taskinfo/<task_id>")
 def get_task_info(task_id) -> Response:
     try:
@@ -1934,6 +1950,9 @@ def get_task_info(task_id) -> Response:
             view_ctx=default_view_ctx,
         )
         tim_vars = find_tim_vars(plugin)
+        model_answer = tim_vars.get("modelAnswer")
+        if model_answer:
+            set_model_answer_info(tim_vars, user_ctx, plugin)
     except PluginException as e:
         raise RouteException(str(e))
     return json_response(tim_vars)
@@ -1951,6 +1970,9 @@ def find_tim_vars(plugin: Plugin) -> dict:
         "triesText": plugin.known.tries_text(),
         "pointsText": plugin.known.points_text(),
         "buttonNewTask": plugin.values.get("buttonNewTask", None),
+        "modelAnswer": asdict_skip_missing(plugin.known.modelAnswer)
+        if plugin.known.modelAnswer
+        else None,
     }
     if plugin.is_new_task():
         tim_vars["newtask"] = True

--- a/timApp/plugin/pluginControl.py
+++ b/timApp/plugin/pluginControl.py
@@ -55,7 +55,6 @@ from timApp.util.utils import (
     Range,
     get_error_html_block,
     get_error_html,
-    get_current_time,
 )
 from tim_common.html_sanitize import sanitize_html
 
@@ -415,21 +414,6 @@ class PluginifyResult:
     has_errors: bool
 
 
-def set_model_answer_info(
-    model_answer_info: dict, context_user: UserContext, plugin: Plugin
-):
-    if not model_answer_info.get("answer"):
-        plugin.values.pop("modelAnswer", None)
-        return
-    model_answer_info.pop("answer", None)
-    lock = model_answer_info.get("lock", True)
-    if lock:
-        plugin.set_access_end_for_user(user=context_user.logged_user)
-        if plugin.access_end_for_user:
-            if plugin.access_end_for_user < get_current_time():
-                model_answer_info["alreadyLocked"] = True
-
-
 def pluginify(
     doc: Document,
     pars: list[DocParagraph],
@@ -593,9 +577,7 @@ def pluginify(
         for _, plugin in plugin_block_map.items():
             plugin.values.pop("postprogram", None)
             plugin.values.pop("preprogram", None)
-            model_answer = plugin.values.get("modelAnswer", None)
-            if model_answer:
-                set_model_answer_info(model_answer, user_ctx, plugin)
+            plugin.values.pop("modelAnswer", None)
             if not plugin.task_id:
                 continue
             if plugin.task_id.is_global:

--- a/timApp/static/scripts/tim/answer/IAnswer.ts
+++ b/timApp/static/scripts/tim/answer/IAnswer.ts
@@ -12,3 +12,14 @@ export interface IAnswer {
 export interface IAnswerWithUsers extends IAnswer {
     users: IUser[];
 }
+
+export type IModelAnswerSettings = {
+    lock: boolean;
+    count: number;
+    revealDate?: string;
+    linkText?: string;
+    linkTextCount?: number;
+    lockConfirmation?: string;
+    lockedLinkText?: string;
+    alreadyLocked?: boolean;
+};

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -1733,6 +1733,7 @@ export class AnswerBrowserController
         this.taskInfo = r.result.data;
         if (r.result.data.modelAnswer) {
             this.modelAnswer = r.result.data.modelAnswer;
+            this.onlyValid = false;
         }
         this.showNewTask = this.isAndSetShowNewTask();
         if (this.taskInfo.buttonNewTask) {

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -17,7 +17,6 @@ import {
     IAnswerBrowserSettings,
     IGenericPluginMarkup,
     IGenericPluginTopLevelFields,
-    IModelAnswerSettings,
 } from "../plugin/attributes";
 import {DestroyScope} from "../ui/destroyScope";
 import {IUser, sortByRealName} from "../user/IUser";
@@ -36,7 +35,7 @@ import {
     to,
     to2,
 } from "../util/utils";
-import {IAnswer, IAnswerWithUsers} from "./IAnswer";
+import {IAnswer, IAnswerWithUsers, IModelAnswerSettings} from "./IAnswer";
 
 /*
  * TODO: if forceBrowser and formMode, now does not show the browser after refresh in view-mode.
@@ -471,6 +470,7 @@ export interface ITaskInfo {
     showPoints: boolean;
     newtask?: boolean;
     buttonNewTask: string;
+    modelAnswer?: IModelAnswerSettings;
 }
 
 export interface IAnswerSaveEvent {
@@ -668,10 +668,6 @@ export class AnswerBrowserController
                 ...this.markupSettings,
                 ...markup.answerBrowser,
             };
-        }
-        if (markup?.modelAnswer) {
-            this.modelAnswer = markup.modelAnswer;
-            this.onlyValid = false;
         }
 
         // Ensure the point step is never zero because some browsers don't like step="0" value in number inputs.
@@ -1735,6 +1731,9 @@ export class AnswerBrowserController
             return;
         }
         this.taskInfo = r.result.data;
+        if (r.result.data.modelAnswer) {
+            this.modelAnswer = r.result.data.modelAnswer;
+        }
         this.showNewTask = this.isAndSetShowNewTask();
         if (this.taskInfo.buttonNewTask) {
             this.buttonNewTask = this.taskInfo.buttonNewTask;

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -23,24 +23,6 @@ export const undoType = t.partial({
     confirmationTitle: nullable(t.string),
 });
 
-export const modelAnswerType = t.intersection([
-    t.type({
-        lock: withDefault(t.boolean, true),
-        count: withDefault(t.number, 1),
-    }),
-    t.partial({
-        revealDate: nullable(t.string),
-        linkText: t.string,
-        linkTextCount: nullable(t.number),
-        lockConfirmation: t.string,
-        lockedLinkText: t.string,
-        alreadyLocked: t.boolean,
-    }),
-]);
-
-export interface IModelAnswerSettings
-    extends t.TypeOf<typeof modelAnswerType> {}
-
 // Attributes that are valid for all plugins.
 export const GenericPluginMarkup = t.partial({
     answerLimit: nullable(t.Integer),
@@ -63,7 +45,6 @@ export const GenericPluginMarkup = t.partial({
     connectionErrorMessage: nullable(t.string),
     answerBrowser: nullable(AnswerBrowserSettings),
     warningFilter: nullable(t.string),
-    modelAnswer: nullable(modelAnswerType),
 });
 
 export const Info = nullable(

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -2209,6 +2209,7 @@ a: b
                 "triesText": "Tries left:",
                 "userMax": 0.5,
                 "userMin": 0.1,
+                "modelAnswer": None,
             },
         )
         p = Plugin.from_paragraph(d.document.get_paragraphs()[0], default_view_ctx)

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -85,8 +85,6 @@ class ModelAnswerInfo:
     lockConfirmation: str | None | Missing = missing
     lockedLinkText: str | None | Missing = missing
     revealDate: PluginDateTime | datetime | None | Missing = missing
-    # TODO: added automatically, this shouldn't be in user given markup
-    alreadyLocked: bool | None | Missing = missing
 
 
 @dataclass


### PR DESCRIPTION
Poistaa mallivastaukseen liittyvän käsittelylogiikan pluginifystä, ja hakee mallivastauksen tiedot answerbrowserin taskInfo-reitissä

https://timdevs01-3.it.jyu.fi/view/modelanswer_lazy

Aiemmissa stresstest-mittauksissa 100 ohj1-monisteella ajat olivat ~43 sek ilman lukkoja, ~1min37 sek lukoilla. Nyt ~36

Normaali ohj1:
```
avg 35.0495

[sijualle@timdevs01 tim3]$ for i in {1..4}; do ./tim tool stress-test --calls 100 502; done

real    0m35.181s
user    0m0.443s
sys     0m1.077s
Errors: 0

real    0m33.894s
user    0m0.393s
sys     0m0.841s
Errors: 0

real    0m35.914s
user    0m0.423s
sys     0m1.028s
Errors: 0

real    0m35.209s
user    0m0.428s
sys     0m0.984s
Errors: 0
```

Ohj1, modelAnswer jokaisessa tehtävässä lukoilla:


```
avg 35.73725

[sijualle@timdevs01 tim3]$ for i in {1..4}; do ./tim tool stress-test --calls 100 506; done

real    0m36.889s
user    0m0.385s
sys     0m0.847s
Errors: 0

real    0m35.262s
user    0m0.416s
sys     0m0.826s
Errors: 0

real    0m35.582s
user    0m0.419s
sys     0m0.864s
Errors: 0

real    0m35.216s
user    0m0.399s
sys     0m0.905s
Errors: 0

```

Ohj1, modelAnswer ilman lukkoja:


```

avg 35.62225

[sijualle@timdevs01 tim3]$ for i in {1..4}; do ./tim tool stress-test --calls 100 508; done

real    0m35.102s
user    0m0.365s
sys     0m0.870s
Errors: 0

real    0m36.219s
user    0m0.415s
sys     0m0.919s
Errors: 0

real    0m35.695s
user    0m0.380s
sys     0m0.892s
Errors: 0

real    0m35.473s
user    0m0.375s
sys     0m0.932s
Errors: 0


```