### PR TITLE
Previoustask area

### DIFF
--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -446,19 +446,17 @@ export class PluginLoaderCtrl extends DestroyScope implements IController {
     }
 
     /**
-     * Hide areas where previoustask-attribute matches plugin's previousTask.taskid and plugin is hidden
-     * until target plugin gets locked after revealing the model answer
+     * Hide areas where hide-with attribute matches current taskid
      * TODO:
      *  This should be handled by the actual plugin containing the modelAnswer and the locks (and later
      *  be handled server-side), but the current implementation of modelAnswer lock query is expensive and unoptimized
      */
     toggleLockedAreas() {
-        const m = this.pluginMarkup();
-        if (!m?.previousTask) {
+        if (!this.parsedTaskId) {
             return;
         }
         const dataAreas = document.querySelectorAll(
-            `[attrs*='"area"'][attrs*='"previoustask": "${m.previousTask.taskid}"']`
+            `[attrs*='"area"'][attrs*='"hide-with": "${this.parsedTaskId.name}"']`
         );
         for (const da of dataAreas) {
             const attrs = da.getAttribute("attrs");

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -171,6 +171,9 @@ export class PluginLoaderCtrl extends DestroyScope implements IController {
                 this.loadPlugin();
             }
         }
+        if (this.lockedByPrerequisite) {
+            this.hidePlugin();
+        }
         $timeout(() => {
             const m = this.pluginMarkup();
             if (
@@ -208,7 +211,6 @@ export class PluginLoaderCtrl extends DestroyScope implements IController {
                     return;
                 }
                 if (this.lockedByPrerequisite) {
-                    this.hidePlugin();
                     this.viewctrl?.addLockListener(this);
                     this.lockedText = m.previousTask.hideText;
                     this.lockedButtonText = m.previousTask.unlockText;

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -549,7 +549,7 @@ timApp.component("timPluginLoader", {
      ng-if="$ctrl.answerId && $ctrl.showPlaceholder && !$ctrl.isPreview()"
      style="width: 1px; height: 23px;"></div>
 <answerbrowser ng-class="{'has-answers': ($ctrl.answerId && !$ctrl.hideBrowser)}"
-               ng-if="$ctrl.showBrowser && !$ctrl.isPreview() && !$ctrl.unlockable && !$ctrl.locked"
+               ng-if="$ctrl.showBrowser && !$ctrl.isPreview() && !$ctrl.unlockable && !$ctrl.lockedByPrerequisite"
                task-id="$ctrl.parsedTaskId"
                answer-id="$ctrl.answerId">
 </answerbrowser>


### PR DESCRIPTION
Piilottaa tai näyttää alueita (vain css) niihin liittyvien piiloutuvien pluginien mukaan

Piiloutuvat pluginit katsovat käynnistyessään alueet, joilla on hide-with attribuutti jossa on sama taskid kuin pluginilla, ja piilottavat / näyttävät ne sen mukaan onko plugin itse piilotettu


https://timdevs01-3.it.jyu.fi/view/previoustask-hide

Sama dokumentti, mutta myös itse plugin on piiloutuvan alueen sisällä:

https://timdevs01-3.it.jyu.fi/view/hide-within-task