### PR TITLE
Use `tests` container for tests in dev

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -88,15 +88,7 @@
 	import tim_server
 }
 
-# For running tests (from IDE).
-http://caddy:81 {
-	import common
-	handle {
-		reverse_proxy * http://tim:5001
-	}
-}
-
-# For running tests (from command line).
+# For running tests
 http://caddy:82 {
 	import common
 	handle {

--- a/cli/commands/test.py
+++ b/cli/commands/test.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 from time import sleep
 
-from cli.commands.up import up
+from cli.config import get_config
 from cli.docker.run import run_compose
 from cli.util.logging import log_debug
 from cli.util.proc import sh_join
@@ -57,8 +57,9 @@ for test_file in test_files:
 
 
 def run(args: Arguments) -> None:
-    if args.up:
-        up()
+    config = get_config()
+    if args.up or config.profile != "test":
+        run_compose(["up", "-d", "--quiet-pull"], "test")
         # Wait for the containers to be up for a small moment
         sleep(5)
 

--- a/cli/templates/.idea/runConfigurations/Test.xml
+++ b/cli/templates/.idea/runConfigurations/Test.xml
@@ -6,7 +6,7 @@
     <envs>
       <env name="TIM_SETTINGS" value="testconfig.py" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$TIM_DOCKER_COMPOSE$]:tim/python3" />
+    <option name="SDK_HOME" value="docker-compose://[$TIM_DOCKER_COMPOSE$]:tests/python3" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/timApp" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/cli/templates/.idea/runConfigurations/_template__of_Autodetect.xml
+++ b/cli/templates/.idea/runConfigurations/_template__of_Autodetect.xml
@@ -6,7 +6,7 @@
     <envs>
       <env name="TIM_SETTINGS" value="testconfig.py" />
     </envs>
-    <option name="SDK_HOME" value="docker-compose://[$TIM_DOCKER_COMPOSE$]:tim/python3" />
+    <option name="SDK_HOME" value="docker-compose://[$TIM_DOCKER_COMPOSE$]:tests/python3" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/timApp" />
     <option name="IS_MODULE_SDK" value="false" />
     <option name="ADD_CONTENT_ROOTS" value="true" />

--- a/cli/templates/docker/docker-compose.tmpl.yml
+++ b/cli/templates/docker/docker-compose.tmpl.yml
@@ -384,8 +384,9 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
  tests:
   profiles:
    - test
+   - dev
   image: timimages/tim:${tim.image_tag}
-  command: "${TEST_COMMAND:-python3 -m unittest discover tests/ 'test_*.py' .}"
+  command: ${ f'''${{TEST_COMMAND:-{"python3 -m unittest discover tests/ 'test_*.py' ." if not tim.is_dev else "sleep infinity"}}}''' }
   volumes:
    - .:/service:rw
   environment:

--- a/cli/templates/docker/docker-compose.tmpl.yml
+++ b/cli/templates/docker/docker-compose.tmpl.yml
@@ -393,21 +393,22 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
    TIM_SETTINGS: testconfig.py
    PYTHONPATH: /service
    CI: ${CI:-false}
-  depends_on:
-   - csplugin
-   - pali
-   - fields
-   - showfile
-   - haskellplugins
-   - imagex
-   - jsrunner
-   - dumbo
-   - feedback
-   - redis
-   - oiko
-   - caddy
-   - postgresql-test
-   - mailman-test
+  depends_on: ${"""
+    - csplugin
+    - pali
+    - fields
+    - showfile
+    - haskellplugins
+    - imagex
+    - jsrunner
+    - dumbo
+    - feedback
+    - redis
+    - oiko
+    - caddy
+    - postgresql-test
+    - mailman-test
+   """ if not tim.is_dev else "[]"}
   tmpfs:
    - /tmp
    - /tim_files

--- a/timApp/testconfig.py
+++ b/timApp/testconfig.py
@@ -5,8 +5,6 @@ from typing import TypedDict
 
 from celery.schedules import crontab
 
-from timApp.util.utils import pycharm_running
-
 DEBUG = True
 PROFILE = False
 TIM_NAME = "tim-test"
@@ -30,9 +28,7 @@ SQLALCHEMY_MAX_OVERFLOW = 100
 LAST_EDITED_BOOKMARK_LIMIT = 3
 TRAP_HTTP_EXCEPTIONS = True
 PROPAGATE_EXCEPTIONS = True
-SELENIUM_BROWSER_URL = os.environ.get(
-    "SELENIUM_BROWSER_URL", "http://caddy:" + ("81" if pycharm_running() else "82")
-)
+SELENIUM_BROWSER_URL = os.environ.get("SELENIUM_BROWSER_URL", "http://caddy:82")
 LIVESERVER_PORT = 5001
 QST_PLUGIN_PORT = LIVESERVER_PORT
 PERMANENT_SESSION_LIFETIME = timedelta(weeks=9999)


### PR DESCRIPTION
Closes #3157

Muuttaa testien ajokonfiguraatiota niin, että 

* `tests`-kontti on aina käytettävissä dev-profiilissa
* PyCharm-testit ajetaan `tests`-kontissa

Tämä mahdollistaa testien ajamisen eristyksessä pääkontista, mikä voi helpottaa tiettyä kehitystä. 

Tämä PR myös päivittää PyCharmin oletuskonfiguraatiot, mutta jo olemassa olevissa asennuksissa ne pitää päivittää käsin seuraavasti:

* Lisää `tests`-kontin interpreter [PyCharm-ohjeiden mukaisesti](https://tim.jyu.fi/view/tim/TIMin-kehitys/PyCharm#interpreter)
* Muuta Testauskonfiguraation aktiivista interpreteria (Python interpreter -kohta) `tests`-kontin interpreteriksi