### PR TITLE
Add common spellcheck plugin attr, implement on cs textArea

### DIFF
--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -3668,6 +3668,10 @@ ${fhtml}
         return this.markup.inputrows;
     }
 
+    get spellcheck() {
+        return this.markup.spellcheck;
+    }
+
     async setData(data: unknown, save: boolean = false) {
         if (SetData.is(data)) {
             for (const name of ["usercode", "userargs", "userinput"] as const) {
@@ -3767,7 +3771,8 @@ ${fhtml}
                                [parsonsStyleWords]="markup['style-words']"
                                [parsonsWords]="words"
                                (close)="onFileClose($event)"
-                               (content)="onContentChange($event)">
+                               (content)="onContentChange($event)"
+                               [spellcheck]="spellcheck">
                     </cs-editor>
                     <div class="csRunChanged" *ngIf="runChanged && !hide.changed"></div>
                     <div class="csRunNotSaved" *ngIf="isUnSaved()"></div>

--- a/timApp/modules/cs/js/editor/editor.ts
+++ b/timApp/modules/cs/js/editor/editor.ts
@@ -152,7 +152,8 @@ export class JSParsonsEditorComponent implements IEditor {
                     [minRows]="minRows_"
                     [maxRows]="maxRows_"
                     [placeholder]="file && file.placeholder ? file.placeholder : ''"
-                    [disabled]="isDisabled">
+                    [disabled]="isDisabled"
+                    [spellcheck]="spellcheck">
             </cs-normal-editor>
             <cs-parsons-editor *ngIf="mode == Mode.Parsons"
                     [shuffle]="parsonsShuffle"
@@ -198,6 +199,7 @@ export class EditorComponent implements IMultiEditor {
     editorreadonly: boolean = false;
 
     @Input() disabled: boolean = false;
+    @Input() spellcheck?: boolean;
 
     allowedPaths?: string[]; // undefined for all allowed
     maxFiles: number = 1;

--- a/timApp/modules/cs/js/editor/normal.ts
+++ b/timApp/modules/cs/js/editor/normal.ts
@@ -19,7 +19,8 @@ import {CURSOR, IEditor} from "./editor";
                 [rows]="rows"
                 [(ngModel)]="content"
                 [placeholder]="placeholder"
-                [disabled]="disabled">
+                [disabled]="disabled"
+                [attr.spellcheck]="spellcheck">
         </textarea>`,
 })
 export class NormalEditorComponent implements IEditor {
@@ -29,6 +30,7 @@ export class NormalEditorComponent implements IEditor {
     @Input() maxRows: number = 100;
     @Input() placeholder: string = "";
     @Input() disabled: boolean = false;
+    @Input() spellcheck?: boolean;
     @ViewChild("area") private area!: ElementRef;
     private editorreadonly: boolean = false;
 

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -59,6 +59,7 @@ export const GenericPluginMarkup = t.partial({
     answerBrowser: nullable(AnswerBrowserSettings),
     warningFilter: nullable(t.string),
     previousTask: nullable(previousTaskType),
+    spellcheck: t.boolean,
 });
 
 export const Info = nullable(

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -227,6 +227,7 @@ class GenericMarkupModel(KnownMarkupFields):
     connectionErrorMessage: str | Missing = missing
     undo: UndoInfo | Missing | None = missing
     answerBrowser: AnswerBrowserInfo | Missing | None = missing
+    spellcheck: bool | None | Missing = missing
 
     def get_visible_data(self) -> dict:
         assert isinstance(self.hidden_keys, list)


### PR DESCRIPTION
https://timdevs01-3.it.jyu.fi/view/cs-spellcheck

Yleinen spellcheck-pluginattribuutti, toistaiseksi käytetään vain cspluginin yhdessä tapauksessa (myöhemmin varmaan ainakin textfieldissä / qst tekstibokseissa jne)

Lisää textareaan attribuutin spellcheck="arvo" jos spellcheck on annettu. Jos ei annettu niin koko attribuuttia ei ole ja selaimet toimii omilla oletuksillaan.