### PR TITLE
Fix non-pluginloader qst complaining about ngZone

### DIFF
--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -697,8 +697,8 @@ def qst_get_html(jso, review):
             + "</div>"
         )
         return result
-
-    runner = "tim-qst"
+    is_task = markup.get("isTask", False)
+    runner = "tim-qst" if is_task else "tim-lecture-qst"
     s = f'<{runner} json="{make_base64(jso, TimJsonEncoder)}"></{runner}>'
     return s
 

--- a/timApp/static/scripts/tim/plugin/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst.component.ts
@@ -395,7 +395,7 @@ export const moduleDefs = [
         createDowngradedModule((extraProviders) =>
             platformBrowserDynamic(extraProviders).bootstrapModule(QstModule)
         ),
-        "timQst",
+        "timLectureQst",
         QstComponent
     ),
 ];

--- a/timApp/tests/browser/test_lecture.py
+++ b/timApp/tests/browser/test_lecture.py
@@ -1,0 +1,29 @@
+import datetime
+
+from timApp.tests.browser.browsertest import BrowserTest
+from timApp.util.utils import get_current_time, static_tim_doc
+
+
+class LectureTest(BrowserTest):
+    def test_lecture_qst_visible(self):
+        self.login_test1()
+        current_time = get_current_time()
+        start_time = current_time - datetime.timedelta(minutes=15)
+        end_time = current_time + datetime.timedelta(hours=2)
+        lecture_code = "test lecture"
+        doc = self.create_doc(from_file=static_tim_doc("questions.md"))
+        j = self.json_post(
+            "/createLecture",
+            json_data=dict(
+                doc_id=doc.id,
+                end_time=end_time,
+                lecture_code=lecture_code,
+                max_students=50,
+                start_time=start_time,
+            ),
+        )
+        self.login_browser_quick_test1()
+        self.goto_document(doc, view="lecture")
+        self.wait_until_present_and_vis("tim-lecture-qst")
+        qst_text = self.find_element_avoid_staleness("tim-lecture-qst p")
+        self.assertEqual("1) Today", qst_text.text)

--- a/timApp/tests/server/test_question.py
+++ b/timApp/tests/server/test_question.py
@@ -16,7 +16,7 @@ class QuestionTest(BrowserTest):
         data = self.get(d.url_relative, as_tree=True)
         first_id = pars[0].get_id()
         self.assert_plugin_json(
-            data.cssselect(".parContent tim-qst")[0],
+            data.cssselect(".parContent tim-lecture-qst")[0],
             self.create_plugin_json(
                 d,
                 "test1",


### PR DESCRIPTION
Muuttaa downgradetetun qst-komponentin nimeksi "tim-lecture-qst", jotta pluginloader ei yrittäisi ladata väärää versiota qst:stä. Tällä hetkellä downgradetetun version lataaminen aiheuttaa virheitä konsolissa:

![kuva](https://user-images.githubusercontent.com/63715895/193569270-b49c793a-515e-458c-bf2c-e3a5c6ca9e5e.png)

Tavallinen qst pluginLoaderissa: https://timdevs01-3.it.jyu.fi/view/qst_normi

Luentoversio: https://timdevs01-3.it.jyu.fi/lecture/qst-lecture
