### PR TITLE
Sort reviewCanvas pdf pages correctly

### DIFF
--- a/timApp/upload/upload.py
+++ b/timApp/upload/upload.py
@@ -333,7 +333,11 @@ def convert_pdf_or_compress_image(f: UploadedFile, u: User, d: DocInfo, task_id:
             ],
             capture_output=True,
         )
-        for imagepath in os.listdir(tempfolder):
+        pdf_image_pages = os.listdir(tempfolder)
+        pdf_image_pages.sort(
+            key=lambda x: int(x[len(p.stem) + 7 : -4])  # filename_image-KEY.png
+        )
+        for imagepath in pdf_image_pages:
             file = tempfolder / imagepath
             try:
                 # TODO: Some pdfs have only one, very large page. Downsampling them to 2048px can make


### PR DESCRIPTION
Varmistaa että yli 10-sivuiset pdf-palautukset latautuvat reviewcanvaksessa oikeassa järjestyksessä. Esimerkiksi omassa lokaalissa tim-asennuksessa os.listdir saa tiedostonimet järjestyksessä `image-1, image-10, image-2...`, eli sivu 10 tulee palautuksessa ennen sivua 2

Tuotantotimissä ja timdevsissä näyttäisi palautuvan valmiiksi oikeassa järjestyksessä, mutta se on kuitenkin parempi muuttaa niin että järjestys on oikein koneesta riippumatta. 