### PR TITLE
Calendar: Add mass editing

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6144,14 +6144,6 @@
           <context context-type="linenumber">18</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6328943491200318160" datatype="html">
-        <source>Export calendar</source>
-        <target state="translated">Vie kalenteri</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar.component.ts</context>
-          <context context-type="linenumber">278</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="1521925891097959460" datatype="html">
         <source>Export calendar information in ics-format?</source>
         <target state="translated">Viedäänkö kalenteritiedot ICS-muodossa?</target>
@@ -6732,6 +6724,94 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar-event-dialog.component.ts</context>
           <context context-type="linenumber">253</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7155374606190083950" datatype="html">
+        <source>Export calendar (ICS)</source>
+        <target state="translated">Vie kalenter (ICS)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar.component.ts</context>
+          <context context-type="linenumber">321</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7702706614417117704" datatype="html">
+        <source>Mass edit (JSON)</source>
+        <target state="translated">Massamuokkaus (JSON)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar.component.ts</context>
+          <context context-type="linenumber">322</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5417693128998500220" datatype="html">
+        <source> Edit event JSON </source>
+        <target state="translated"> Muokkaa tapahtumien JSON </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">20,22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4639688582102685996" datatype="html">
+        <source>Below are all events visible in this calendar in JSON format. You can add or edit events en masse.</source>
+        <target state="translated">Alla listataan kaikki tässä kalenterissa näkyvät tapahtumat JSON-muodossa. Voit massalisätä tai -muokata tapahtumat.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6774950862300413361" datatype="html">
+        <source>Adding <x id="START_TAG_CODE" ctype="x-code" equiv-text="&lt;code>"/>"delete": true<x id="CLOSE_TAG_CODE" ctype="x-code" equiv-text="&lt;/code>"/> to an event will delete it.</source>
+        <target state="translated">Voit poistaa tapahtuman lisäämällä siihen <x id="START_TAG_CODE" ctype="x-code" equiv-text="&lt;code>"/>"delete": true<x id="CLOSE_TAG_CODE" ctype="x-code" equiv-text="&lt;/code>"/>.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3768927257183755959" datatype="html">
+        <source>Save</source>
+        <target state="translated">Tallenna</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1114053555099864231" datatype="html">
+        <source>Close without saving</source>
+        <target state="translated">Sulje tallentamatta</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="77403962170767516" datatype="html">
+        <source>Could not load events. More info: <x id="PH" equiv-text="res.result.error.error"/></source>
+        <target state="translated">Tapahtumia ei voitu ladata. Lisätietoja: <x id="PH" equiv-text="res.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="537772008731260124" datatype="html">
+        <source>Could not parse JSON. Error info: <x id="PH" equiv-text="e"/></source>
+        <target state="translated">JSONia ei voitu käsitellä: <x id="PH" equiv-text="e"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6652424493490915459" datatype="html">
+        <source>Error: <x id="PH" equiv-text="res.result.web.error"/></source>
+        <target state="translated">Virhe: <x id="PH" equiv-text="res.result.web.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2778484883809271924" datatype="html">
+        <source>Could not save events. More info: <x id="PH" equiv-text="res.result.error.error"/></source>
+        <target state="translated">Tapahtumia ei voitu tallentaa. Lisätietoja: <x id="PH" equiv-text="res.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">110</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6034,14 +6034,6 @@
           <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6328943491200318160" datatype="html">
-        <source>Export calendar</source>
-        <target state="translated">Exportera kalender</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar.component.ts</context>
-          <context context-type="linenumber">278</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="1521925891097959460" datatype="html">
         <source>Export calendar information in ics-format?</source>
         <target state="translated">Exportera kalenderinformation i ics-format?</target>
@@ -6622,6 +6614,94 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar-event-dialog.component.ts</context>
           <context context-type="linenumber">253</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7155374606190083950" datatype="html">
+        <source>Export calendar (ICS)</source>
+        <target state="translated">Exportera kalender (ICS)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar.component.ts</context>
+          <context context-type="linenumber">321</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7702706614417117704" datatype="html">
+        <source>Mass edit (JSON)</source>
+        <target state="translated">Massredigering (JSON)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/calendar.component.ts</context>
+          <context context-type="linenumber">322</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5417693128998500220" datatype="html">
+        <source> Edit event JSON </source>
+        <target state="translated"> Redigera händelsens JSON </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">20,22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4639688582102685996" datatype="html">
+        <source>Below are all events visible in this calendar in JSON format. You can add or edit events en masse.</source>
+        <target state="translated">Nedan visas alla händelser som är synliga i den här kalendern i JSON-format. Du kan lägga till eller redigera händelser i en massa.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6774950862300413361" datatype="html">
+        <source>Adding <x id="START_TAG_CODE" ctype="x-code" equiv-text="&lt;code>"/>"delete": true<x id="CLOSE_TAG_CODE" ctype="x-code" equiv-text="&lt;/code>"/> to an event will delete it.</source>
+        <target state="translated">Om du lägger till <x id="START_TAG_CODE" ctype="x-code" equiv-text="&lt;code>"/>"delete": true<x id="CLOSE_TAG_CODE" ctype="x-code" equiv-text="&lt;/code>"/> till en händelse raderas den.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3768927257183755959" datatype="html">
+        <source>Save</source>
+        <target state="translated">Spara</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1114053555099864231" datatype="html">
+        <source>Close without saving</source>
+        <target state="translated">Stäng utan att spara</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="77403962170767516" datatype="html">
+        <source>Could not load events. More info: <x id="PH" equiv-text="res.result.error.error"/></source>
+        <target state="translated">Kunde inte läsa in händelser. Mer information: <x id="PH" equiv-text="res.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="537772008731260124" datatype="html">
+        <source>Could not parse JSON. Error info: <x id="PH" equiv-text="e"/></source>
+        <target state="translated">Kunde inte analysera JSON. Felinformation: <x id="PH" equiv-text="e"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">91</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6652424493490915459" datatype="html">
+        <source>Error: <x id="PH" equiv-text="res.result.web.error"/></source>
+        <target state="translated">Fel: <x id="PH" equiv-text="res.result.web.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">105</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2778484883809271924" datatype="html">
+        <source>Could not save events. More info: <x id="PH" equiv-text="res.result.error.error"/></source>
+        <target state="translated">Kunde inte spara händelser. Mer information: <x id="PH" equiv-text="res.result.error.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts</context>
+          <context context-type="linenumber">110</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/modules/cs/js/editor/module.ts
+++ b/timApp/modules/cs/js/editor/module.ts
@@ -19,6 +19,6 @@ import {ParsonsEditorComponent} from "./parsons";
         JSParsonsEditorComponent,
     ],
     imports: [BrowserModule, FormsModule, TimUtilityModule, CsUtilityModule],
-    exports: [CountBoardComponent, EditorComponent],
+    exports: [CountBoardComponent, EditorComponent, AceEditorComponent],
 })
 export class EditorModule {}

--- a/timApp/plugin/calendar/models.py
+++ b/timApp/plugin/calendar/models.py
@@ -145,6 +145,11 @@ class EnrollmentRight:
     can_enroll: bool
     extra: bool
     manager: bool
+    creator: bool
+
+    @property
+    def can_manage_event(self) -> bool:
+        return self.manager or self.creator
 
 
 class Event(db.Model):
@@ -255,7 +260,7 @@ class Event(db.Model):
             (EventGroup.event_id == self.event_id) & EventGroup.usergroup_id.in_(ug_ids)
         ).all()
         if not event_groups:
-            return EnrollmentRight(False, False, False)
+            return EnrollmentRight(False, False, False, self.creator_user_id == user.id)
         extra = False
         manager = False
         for event_group in event_groups:
@@ -263,7 +268,7 @@ class Event(db.Model):
                 extra = True
             if event_group.manager:
                 manager = True
-        return EnrollmentRight(True, extra, manager)
+        return EnrollmentRight(True, extra, manager, self.creator_user_id == user.id)
 
     @staticmethod
     def get_by_id(event_id: int) -> Optional["Event"]:

--- a/timApp/plugin/calendar/models.py
+++ b/timApp/plugin/calendar/models.py
@@ -121,6 +121,7 @@ class EventTag(db.Model):
         :return: List of already existing or new event tags that match
         """
         result = []
+        # noinspection PyUnresolvedReferences
         existing_tags = EventTag.query.filter(EventTag.tag.in_(tags)).all()
         existing_tags_dict = {tag.tag: tag for tag in existing_tags}
         for tag in tags:
@@ -218,6 +219,7 @@ class Event(db.Model):
     @property
     def enrollments_count(self) -> EnrollmentCounts:
         """Returns the number of enrollments in the event"""
+        # noinspection PyUnresolvedReferences
         has_extras = (
             EventGroup.query.filter(
                 (EventGroup.event_id == self.event_id) & EventGroup.extra.is_(True)
@@ -248,6 +250,7 @@ class Event(db.Model):
         :return: Information about the user's rights for enrolling in the event
         """
         ug_ids = [ug.id for ug in user.groups]
+        # noinspection PyUnresolvedReferences
         event_groups = EventGroup.query.filter(
             (EventGroup.event_id == self.event_id) & EventGroup.usergroup_id.in_(ug_ids)
         ).all()
@@ -281,6 +284,7 @@ class Event(db.Model):
         user_group_ids = []
         if for_user:
             user_group_ids = [ug.id for ug in for_user.groups]
+            # noinspection PyUnresolvedReferences
             e = (
                 db.session.query(EventGroup.extra)
                 .filter(

--- a/timApp/static/scripts/tim/plugin/calendar/calendar.component.scss
+++ b/timApp/static/scripts/tim/plugin/calendar/calendar.component.scss
@@ -9,8 +9,15 @@ The style sheet for the calendar plugin
  * @date 24.5.2022
  */
 
+.button-panel {
+  display: flex;
+  column-gap: 0.5em;
+  align-items: center;
+  margin-top: 0.5em;
+}
+
 .cal-week-view .cal-day-headers .cal-header {
-  padding: 5px 0px;
+  padding: 5px 0;
 }
 
 .cal-event {

--- a/timApp/static/scripts/tim/plugin/calendar/custom-event-title-formatter.service.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/custom-event-title-formatter.service.ts
@@ -35,7 +35,6 @@ export class CustomEventTitleFormatter extends CalendarEventTitleFormatter {
             res += ` +${event.meta.extraEnrollments}`;
         }
         res += `) ${event.title}`;
-        console.log(event.meta, res);
         return res;
     }
 

--- a/timApp/static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/edit-json-event-dialog.component.ts
@@ -1,0 +1,128 @@
+import {AngularDialogComponent} from "tim/ui/angulardialog/angular-dialog-component.directive";
+import {Component, NgModule, ViewChild} from "@angular/core";
+import {DialogModule} from "tim/ui/angulardialog/dialog.module";
+import {BrowserModule} from "@angular/platform-browser";
+import {TimUtilityModule} from "tim/ui/tim-utility.module";
+import {HttpClient, HttpClientModule} from "@angular/common/http";
+import {EditorModule} from "../../../../../modules/cs/js/editor/module";
+import {AceEditorComponent} from "../../../../../modules/cs/js/editor/ace";
+import {toPromise} from "../../util/utils";
+import {PurifyModule} from "../../util/purify.module";
+
+export interface IEditJsonEventOptions {
+    filterParams: Record<string, string>;
+}
+
+@Component({
+    selector: "tim-edit-json-event-dialog",
+    template: `
+        <tim-dialog-frame>
+            <ng-container header i18n>
+                Edit event JSON
+            </ng-container>
+            <ng-container body>
+                <p i18n>Below are all events visible in this calendar in JSON format. You can add or edit events en masse.</p>
+                <p i18n>Adding <code>"delete": true</code> to an event will delete it.</p>
+                <tim-loading *ngIf="loading"></tim-loading>
+                <tim-alert *ngIf="wasSaved" severity="success" i18n>Saved!</tim-alert>
+                <tim-alert *ngIf="error">{{error}}</tim-alert>
+                <tim-alert *ngIf="htmlError"><div [innerHTML]="htmlError | purify"></div></tim-alert>
+                <cs-ace-editor [disabled]="loading" [minRows]="20" [maxRows]="30" languageMode="json" #editor></cs-ace-editor>
+            </ng-container>
+            <div footer class="dialog-button-panel">
+                <button class="timButton" (click)="saveEvents()" i18n>Save</button>
+                <button class="btn btn-default" [class.btn-danger]="!wasSaved" (click)="close(wasSaved)">
+                    <ng-container *ngIf="wasSaved" i18n>Close</ng-container>
+                    <ng-container *ngIf="!wasSaved" i18n>Close without saving</ng-container>
+                </button>
+            </div>
+        </tim-dialog-frame>
+    `,
+})
+export class EditJsonEventDialogComponent extends AngularDialogComponent<
+    IEditJsonEventOptions,
+    boolean
+> {
+    protected dialogName = "EventJsonEdit";
+    @ViewChild("editor", {static: true}) editor!: AceEditorComponent;
+
+    wasSaved = false;
+    loading = true;
+    error?: string;
+    htmlError?: string;
+
+    constructor(private http: HttpClient) {
+        super();
+    }
+
+    ngOnInit() {
+        void this.loadEvents();
+    }
+
+    private async loadEvents() {
+        this.error = undefined;
+        const res = await toPromise(
+            this.http.get("/calendar/export", {
+                params: {
+                    format: "template-json",
+                    ...this.data.filterParams,
+                },
+            })
+        );
+        if (res.ok) {
+            this.editor.content = JSON.stringify(res.result, null, 4);
+        } else {
+            this.error = $localize`Could not load events. More info: ${res.result.error.error}`;
+        }
+        this.loading = false;
+    }
+
+    async saveEvents() {
+        this.loading = true;
+        this.wasSaved = false;
+        this.error = undefined;
+        this.htmlError = undefined;
+
+        let jsonData: unknown;
+        try {
+            jsonData = JSON.parse(this.editor.content);
+        } catch (e) {
+            this.loading = false;
+            this.error = $localize`Could not parse JSON. Error info: ${e}`;
+            return;
+        }
+
+        const res = await toPromise(
+            this.http.post<{
+                web?: {error?: string};
+            }>("/calendar/import", {
+                events: jsonData,
+            })
+        );
+
+        if (res.ok) {
+            if (res.result.web?.error) {
+                this.htmlError = $localize`Error: ${res.result.web.error}`;
+            } else {
+                this.wasSaved = true;
+            }
+        } else {
+            this.error = $localize`Could not save events. More info: ${res.result.error.error}`;
+        }
+
+        this.loading = false;
+    }
+}
+
+@NgModule({
+    declarations: [EditJsonEventDialogComponent],
+    imports: [
+        BrowserModule,
+        DialogModule,
+        TimUtilityModule,
+        EditorModule,
+        HttpClientModule,
+        PurifyModule,
+    ],
+})
+export class EditJsonEventDialogModule {}

--- a/timApp/static/scripts/tim/plugin/calendar/showEditJsonEventDialog.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/showEditJsonEventDialog.ts
@@ -1,0 +1,12 @@
+import {to2} from "../../util/utils";
+import {angularDialog} from "../../ui/angulardialog/dialog.service";
+import {IEditJsonEventOptions} from "./edit-json-event-dialog.component";
+
+export async function showEditJsonEventDialog(opts: IEditJsonEventOptions) {
+    const {EditJsonEventDialogComponent} = await import(
+        "./edit-json-event-dialog.component"
+    );
+    return to2(
+        (await angularDialog.open(EditJsonEventDialogComponent, opts)).result
+    );
+}

--- a/tim_common/timjsonencoder.py
+++ b/tim_common/timjsonencoder.py
@@ -6,6 +6,7 @@ from enum import Enum
 from isodate import duration_isoformat
 from isodate.duration import Duration
 from jinja2 import Undefined
+from marshmallow import missing
 
 try:
     from sqlalchemy.ext.declarative import DeclarativeMeta
@@ -58,5 +59,9 @@ class TimJsonEncoder(json.JSONEncoder):
         if isinstance(o, Enum):
             return o.value
         if is_dataclass(o):
-            return {f.name: getattr(o, f.name) for f in fields(o)}
+            return {
+                f.name: val
+                for f in fields(o)
+                if (val := getattr(o, f.name)) is not missing
+            }
         return None


### PR DESCRIPTION
Lisää yksinkertaisen massamuokkauksen JSONin kautta.

Toiminta:

* Avaa kalenterin edit-tila
* Exportin viereen ilmestyy uusi painike:
    
     ![image](https://user-images.githubusercontent.com/5202606/185740269-31dd232e-c65d-45f4-b3a6-cf4e5fafb9bb.png)

* Painikkeesta painaminen avaa saman kalenterin *samoilla filtteriasetuksilla* JSON-muodossa
* Tapahtumien muokkaus, lisäys ja poisto onnistuu odotetusti (jos id paikalla, tehdään muokkaus; jos idtä ei ole, luodaan uusi tapahtuma)
* Tapahtuman poisto onnistuu lisäämällä `"delete": true` tapahtumaan (dialogissa on tästä vinkki)
* Tällä hetkellä filtteröinti tehdään kalenterin markupin perusteella

Testi: https://timdevs01-2.it.jyu.fi/view/users/test-user-1/test-extrabookers (testuser1, se omistaa kaikki tapahtumat)

Tämä mergetään vasta #3134 jälkeen.
