### PR TITLE
SidebarMenu: Tools drawer for draggable components (userlist, velp menu)

### DIFF
--- a/timApp/static/scripts/tim/sidebarmenu/services/tab-entry-list.service.ts
+++ b/timApp/static/scripts/tim/sidebarmenu/services/tab-entry-list.service.ts
@@ -10,6 +10,7 @@ import {ScoreInfoTabComponent} from "tim/sidebarmenu/tabs/score-info-tab.compone
 import {LectureInfoTabComponent} from "tim/sidebarmenu/tabs/lecture-info-tab.component";
 import {LoadQuestionsTabComponent} from "tim/sidebarmenu/tabs/load-questions-tab.component";
 import {LoggedUsersTabComponent} from "tim/sidebarmenu/tabs/logged-users-tab.component";
+import {ToolsTabComponent} from "tim/sidebarmenu/tabs/tools-tab.component";
 import {TabEntry} from "../menu-tab.directive";
 import {HeaderIndexerService} from "./header-indexer.service";
 
@@ -52,6 +53,14 @@ export class TabEntryListService {
                 visible: () =>
                     !hide.index && this.headerIndexer.headers.length > 0,
                 component: IndexTabComponent,
+            },
+            {
+                id: "tab-tools",
+                icon: "wrench",
+                title: $localize`Tools`,
+                // TODO: additional visibility restrictions
+                visible: () => Users.isLoggedIn(),
+                component: ToolsTabComponent,
             },
             {
                 id: "tab-score-info",

--- a/timApp/static/scripts/tim/sidebarmenu/side-bar-menu.module.ts
+++ b/timApp/static/scripts/tim/sidebarmenu/side-bar-menu.module.ts
@@ -7,6 +7,7 @@ import {CollapseModule} from "ngx-bootstrap/collapse";
 import {SidebarMenuComponent} from "tim/sidebarmenu/sidebar-menu.component";
 import {BsDropdownModule} from "ngx-bootstrap/dropdown";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
+import {ToolsTabComponent} from "tim/sidebarmenu/tabs/tools-tab.component";
 import {BookmarksTabComponent} from "./tabs/bookmarks-tab.component";
 import {MenuTabDirective} from "./menu-tab.directive";
 import {TabContainerComponent} from "./tab-container.component";
@@ -33,6 +34,7 @@ import {ScoreInfoTabComponent} from "./tabs/score-info-tab.component";
         BookmarksComponent,
         TimeSincePipe,
         ScoreInfoTabComponent,
+        ToolsTabComponent,
     ],
     imports: [
         CommonModule,
@@ -55,6 +57,7 @@ import {ScoreInfoTabComponent} from "./tabs/score-info-tab.component";
         LectureInfoTabComponent,
         LoadQuestionsTabComponent,
         LoggedUsersTabComponent,
+        ToolsTabComponent,
     ],
 })
 export class SideBarMenuModule {}

--- a/timApp/static/scripts/tim/sidebarmenu/tabs/tools-tab.component.ts
+++ b/timApp/static/scripts/tim/sidebarmenu/tabs/tools-tab.component.ts
@@ -1,0 +1,12 @@
+import {Component} from "@angular/core";
+
+@Component({
+    selector: "tools-tab",
+    template: `
+        <ng-template i18n>Tools</ng-template>
+        <h5 i18n>Tools</h5>
+    `,
+})
+export class ToolsTabComponent {
+    constructor() {}
+}

--- a/timApp/static/stylesheets/velpSelection.scss
+++ b/timApp/static/stylesheets/velpSelection.scss
@@ -50,7 +50,8 @@ annotation .fulldiv {
 
 .velpFixed {
     position: fixed;
-    min-width: fit-content;
+    /* disable fit-content for now, since it prevents drag handle size change when minimized */
+    /* min-width: fit-content; */
     max-width: 23em;
     min-height: 24em;
     height: fit-content;

--- a/timApp/static/stylesheets/velpSelection.scss
+++ b/timApp/static/stylesheets/velpSelection.scss
@@ -50,8 +50,7 @@ annotation .fulldiv {
 
 .velpFixed {
     position: fixed;
-    /* disable fit-content for now, since it prevents drag handle size change when minimized */
-    /* min-width: fit-content; */
+    min-width: fit-content;
     max-width: 23em;
     min-height: 24em;
     height: fit-content;
@@ -64,6 +63,10 @@ annotation .fulldiv {
     background: white;
     z-index: 1000;
     /* border-top-left-radius: 8px; */
+}
+
+.velpFixed:nth-child(1) {
+    min-width: 200px;
 }
 
 /** Velp area styles **/


### PR DESCRIPTION
Fixes issues: #3156 #3150 

Adds a new tab `Tools` to the SidebarMenu that can house 'free-floating' draggable components/windows, such as Answerbrowser's `userlist` or the `Velp menu` window.

Tasks/todos:

- [x] Fix `Velp menu`'s oversized drag handle when minimized
- [x] Add `Tools` menu tab to sidebarmenu
- [ ] Add visibility constraints to `Tools` tab: exact constraints will depend on what 'tools' will be added to the tab
- [ ] Add logic to move draggables to and from the `Tools` menu
- [ ] Update test screenshots