### PR TITLE
Add basic floating paragraph support

### DIFF
--- a/timApp/static/scripts/tim/document/structure/parContext.ts
+++ b/timApp/static/scripts/tim/document/structure/parContext.ts
@@ -95,7 +95,11 @@ export class ParContext {
         if (n.length === 0) {
             const newContainer = document.createElement("div");
             newContainer.classList.add("notes");
-            this.par.htmlElement.appendChild(newContainer);
+            const target =
+                this.par.htmlElement.querySelector(
+                    ".parContent"
+                )?.parentElement;
+            target?.appendChild(newContainer);
             return newContainer;
         }
         return n[0];

--- a/timApp/static/scripts/tim/document/structure/parsing.ts
+++ b/timApp/static/scripts/tim/document/structure/parsing.ts
@@ -76,7 +76,7 @@ function tryParseCollapsibleArea(
     if (!x) {
         return {ok: false, result: "area container missing"};
     }
-    const content = x.firstElementChild;
+    const content = x.querySelector(".areaContent");
     if (!content || !(content instanceof HTMLElement)) {
         return {ok: false, result: "area container content missing"};
     }
@@ -239,7 +239,7 @@ function tryParseUncollapsibleArea(
     if (!areaname) {
         return {ok: false, result: "area name missing"};
     }
-    const areacontent = el.firstElementChild;
+    const areacontent = el.querySelector(".areaContent");
     if (!areacontent || !(areacontent instanceof HTMLElement)) {
         return {ok: false, result: "areacontent missing"};
     }

--- a/timApp/static/scripts/tim/ui/draggable.ts
+++ b/timApp/static/scripts/tim/ui/draggable.ts
@@ -187,11 +187,6 @@ export class DraggableController implements IController {
         });
         // User may have refreshed the document after resizing the window.
         void this.restoreSizeAndPosition(VisibilityFix.Full);
-        if (this.canDrag()) {
-            this.element.addClass("draggable-detached");
-        } else {
-            this.element.addClass("draggable-attached");
-        }
     }
 
     private setVisibility(v: "visible" | "hidden" | "inherit") {
@@ -220,7 +215,8 @@ export class DraggableController implements IController {
     }
 
     private toggleDetach() {
-        if (this.canDrag()) {
+        const canDrag = this.canDrag();
+        if (canDrag) {
             if (this.areaMinimized) {
                 this.toggleMinimize();
             }
@@ -240,7 +236,7 @@ export class DraggableController implements IController {
         }
         this.element.css("z-index", this.getVisibleLayer());
 
-        this.detachStorage.set(this.canDrag());
+        this.detachStorage.set(!canDrag);
     }
 
     /**
@@ -341,6 +337,13 @@ export class DraggableController implements IController {
         // DialogController will call setInitialLayout in case draggable is inside modal
         if (!this.isModal()) {
             await this.setInitialLayout(VisibilityFix.Partial);
+        }
+
+        const canDrag = this.detachStorage.get();
+        if (canDrag) {
+            this.element.addClass("draggable-detached");
+        } else {
+            this.element.addClass("draggable-attached");
         }
     }
 

--- a/timApp/static/stylesheets/style.scss
+++ b/timApp/static/stylesheets/style.scss
@@ -48,6 +48,21 @@ tim-dialog-frame {
     }
 }
 
+.draggable-block, .draggable-area {
+    z-index: 1200 !important;
+    position: static;
+    background-color: var(--bg-color);
+
+    &.draggable-attached {
+        width: initial !important;
+        height: auto !important;
+    }
+
+    .draggable-content {
+        position: relative;
+    }
+}
+
 .draggable-plugin {
     z-index: 1200;
     background-color: $material-bg;

--- a/timApp/templates/partials/paragraphs.jinja2
+++ b/timApp/templates/partials/paragraphs.jinja2
@@ -5,9 +5,21 @@
 
 {%- macro start_area(t) -%}
     {% set area_name = t.areainfo.name %}
-    <div class="{{ t.areainfo.area_class_str }} area_{{area_name}}"
-         data-doc-id="{{ t.doc_id }}">
-        <div class="areaContent {{ t.class_str }}" data-area="{{area_name}}">
+    {% set attrs = t.target.attrs or t.attrs %}
+    <div class="{{ t.areainfo.area_class_str }} area_{{area_name}} {% if attrs.float %}draggable-area{% endif %}"
+         data-doc-id="{{ t.doc_id }}"
+         {% if attrs.float %}
+             tim-draggable-fixed
+             anchor="fixed"
+             click="true"
+             detachable="true"
+             save="%%PAGEID%%DraggableBlockArea{{ area_name }}"
+             {% if attrs.float_caption %}
+             caption="{{ attrs.float_caption }}"
+             {% endif %}
+         {% endif %}
+    >
+        <div class="areaContent {{ t.class_str }} {% if attrs.float %}draggable-content{% endif %}" data-area="{{area_name}}">
 {%- endmacro -%}
 
 {%- macro notes(t) -%}
@@ -38,16 +50,27 @@
 
 {%- for t in text -%}
     {% set ai = t.areainfo %}
+    {% set attrs = t.target.attrs or t.attrs %}
     {%- if not ai or ai.is_collapsed is not boolean -%}
         {%- if ai and ai.is_collapsed is none -%}
             {{ start_area(t) }}
         {%- endif -%}
-        <div class="{{ t.html_class }}"
+        <div class="{{ t.html_class }} {% if attrs.float %}draggable-block{% endif %}"
              id="{{ t.id }}"
              t="{{ t.hash }}"
              attrs='{{ t.attrs_str }}'
          {% if t.from_preamble %}
              data-from-preamble="{{ t.from_preamble|safe }}"
+         {% endif %}
+         {% if attrs.float and not ai %}
+             tim-draggable-fixed
+             anchor="fixed"
+             click="true"
+             detachable="true"
+             save="%%PAGEID%%DraggableBlock{{ t.id }}"
+             {% if attrs.float_caption %}
+             caption="{{ attrs.float_caption }}"
+             {% endif %}
          {% endif %}
          {% if t.target %}
              ref-id="{{ t.target.id }}"
@@ -55,7 +78,9 @@
              ref-attrs="{{ t.target.attrs_str }}"
              ref-doc-id="{{ t.target.doc_id }}"
          {% endif %}>
-        {% set attrs = t.target.attrs or t.attrs %}
+        {% if attrs.float and not ai %}
+            <div class="draggable-content">
+        {% endif %}
         {% set task_id = attrs['taskId'] %}
         {%- if task_id and not preview and not exam_mode -%}
             <span  class="headerlink">
@@ -95,6 +120,9 @@
         {%- endif -%}
 
         {{ notes(t) }}
+        {% if attrs.float and not ai %}
+            </div>
+        {% endif %}
         </div>
         {% if ai and ai.is_collapsed is undefined %}
             </div></div>

--- a/timApp/templates/partials/paragraphs.jinja2
+++ b/timApp/templates/partials/paragraphs.jinja2
@@ -6,9 +6,9 @@
 {%- macro start_area(t) -%}
     {% set area_name = t.areainfo.name %}
     {% set attrs = t.target.attrs or t.attrs %}
-    <div class="{{ t.areainfo.area_class_str }} area_{{area_name}} {% if attrs.float %}draggable-area{% endif %}"
+    <div class="{{ t.areainfo.area_class_str }} area_{{area_name}} {% if attrs.float and not preview %}draggable-area{% endif %}"
          data-doc-id="{{ t.doc_id }}"
-         {% if attrs.float %}
+         {% if attrs.float and not preview %}
              tim-draggable-fixed
              anchor="fixed"
              click="true"
@@ -19,7 +19,7 @@
              {% endif %}
          {% endif %}
     >
-        <div class="areaContent {{ t.class_str }} {% if attrs.float %}draggable-content{% endif %}" data-area="{{area_name}}">
+        <div class="areaContent {{ t.class_str }} {% if attrs.float and not preview %}draggable-content{% endif %}" data-area="{{area_name}}">
 {%- endmacro -%}
 
 {%- macro notes(t) -%}
@@ -55,14 +55,14 @@
         {%- if ai and ai.is_collapsed is none -%}
             {{ start_area(t) }}
         {%- endif -%}
-        <div class="{{ t.html_class }} {% if attrs.float %}draggable-block{% endif %}"
+        <div class="{{ t.html_class }} {% if attrs.float and not preview %}draggable-block{% endif %}"
              id="{{ t.id }}"
              t="{{ t.hash }}"
              attrs='{{ t.attrs_str }}'
          {% if t.from_preamble %}
              data-from-preamble="{{ t.from_preamble|safe }}"
          {% endif %}
-         {% if attrs.float and not ai %}
+         {% if attrs.float and not ai and not preview %}
              tim-draggable-fixed
              anchor="fixed"
              click="true"
@@ -78,7 +78,7 @@
              ref-attrs="{{ t.target.attrs_str }}"
              ref-doc-id="{{ t.target.doc_id }}"
          {% endif %}>
-        {% if attrs.float and not ai %}
+        {% if attrs.float and not ai and not preview %}
             <div class="draggable-content">
         {% endif %}
         {% set task_id = attrs['taskId'] %}
@@ -120,7 +120,7 @@
         {%- endif -%}
 
         {{ notes(t) }}
-        {% if attrs.float and not ai %}
+        {% if attrs.float and not ai and not preview %}
             </div>
         {% endif %}
         </div>

--- a/timApp/templates/partials/paragraphs.jinja2
+++ b/timApp/templates/partials/paragraphs.jinja2
@@ -6,7 +6,7 @@
 {%- macro start_area(t) -%}
     {% set area_name = t.areainfo.name %}
     {% set attrs = t.target.attrs or t.attrs %}
-    <div class="{{ t.areainfo.area_class_str }} area_{{area_name}} {% if attrs.float and not preview %}draggable-area{% endif %}"
+    <div class="{{ t.areainfo.area_class_str }} area_{{area_name}}{% if attrs.float and not preview %} draggable-area{% endif %}"
          data-doc-id="{{ t.doc_id }}"
          {% if attrs.float and not preview %}
              tim-draggable-fixed
@@ -19,7 +19,7 @@
              {% endif %}
          {% endif %}
     >
-        <div class="areaContent {{ t.class_str }} {% if attrs.float and not preview %}draggable-content{% endif %}" data-area="{{area_name}}">
+        <div class="areaContent {{ t.class_str }}{% if attrs.float and not preview %} draggable-content{% endif %}" data-area="{{area_name}}">
 {%- endmacro -%}
 
 {%- macro notes(t) -%}
@@ -55,7 +55,7 @@
         {%- if ai and ai.is_collapsed is none -%}
             {{ start_area(t) }}
         {%- endif -%}
-        <div class="{{ t.html_class }} {% if attrs.float and not preview %}draggable-block{% endif %}"
+        <div class="{{ t.html_class }}{% if attrs.float and not preview %} draggable-block{% endif %}"
              id="{{ t.id }}"
              t="{{ t.hash }}"
              attrs='{{ t.attrs_str }}'


### PR DESCRIPTION
Closes #3170 

Lisää hyvin yksinkertaisen ja alustavan tuen kelluville lohkoille.

Toimintaperiaate: lohkolle tai alueelle lisätään `float="true"`. Dialogin otsikkoa voi muuttaa attribuutilla `float_caption="Otsikko"` 

Tällä hetkellä toteutus on yksinkertainen mutta riittänee SUKOLin tarkoitukseen:

* Käyttää vanhoja AngularJS-dialogeja, joilla on erilaisia tunnetuja bugeja (mutta AngularJS-dialogit toimivat parhaiten yksinkertaisessa toteutuksessa)
* Muutokset tehty Jinja2-pohjiin, mikä sekoittaa koodia hieman
* collapsible-alueet eivät vielä toimi täydellisesti

Esimerkki: https://timdevs01-2.it.jyu.fi/view/users/test-user-1/test-float-par