### PR TITLE
Model answer raw

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2365,7 +2365,9 @@ def get_model_answer(task_id: str) -> Response:
     dumbo_opts = plug.par.get_dumbo_options(
         base_opts=doc.get_settings().get_dumbo_options()
     )
-    answer_html = md_to_html(model_answer_info.answer, dumbo_options=dumbo_opts)
+    answer_html = md_to_html(
+        model_answer_info.answer, dumbo_options=dumbo_opts, ignore_errors=True
+    )
     return json_response({"answer": answer_html})
 
 

--- a/timApp/markdown/markdownconverter.py
+++ b/timApp/markdown/markdownconverter.py
@@ -504,6 +504,7 @@ def md_to_html(
         env=create_environment(
             "%%", user_ctx=None, view_ctx=default_view_ctx, macros=macros
         ),
+        ignore_errors=True,
     )
     raw = call_dumbo([text], options=dumbo_options)
     if sanitize:

--- a/timApp/markdown/markdownconverter.py
+++ b/timApp/markdown/markdownconverter.py
@@ -486,9 +486,11 @@ def md_to_html(
     sanitize: bool = True,
     macros: dict[str, object] | None = None,
     dumbo_options: DumboOptions = DumboOptions.default(),
+    ignore_errors=False,
 ) -> str:
     """Converts the specified markdown text to HTML.
 
+    :param ignore_errors: Whether to ignore errors expanding macros
     :param dumbo_options: Options for Dumbo.
     :param macros: The macros to use.
     :param sanitize: Whether the HTML should be sanitized. Default is True.
@@ -504,7 +506,7 @@ def md_to_html(
         env=create_environment(
             "%%", user_ctx=None, view_ctx=default_view_ctx, macros=macros
         ),
-        ignore_errors=True,
+        ignore_errors=ignore_errors,
     )
     raw = call_dumbo([text], options=dumbo_options)
     if sanitize:


### PR DESCRIPTION
Mahdollistaa {%raw%} ja {%endraw%} tagit mallivastauksessa

>Miten saan mallivastaukseen "raakaa koodia" sillä tavalla ettei mene makroista selaisin

https://timdevs01-3.it.jyu.fi/view/modelanswer-raw
