### PR TITLE
Calendar: Add 120 minute segments, add view options to markup, add plugin templates

### DIFF
--- a/timApp/plugin/calendar/calendar.py
+++ b/timApp/plugin/calendar/calendar.py
@@ -77,11 +77,19 @@ class EventTemplate:
 
 
 @dataclass
+class ViewOptions:
+    dayStartHour: int = 8
+    dayEndHour: int = 20
+    segmentDuration: int = 60
+
+
+@dataclass
 class CalendarMarkup(GenericMarkupModel):
     """Highest level attributes in the calendar markup"""
 
     filter: FilterOptions = field(default_factory=FilterOptions)
     eventTemplates: dict[str, EventTemplate] = field(default_factory=dict)
+    viewOptions: ViewOptions = field(default_factory=ViewOptions)
 
 
 @dataclass

--- a/timApp/plugin/calendar/calendar.py
+++ b/timApp/plugin/calendar/calendar.py
@@ -44,6 +44,7 @@ from tim_common.pluginserver_flask import (
     GenericHtmlModel,
     PluginReqs,
     register_html_routes,
+    EditorTab,
 )
 
 calendar_plugin = TypedBlueprint("calendar_plugin", __name__, url_prefix="/calendar")
@@ -116,7 +117,55 @@ class CalendarHtmlModel(
 
 
 def reqs_handle() -> PluginReqs:
-    return {"js": ["calendar"], "multihtml": True}
+    template_full = """
+``` {plugin="calendar"}
+viewOptions:               # Default view options for the calendar
+    dayStartHour: 8        # Time at which the day starts (0-24)
+    dayEndHour: 20         # Time at which the day ends (0-24)
+    segmentDuration: 60    # Duration of a single time segment (a selectable slot in calendar) in minutes. Allowed values: 15, 20, 30, 60, 120
+eventTemplates:            # Event templates for the calendar. Used to create new events.
+    Event:                 # Name of the template. Can contain spaces.
+        title: Event name  # Name of the event.
+        bookers:           # List of groups that can see the event in their calendars and book it.
+          - bookersgroup
+        setters:           # List of groups that can edit the event details.
+          - settersgroup
+        capacity: 1        # Maximum number of people that can book the event.
+```
+"""
+
+    template_mini = """
+``` {plugin="calendar"}
+```
+"""
+
+    editor_tabs: list[EditorTab] = [
+        {
+            "text": "plugins",
+            "items": [
+                {
+                    "text": "Calendar",
+                    "items": [
+                        {
+                            "data": template_mini.strip(),
+                            "text": "Calendar (minimal)",
+                            "expl": "A minimal calendar that shows all events you can book",
+                        },
+                        {
+                            "data": template_full.strip(),
+                            "text": "Calendar (full example)",
+                            "expl": "A full example of the calendar plugin",
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    return {
+        "js": ["calendar"],
+        "multihtml": True,
+        "editor_tabs": editor_tabs,
+    }
 
 
 @calendar_plugin.get("/export")

--- a/timApp/static/scripts/tim/plugin/calendar/timeviewselector.component.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/timeviewselector.component.ts
@@ -10,7 +10,7 @@
  * @license MIT
  * @date 24.5.2022
  */
-import {Component, EventEmitter, OnInit, Output} from "@angular/core";
+import {Component, EventEmitter, Input, Output} from "@angular/core";
 
 export const TIME_VIEW_SLOT_SIZES: number[] = [15, 20, 30, 60, 120];
 export const TIME_VIEW_MORNING_HOURS: number[] = new Array(12)
@@ -23,36 +23,29 @@ export const TIME_VIEW_EVENING_HOURS: number[] = TIME_VIEW_MORNING_HOURS.map(
 @Component({
     selector: "tim-time-view-selector",
     template: `
-    <ng-container>
-        <span i18n >Set view with timeslots of </span>
-        <select [(ngModel)]="selectedAccuracy" (change)="submit(selectedAccuracy, selectedStart, selectedEnd)">
-            <option *ngFor="let item of accuracies" [value]="item">{{ item | number:'2.0' }}</option>
-        </select>
-        <span i18n > minutes from </span>
-        <select [(ngModel)]="selectedStart" (change)="submit(selectedAccuracy, selectedStart, selectedEnd)">
-            <option *ngFor="let hour of morningHours" [value]="hour">{{ hour | number:'2.0' }}</option>
-        </select>
-        <span i18n > to </span>
-        <select [(ngModel)]="selectedEnd" (change)="submit(selectedAccuracy, selectedStart, selectedEnd)">
-            <option *ngFor="let hour of eveningHours" [value]="hour">{{ hour | number:'2.0' }}</option>
-        </select>
-    </ng-container>`,
+        <ng-container>
+            <span i18n>Set view with timeslots of </span>
+            <select [(ngModel)]="segmentDuration" (ngModelChange)="segmentDurationChange.emit($event)">
+                <option *ngFor="let item of accuracies" [value]="item">{{ item | number:'2.0' }}</option>
+            </select>
+            <span i18n> minutes from </span>
+            <select [(ngModel)]="startHour" (ngModelChange)="startHourChange.emit($event)">
+                <option *ngFor="let hour of morningHours" [value]="hour">{{ hour | number:'2.0' }}</option>
+            </select>
+            <span i18n> to </span>
+            <select [(ngModel)]="endHour" (ngModelChange)="endHourChange.emit($event)">
+                <option *ngFor="let hour of eveningHours" [value]="hour">{{ hour | number:'2.0' }}</option>
+            </select>
+        </ng-container>`,
     styleUrls: ["calendar.component.scss"],
 })
-export class TimeViewSelectorComponent implements OnInit {
-    selectedAccuracy: number = 20;
-    selectedStart: number = 8;
-    selectedEnd: number = 20;
-
-    accuracies = accuracies;
-    eveningHours = eveningHours;
-    morningHours = morningHours;
-
-    @Output() accuracy = new EventEmitter<number>();
-
-    @Output() evening = new EventEmitter<number>();
-
-    @Output() morning = new EventEmitter<number>();
+export class TimeViewSelectorComponent {
+    @Input() segmentDuration: number = 20;
+    @Input() startHour: number = 8;
+    @Input() endHour: number = 20;
+    @Output() segmentDurationChange = new EventEmitter<number>();
+    @Output() startHourChange = new EventEmitter<number>();
+    @Output() endHourChange = new EventEmitter<number>();
 
     accuracies = TIME_VIEW_SLOT_SIZES;
     eveningHours = TIME_VIEW_EVENING_HOURS;

--- a/timApp/static/scripts/tim/plugin/calendar/timeviewselector.component.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/timeviewselector.component.ts
@@ -12,9 +12,13 @@
  */
 import {Component, EventEmitter, OnInit, Output} from "@angular/core";
 
-const accuracies: number[] = [15, 20, 30, 60];
-const morningHours: number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-const eveningHours: number[] = [13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24];
+export const TIME_VIEW_SLOT_SIZES: number[] = [15, 20, 30, 60, 120];
+export const TIME_VIEW_MORNING_HOURS: number[] = new Array(12)
+    .fill(0)
+    .map((_, i) => i);
+export const TIME_VIEW_EVENING_HOURS: number[] = TIME_VIEW_MORNING_HOURS.map(
+    (i) => i + 12
+);
 
 @Component({
     selector: "tim-time-view-selector",
@@ -50,26 +54,7 @@ export class TimeViewSelectorComponent implements OnInit {
 
     @Output() morning = new EventEmitter<number>();
 
-    constructor() {}
-
-    /**
-     * Called when component is loaded
-     */
-    ngOnInit() {}
-
-    /**
-     * Submits the values user has selected to the calendar component
-     * @param selectedAccuracy selected accuracy value
-     * @param selectedStart selected start value
-     * @param selectedEnd selected end value
-     */
-    submit(
-        selectedAccuracy: number,
-        selectedStart: number,
-        selectedEnd: number
-    ) {
-        this.accuracy.emit(selectedAccuracy);
-        this.evening.emit(selectedEnd);
-        this.morning.emit(selectedStart);
-    }
+    accuracies = TIME_VIEW_SLOT_SIZES;
+    eveningHours = TIME_VIEW_EVENING_HOURS;
+    morningHours = TIME_VIEW_MORNING_HOURS;
 }

--- a/timApp/static/scripts/tim/util/utils.ts
+++ b/timApp/static/scripts/tim/util/utils.ts
@@ -1014,3 +1014,9 @@ export function shortestUniquePrefixes(strs: string[]): string[] {
     }
     return result;
 }
+
+export function closest(arr: number[], val: number): number {
+    return arr.reduce((prev, curr) =>
+        Math.abs(curr - val) < Math.abs(prev - val) ? curr : prev
+    );
+}


### PR DESCRIPTION
Ensimmäinen satsi nopeita refaktorointeja ja lisäyksiä kalenteriin:

* Lisää 120 min aikasegmentin
* Lisää `viewOptions`-asetuksen markuppiin, jolla voi valita oletusasetukset kalenterin alalaidassa oleviin näkyvyysasetuksiin:

     ```yaml
     viewOptions:               # Default view options for the calendar
        dayStartHour: 8        # Time at which the day starts (0-24)
        dayEndHour: 20         # Time at which the day ends (0-24)
        segmentDuration: 60    # Duration of a single time segment (a selectable slot in calendar) in minutes. Allowed values: 15, 20, 30, 60, 120
     ```
* Muutettu hieman oletusarvoja: nyt oletuskoko aikasegmentille on 60 min, niin kalenteri ei paisu liian korkeaksi heti alkuun
* Lisää pari templatea lohkoeditoriin (`Plugin -> Calendar`), niin ei tarvitse etsiä pohja ohjeista
* Muutenkin muutama sisäinen refaktorointi nimityksiin ja logiikkaan

Testi: https://timdevs01-2.it.jyu.fi/view/users/test-user-1/test-calendar