### PR TITLE
Add separate text for hiding model answer

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6814,6 +6814,14 @@
           <context context-type="linenumber">958</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2975577548588791187" datatype="html">
+        <source>Hide model answer</source>
+        <target state="translated">Piilota mallivastaus</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">1493</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6704,6 +6704,14 @@
           <context context-type="linenumber">958</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2975577548588791187" datatype="html">
+        <source>Hide model answer</source>
+        <target state="translated">Dölj modellsvaret</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answerbrowser3.ts</context>
+          <context context-type="linenumber">1493</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/static/scripts/tim/answer/IAnswer.ts
+++ b/timApp/static/scripts/tim/answer/IAnswer.ts
@@ -17,6 +17,7 @@ export type IModelAnswerSettings = {
     lock: boolean;
     count: number;
     revealDate?: string;
+    hideText?: string;
     linkText?: string;
     linkTextCount?: number;
     linkTextBeforeCount?: string;

--- a/timApp/static/scripts/tim/answer/answerbrowser3.ts
+++ b/timApp/static/scripts/tim/answer/answerbrowser3.ts
@@ -1489,6 +1489,9 @@ export class AnswerBrowserController
         ) {
             return this.modelAnswer.lockedLinkText;
         }
+        if (this.modelAnswerVisible) {
+            return this.modelAnswer?.hideText ?? $localize`Hide model answer`;
+        }
         return this.modelAnswer?.linkText ?? $localize`Show model answer`;
     }
 

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -78,6 +78,7 @@ class AccessField:
 class ModelAnswerInfo:
     answer: str | None | Missing = missing
     count: int | None | Missing = 1
+    hideText: str | None | Missing = missing
     linkText: str | None | Missing = missing
     linkTextCount: int | None | Missing = missing
     linkTextBeforeCount: str | None | Missing = missing


### PR DESCRIPTION
Lisää vielä yhden attribuutin modelAnsweriin

hideText: Teksti jota painamalla avattu mallivastaus. Oletuksena lokalisoitu "Piilota mallivastaus" 

https://timdevs01-3.it.jyu.fi/view/modelanswer_tex