### PR TITLE
Set min-width for day/week/month scroller

### DIFF
--- a/timApp/static/scripts/tim/plugin/calendar/calendar.component.scss
+++ b/timApp/static/scripts/tim/plugin/calendar/calendar.component.scss
@@ -121,3 +121,6 @@ input[type="checkbox"] {
   margin-left: 1em;
 }
 
+.btn-outline-secondary {
+  min-width: 8em;
+}


### PR DESCRIPTION
Sets the min-width css property for the 'middle' button of the view scroller to prevent its arrow buttons from 'jumping' around when the middle button resizes itself.

The exact size is adjustable under *btn-outline-secondary* in `calendar.component.scss`.


| Before | After |
|:--------|:------|
| ![before1](https://user-images.githubusercontent.com/46485327/189368610-42acba43-50c2-4423-890d-2e13b96f1d8b.png) | ![after1](https://user-images.githubusercontent.com/46485327/189368601-3dd5137f-9054-4b25-8d8a-3752d5809421.png) |
| ![before2](https://user-images.githubusercontent.com/46485327/189368611-f3881f50-9453-4384-b5fd-4030d9b66e05.png) | ![after2](https://user-images.githubusercontent.com/46485327/189368608-30e65d9a-9c41-48a8-b7a8-bf88e543355e.png) |
