### PR TITLE
ModelAnswer: add disabled, endDate and groups attributes

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2361,11 +2361,8 @@ def get_model_answer(task_id: str) -> Response:
             if not has_access:
                 raise RouteException("You cannot view this model answer")
         if model_answer_info.count:
-            answer_count = (
-                answer_count
-                if answer_count is not None
-                else current_user.get_answers_for_task(tid.doc_task).count()
-            )
+            if answer_count is None:
+                answer_count = current_user.get_answers_for_task(tid.doc_task).count()
             if answer_count < model_answer_info.count:
                 raise RouteException(
                     f"You need to attempt at least {model_answer_info.count} times before viewing the model answer"

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2337,7 +2337,7 @@ def get_model_answer(task_id: str) -> Response:
     if not model_answer_info or not model_answer_info.answer:
         raise RouteException(f"No model answer for task {task_id}")
     if not has_teacher_access(d):
-        answer_count: Union[int | None] = None
+        answer_count: int | None = None
         if model_answer_info.disabled:
             raise RouteException("This model answer has been disabled")
         if model_answer_info.endDate:
@@ -2346,7 +2346,7 @@ def get_model_answer(task_id: str) -> Response:
         if model_answer_info.revealDate:
             if model_answer_info.revealDate > get_current_time():
                 raise RouteException("The model answer cannot be viewed yet")
-        if model_answer_info.groups and len(model_answer_info.groups) > 0:
+        if model_answer_info.groups:
             requested_groups = RequestedGroups.from_name_list(model_answer_info.groups)
             user_groups = [group.id for group in current_user.groups]
             has_access = False

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -79,6 +79,9 @@ class AccessField:
 class ModelAnswerInfo:
     answer: str | None | Missing = missing
     count: int | None | Missing = 1
+    disabled: bool | None | Missing = missing
+    endDate: PluginDateTime | datetime | None | Missing = missing
+    groups: list[str] | None | Missing = missing
     hideText: str | None | Missing = missing
     linkText: str | None | Missing = missing
     linkTextCount: int | None | Missing = missing


### PR DESCRIPTION
Kolme uutta attribuuttia modelAnsweriin:

disabled: estää avaamisen kokonaan
endDate: Aikaleima jonka jälkeen avaaminen estetään
groups: ryhmät joille vastaus voidaan antaa ( * = vastanneet, tyhjä taulukko = avoin kaikille)

https://timdevs01-3.it.jyu.fi/view/modelanswer-limits