### PR TITLE
Add addTemplateAbove and addTemplateBelow

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6822,6 +6822,14 @@
           <context context-type="linenumber">1493</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2447385110832649758" datatype="html">
+        <source>Could not add paragraph: <x id="PH" equiv-text="r.result.data"/></source>
+        <target state="translated">Kappaletta ei voitu lisätä: <x id="PH" equiv-text="r.result.data"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/document/editing/editing.ts</context>
+          <context context-type="linenumber">549</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6712,6 +6712,14 @@
           <context context-type="linenumber">1493</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2447385110832649758" datatype="html">
+        <source>Could not add paragraph: <x id="PH" equiv-text="r.result.data"/></source>
+        <target state="translated">Kunde inte lägga till ett stycke: <x id="PH" equiv-text="r.result.data"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/document/editing/editing.ts</context>
+          <context context-type="linenumber">549</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/static/scripts/tim/document/editing/editing.ts
+++ b/timApp/static/scripts/tim/document/editing/editing.ts
@@ -142,6 +142,34 @@ export class EditingHandler {
                 );
             });
 
+            onClick(".addTemplateAbove", ($this, e) => {
+                this.viewctrl.closePopupIfOpen();
+                const [par, options] = prepareOptions(
+                    $this[0],
+                    "addTemplateAbove"
+                );
+                return this.addParagraph(
+                    e.originalEvent,
+                    EditType.AddAbove,
+                    par,
+                    options
+                );
+            });
+
+            onClick(".addTemplateBelow", ($this, e) => {
+                this.viewctrl.closePopupIfOpen();
+                const [par, options] = prepareOptions(
+                    $this[0],
+                    "addTemplateBelow"
+                );
+                return this.addParagraph(
+                    e.originalEvent,
+                    EditType.AddBelow,
+                    par,
+                    options
+                );
+            });
+
             onClick(".addBelow", ($this, e) => {
                 this.viewctrl.closePopupIfOpen();
                 const [par, options] = prepareOptions($this[0], "addBelow");
@@ -484,6 +512,43 @@ auto_number_headings: 0${CURSOR}
             }
             this.viewctrl.areaHandler.cancelSelection();
         });
+    }
+
+    async addParagraph(
+        e: MouseEvent,
+        type: EditType.AddAbove | EditType.AddBelow,
+        par: ParContext,
+        options: IParEditorOptions = {}
+    ) {
+        const text = await replaceTemplateValues(
+            options.initialText ?? "New paragraph"
+        );
+        const params: EditPosition = {
+            type,
+            par: par,
+        };
+        const next = getNextId(params);
+        const data: IExtraData = {
+            docId: this.viewctrl.docId,
+            par_next: next,
+            tags: {
+                markread: true,
+            },
+        };
+        const r = await to(
+            $http.post<IParResponse>("/newParagraph/", {
+                text,
+                ...extraDataForServer(data),
+                view: getViewName(),
+            })
+        );
+        if (r.ok) {
+            this.addSavedParToDom(r.result.data, params);
+        } else {
+            await showMessageDialog(
+                $localize`Could not add paragraph: ${r.result.data}`
+            );
+        }
     }
 
     showAddParagraphAbove(

--- a/timApp/static/scripts/tim/ui/showTemplateReplaceDialog.ts
+++ b/timApp/static/scripts/tim/ui/showTemplateReplaceDialog.ts
@@ -57,12 +57,14 @@ export async function showTemplateReplaceDialog(
 export async function replaceTemplateValues(data: string): Promise<string> {
     const replaceList: ITemplateParam[] = [];
     const rows = data.split("\n");
-    while (rows?.[0].startsWith('- {"what"')) {
+    while (rows?.[0].startsWith("- {")) {
         const s = rows[0].substring(2);
         try {
             const jso = JSON.parse(s);
-            replaceList.push(jso);
-            rows.shift();
+            if (TemplateParam.is(jso)) {
+                replaceList.push(jso);
+                rows.shift();
+            }
         } catch (e) {
             return "" + e + "\n" + s;
         }


### PR DESCRIPTION
Closes #3158 

Lisää `.addTemplateAbove` ja `.addTemplateBelow` -luokat. Ne toimivat samalla tavalla kuin nykyiset `.addAbove` ja `.addBelow`, mutta editorin avaamisen sijaan niillä avataan vain yksinkertainen dialogi.

Esimerkki: https://timdevs01-5.it.jyu.fi/view/users/test-user-1/test-addpar