### PR TITLE
Handle empty pluginLoader

### DIFF
--- a/timApp/static/scripts/tim/answer/pluginLoader.ts
+++ b/timApp/static/scripts/tim/answer/pluginLoader.ts
@@ -353,6 +353,14 @@ export class PluginLoaderComponent
     };
 
     async determineAndSetComponent(component: HTMLElement) {
+        if (component.nodeType === Node.COMMENT_NODE) {
+            // empty loader, do nothing
+            return;
+        }
+        if (component.tagName == undefined) {
+            this.error = `Unknown component ${this.taskId}`;
+            return;
+        }
         const runnername = component.tagName.toLowerCase();
         if (runnername == "div") {
             // For now assume every non-component plugin html (e.g plugins in error state) is wrapped in div, so we


### PR DESCRIPTION
Tarkistaa onko pluginloaderin sisällä mitään ladattavaa komponenttia
Esim showInView saattaa aiheuttaa sen, että sivulla on pluginloader, mutta sen sisällä on pelkkää kommenttitekstiä.

![kuva](https://user-images.githubusercontent.com/63715895/193803456-544b398e-7de7-4fb2-a387-adac158ba2bd.png)

https://timdevs01-3.it.jyu.fi/view/hiddenplugin vs https://tim.jyu.fi/view/users/sijualle/kokeiluja/hiddenplugin