### PR TITLE
Fix detached draggable dialog size and position

### DIFF
--- a/timApp/static/stylesheets/style.scss
+++ b/timApp/static/stylesheets/style.scss
@@ -71,15 +71,20 @@ tim-dialog-frame {
         background-color: $material-bg;
     }
 
+    &.draggable-detached {
+        max-width: $paragraph-preferred-width !important;
+        min-height: fit-content !important;
+    }
+
     &.draggable-detached .csRunDiv {
         max-width: $paragraph-preferred-width;
         background-color: $material-bg;
     }
 
     &.draggable-detached .draggable-content {
-        height: inherit;
+        /* height: inherit; */
         overflow-y: auto;
-        max-height: 90vh;
+        min-height: fit-content !important;
     }
 }
 


### PR DESCRIPTION
Fixes #3186 by adding some minimum sizes in css and enforcing appropriate sizes manually when the dialog is detached from its container.