### PR TITLE
Add method to clear task blocks

### DIFF
--- a/timApp/plugin/plugin.py
+++ b/timApp/plugin/plugin.py
@@ -622,7 +622,7 @@ class Plugin:
                         type=AccessType.view.value,
                         usergroup_id=current_user.get_personal_group().id,
                     ).first()
-                    if ba:
+                    if ba and ba.accessible_to:
                         if ba.accessible_to < get_current_time():
                             self.hidden = False
             if prev_info.count:

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -11,6 +11,7 @@ import {ParContext} from "tim/document/structure/parContext";
 import {ReadonlyMoment} from "tim/util/readonlymoment";
 import moment from "moment";
 import {showConfirm} from "tim/ui/showConfirmDialog";
+import {showResetTaskLock} from "tim/answer/showResetTaskLock";
 import {isVelpable, ITimComponent, ViewCtrl} from "../document/viewctrl";
 import {compileWithViewctrl, ParCompiler} from "../editor/parCompiler";
 import {
@@ -1508,6 +1509,21 @@ export class AnswerBrowserController
             }
         }
         return true;
+    }
+
+    showClearModelAnswerLockLink() {
+        return this.viewctrl?.item.rights.teacher && this.modelAnswer?.lock;
+    }
+
+    async clearModelAnswerLock() {
+        if (!this.user) {
+            return;
+        }
+        // TODO: Fetch users who have taskBlocks to show as dropdown list in resetTaskLockDialog
+        await showResetTaskLock({
+            currentUser: this.user.name,
+            taskId: this.taskId.docTask().toString(),
+        });
     }
 
     async showModelAnswer() {

--- a/timApp/static/scripts/tim/answer/reset-task-lock-dialog-component.ts
+++ b/timApp/static/scripts/tim/answer/reset-task-lock-dialog-component.ts
@@ -1,0 +1,92 @@
+import {AngularDialogComponent} from "tim/ui/angulardialog/angular-dialog-component.directive";
+import {Component, NgModule} from "@angular/core";
+import {DialogModule} from "tim/ui/angulardialog/dialog.module";
+import {TimUtilityModule} from "tim/ui/tim-utility.module";
+import {FormsModule} from "@angular/forms";
+import {BrowserModule} from "@angular/platform-browser";
+import {to} from "tim/util/utils";
+import {$http} from "../util/ngimport";
+
+export interface IRestTaskLockDialogParams {
+    currentUser: string;
+    taskId: string;
+}
+
+@Component({
+    selector: "tim-reset-task-lock-dialog",
+    template: `
+        <tim-dialog-frame>
+            <ng-container header>
+                {{ getTitle() }}
+            </ng-container>
+            <ng-container body>
+                <form class="form-horizontal">
+                    <div class="form-group">
+                        <label for="targetUser" class="col-sm-3 control-label">Username:</label>
+                        <div class="col-sm-9">
+                            <input id="targetUser"
+                                   class="form-control"
+                                   type="text"
+                                   [(ngModel)]="targetUser"
+                                   name="targetUser"
+                                   focusMe/>
+                            <button class="timButton" type="button" (click)="doClearRequest()">Clear</button>
+                        </div>
+                    </div>
+                </form>
+                <div *ngIf="responseMessage">{{responseMessage}}</div>
+            </ng-container>
+            <ng-container footer>
+                <button class="btn btn-default" type="button" (click)="done()">Close</button>
+            </ng-container>
+        </tim-dialog-frame>`,
+})
+export class ResetTaskLockDialogComponent extends AngularDialogComponent<
+    {currentUser: string; taskId: string},
+    void
+> {
+    protected dialogName = "ResetTaskLock";
+
+    targetUser = "";
+    responseMessage = "";
+
+    getTitle() {
+        return `Clear task locking for task ${this.data.taskId}`;
+    }
+
+    ngOnInit() {
+        this.targetUser = this.data.currentUser;
+    }
+
+    async doClearRequest() {
+        // TODO: Clear for everyone
+        this.responseMessage = "";
+        const r = await to(
+            $http.post<{cleared: boolean; error?: string}>(`/clearTaskBlock`, {
+                user: this.targetUser,
+                task_id: this.data.taskId,
+            })
+        );
+        if (r.ok) {
+            if (r.result.data.cleared) {
+                this.responseMessage = `Cleared lock for user ${this.targetUser}`;
+            } else {
+                this.responseMessage =
+                    r.result.data.error ??
+                    `No lock found for user ${this.targetUser}`;
+            }
+        } else {
+            this.responseMessage = r.result.data.error;
+        }
+    }
+
+    done() {
+        this.dismiss();
+    }
+}
+
+@NgModule({
+    declarations: [ResetTaskLockDialogComponent],
+    imports: [BrowserModule, DialogModule, TimUtilityModule, FormsModule],
+})
+export class ResetTaskLockDialogModule {}

--- a/timApp/static/scripts/tim/answer/showResetTaskLock.ts
+++ b/timApp/static/scripts/tim/answer/showResetTaskLock.ts
@@ -1,0 +1,9 @@
+import {angularDialog} from "tim/ui/angulardialog/dialog.service";
+import {IRestTaskLockDialogParams} from "./reset-task-lock-dialog-component";
+
+export async function showResetTaskLock(p: IRestTaskLockDialogParams) {
+    const {ResetTaskLockDialogComponent} = await import(
+        "./reset-task-lock-dialog-component"
+    );
+    return (await angularDialog.open(ResetTaskLockDialogComponent, p)).result;
+}

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -215,6 +215,8 @@
            title="Show model answer"
            ng-click="$ctrl.showModelAnswer()">{{$ctrl.getModelAnswerLinkText()}}</a>
         <div ng-if="!$ctrl.showModelAnswerLink() && $ctrl.modelAnswer.linkTextBeforeCount">{{$ctrl.modelAnswer.linkTextBeforeCount}}</div>
+        <span ng-if="$ctrl.showClearModelAnswerLockLink()"> | <a ng-click="$ctrl.clearModelAnswerLock()" title="Manage model answer locks">Manage task locks</a>
+        </span>
         <div ng-if="$ctrl.modelAnswerVisible" ng-bind-html="$ctrl.modelAnswerHtml">
 
         </div>


### PR DESCRIPTION
Alustava ui taskBlockien poistamiseen (=asetetaan blockAccessissa accessible_to nulliksi). Mallivastauslinkin viereen tulee poistolinkki, josta voi (toistaiseksi manuaalisesti nimellä) valita kenen blockAccess tyhjenee

Testuser1:llä omistuisoikeus, muilla view: https://timdevs01-3.it.jyu.fi/view/previoustask-hide