### PR TITLE
Previoustask

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2603,7 +2603,7 @@ def unlock_locked_task(task_id: str) -> Response:
         raise RouteException(str(e))
     prerequisite_info = plug.known.previousTask
     if not prerequisite_info:
-        raise RouteException("Invalid task")
+        raise RouteException("Missing prerequisite task")
     prerequisite_taskid = TaskId.parse(prerequisite_info.taskid, require_doc_id=False)
     if not prerequisite_taskid.doc_id:
         prerequisite_taskid = TaskId.parse(
@@ -2619,16 +2619,16 @@ def unlock_locked_task(task_id: str) -> Response:
             ).first()
             if ba and ba.accessible_to and ba.accessible_to < get_current_time():
                 return json_response({"unlocked": True})
-        raise RouteException(
-            prerequisite_info.hideText or "You haven't unlocked this task yet"
+        return json_response(
+            {"unlocked": False, "error": prerequisite_info.unlockError or None}
         )
     if prerequisite_info.count:
         current_count = current_user.get_answers_for_task(
             prerequisite_taskid.doc_task
         ).count()
         if current_count < prerequisite_info.count:
-            raise RouteException(
-                prerequisite_info.hideText or "You haven't unlocked this task yet"
+            return json_response(
+                {"unlocked": False, "error": prerequisite_info.unlockError or None}
             )
     return json_response({"unlocked": True})
 

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6690,6 +6690,22 @@
           <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="477178334933600676" datatype="html">
+        <source>You haven't unlocked this task yet</source>
+        <target state="translated">Et ole vielä avannut tätä tehtävää</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">431</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5556218630376316917" datatype="html">
+        <source>Open task</source>
+        <target state="translated">Avaa tehtävä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">475</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6580,6 +6580,22 @@
           <context context-type="linenumber">161</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="477178334933600676" datatype="html">
+        <source>You haven't unlocked this task yet</source>
+        <target state="translated">Du har inte låst upp den här uppgiften än</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">431</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5556218630376316917" datatype="html">
+        <source>Open task</source>
+        <target state="translated">Öppen uppgift</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">475</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/static/scripts/tim/answer/IAnswer.ts
+++ b/timApp/static/scripts/tim/answer/IAnswer.ts
@@ -19,6 +19,7 @@ export type IModelAnswerSettings = {
     revealDate?: string;
     linkText?: string;
     linkTextCount?: number;
+    linkTextBeforeCount?: string;
     lockConfirmation?: string;
     lockedLinkText?: string;
     alreadyLocked?: boolean;

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -500,7 +500,7 @@ timApp.component("timPluginLoader", {
      ng-if="$ctrl.answerId && $ctrl.showPlaceholder && !$ctrl.isPreview()"
      style="width: 1px; height: 23px;"></div>
 <answerbrowser ng-class="{'has-answers': ($ctrl.answerId && !$ctrl.hideBrowser)}"
-               ng-if="$ctrl.showBrowser && !$ctrl.isPreview() && !$$ctrl.unlockable"
+               ng-if="$ctrl.showBrowser && !$ctrl.isPreview() && !$ctrl.unlockable && !$ctrl.locked"
                task-id="$ctrl.parsedTaskId"
                answer-id="$ctrl.answerId">
 </answerbrowser>

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -466,9 +466,7 @@ export class PluginLoaderCtrl extends DestroyScope implements IController {
     }
 
     getPrerequisiteLockedText() {
-        return (
-            this.lockedText ?? $localize`You have not unlocked this task yet`
-        );
+        return this.lockedText ?? $localize`You haven't unlocked this task yet`;
     }
 
     getPrerequisiteUnlockText() {

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -248,6 +248,7 @@ export class ViewCtrl implements IController {
     private userChangeListeners: Map<string, IUserChanged> = new Map();
 
     private inputChangeListeners = new Set<IChangeListener>();
+    private lockListeners = new Set<PluginLoaderCtrl>();
 
     private pendingUpdates: PendingCollection = new Map<string, string>();
     private document?: TimDocument;
@@ -788,6 +789,17 @@ export class ViewCtrl implements IController {
 
     public getTableForm(taskId: string) {
         return this.tableForms.get(taskId);
+    }
+
+    public addLockListener(listener: PluginLoaderCtrl) {
+        this.lockListeners.add(listener);
+    }
+
+    public informAboutLock(tid: TaskId) {
+        // todo: integrate to generic listener?
+        this.lockListeners.forEach((listener) => {
+            listener.informAboutLock(tid);
+        });
     }
 
     public informChangeListeners(

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -32,6 +32,7 @@ export const previousTaskType = t.intersection([
         count: t.number,
         hide: t.boolean,
         hideText: t.string,
+        unlockText: t.string,
     }),
 ]);
 

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -23,13 +23,17 @@ export const undoType = t.partial({
     confirmationTitle: nullable(t.string),
 });
 
-export const previousTaskType = t.partial({
-    taskid: t.string,
-    requireLock: t.boolean,
-    count: t.number,
-    hide: t.boolean,
-    hideText: t.string,
-});
+export const previousTaskType = t.intersection([
+    t.type({
+        taskid: t.string,
+    }),
+    t.partial({
+        requireLock: t.boolean,
+        count: t.number,
+        hide: t.boolean,
+        hideText: t.string,
+    }),
+]);
 
 // Attributes that are valid for all plugins.
 export const GenericPluginMarkup = t.partial({

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -23,6 +23,14 @@ export const undoType = t.partial({
     confirmationTitle: nullable(t.string),
 });
 
+export const previousTaskType = t.partial({
+    taskid: t.string,
+    requireLock: t.boolean,
+    count: t.number,
+    hide: t.boolean,
+    hideText: t.string,
+});
+
 // Attributes that are valid for all plugins.
 export const GenericPluginMarkup = t.partial({
     answerLimit: nullable(t.Integer),
@@ -45,6 +53,7 @@ export const GenericPluginMarkup = t.partial({
     connectionErrorMessage: nullable(t.string),
     answerBrowser: nullable(AnswerBrowserSettings),
     warningFilter: nullable(t.string),
+    previousTask: nullable(previousTaskType),
 });
 
 export const Info = nullable(

--- a/timApp/static/scripts/tim/plugin/taskid.ts
+++ b/timApp/static/scripts/tim/plugin/taskid.ts
@@ -43,6 +43,21 @@ export interface DocIdDotName
 
 const docIdDotName = iso<DocIdDotName>();
 
+export function TaskIdWithDefaultDocId(
+    input: string,
+    defaultDocId: number
+): TaskId | undefined {
+    const tid = TaskId.tryParse(input, DocIdOption.Optional);
+    if (tid.ok) {
+        const res = tid.result;
+        if (!res.docId) {
+            res.docId = defaultDocId;
+        }
+        return res;
+    }
+    return undefined;
+}
+
 /**
  * Represents a task id. Every plugin that wants to save answers needs to have one.
  */

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -214,6 +214,7 @@
         <a ng-if="$ctrl.showModelAnswerLink()"
            title="Show model answer"
            ng-click="$ctrl.showModelAnswer()">{{$ctrl.getModelAnswerLinkText()}}</a>
+        <div ng-if="!$ctrl.showModelAnswerLink() && $ctrl.modelAnswer.linkTextBeforeCount">{{$ctrl.modelAnswer.linkTextBeforeCount}}</div>
         <div ng-if="$ctrl.modelAnswerVisible" ng-bind-html="$ctrl.modelAnswerHtml">
 
         </div>

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -80,6 +80,7 @@ class ModelAnswerInfo:
     count: int | None | Missing = 1
     linkText: str | None | Missing = missing
     linkTextCount: int | None | Missing = missing
+    linkTextBeforeCount: str | None | Missing = missing
     lock: bool = True
     lockedAnswerMessage: str | None | Missing = missing
     lockConfirmation: str | None | Missing = missing

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -92,7 +92,8 @@ class PreviousTaskInfo:
     taskid: str
     requireLock: bool | None | Missing = False
     count: int | None | Missing = missing
-    # errormessage, hide, hidetext
+    hide: bool | None | Missing = missing
+    hideText: str | None | Missing = missing
 
 
 @dataclass

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -94,6 +94,8 @@ class PreviousTaskInfo:
     count: int | None | Missing = missing
     hide: bool | None | Missing = missing
     hideText: str | None | Missing = missing
+    unlockText: str | None | Missing = missing
+    unlockError: str | None | Missing = missing
 
 
 @dataclass

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -88,6 +88,14 @@ class ModelAnswerInfo:
 
 
 @dataclass
+class PreviousTaskInfo:
+    taskid: str
+    requireLock: bool | None | Missing = False
+    count: int | None | Missing = missing
+    # errormessage, hide, hidetext
+
+
+@dataclass
 class KnownMarkupFields(HiddenFieldsMixin):
     """Represents the plugin markup fields that are known and used by TIM."""
 
@@ -119,6 +127,7 @@ class KnownMarkupFields(HiddenFieldsMixin):
     pointsText: str | None | Missing = missing
     postprogram: str | Missing = missing
     postoutput: str | Missing = missing
+    previousTask: PreviousTaskInfo | None | Missing = missing
     showPoints: bool | None | Missing = missing
     starttime: PluginDateTime | datetime | None | Missing = missing
     showInView: bool | Missing = missing


### PR DESCRIPTION
Lisää uuden yleisen pluginattribuutin tehtävien ketjutusta varten
https://timdevs01-3.it.jyu.fi/view/previoustask

```
class PreviousTaskInfo:
    taskid: str # pakollinen
    requireLock: bool | None | Missing = False # Jos true niin edellinen tehtävä pitää olla lukittu modelAnswerin kautta (löytyy taskBlock ja umpeen mennyt blockAccess)
    count: int | None | Missing = missing # Kuinka monta vastausyritystä edellisessä tehtävässä pitää olla.
    hide: bool | None | Missing = missing # piilotetaanko tehtävä jos ehdot ei täyty
    hideText: str | None | Missing = missing # Teksti piilotetun tehtävän paikalla 
    unlockText: str | None | Missing = missing # Painiketeksti piilotetun tehtävän kohdalla
    unlockError: str | None | Missing = missing # Virheviesti jos yrittää avata piilotettua tehtävää, jota ei saa vielä auki
```

Tähän jäi vielä aika paljon toistoa ja refaktoroinnin tarvetta, mutta ajattelin että olisi hyvä saada ensimmäinen versio tuotantoon jotta avoimen kurssin valmistelu voi jatkua.

Mietin vähän tuota countin mielekkyyttä. Jos käyttötapauksissa halutaan nimenomaan lukitsemista edellisen mallivastauksen mukaan, niin tuo on parempi jättää pois ja hoitaa se edellisen tehtävän modelAnswerin countilla. Tuleekohan tarvetta tilanteelle jossa seuraava tehtävä tarjotaan x yrityksen jälkeen, mutta edellisessä tehtävässä ei ole modelAnsweria tai lukitusta tms

Jatkoon:
 - testit
 - taskBlock-haut yhdellä haulla (nyt joka taskissa erikseen)
 - Vahva tehtävän piilotus palvelimella, toistaiseksi vain css selainpuolella