### PR TITLE
Fix drag plugin 'max' option

### DIFF
--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -88,7 +88,7 @@ interface WordObject {
                     [dndDropzone]="[type]"
                     [dndHorizontal]="true"
                     [dndDraggable]="wordObjs"
-                    [dndDisableDragIf]="wordObjs.length >= max"
+                    [dndDisableIf]="wordObjs.length >= max"
                     [dndEffectAllowed]="effectAllowed"
                     (dndDrop)="handleDrop($event)"
                 >


### PR DESCRIPTION
The 'max' option for the drag plugin was not working because of calling removed or deprecated external directive. This pull request fixes the issue by calling the correct directive.