### PR TITLE
Dragdrop styles

### DIFF
--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -112,6 +112,7 @@ interface WordObject {
                         (dndMoved)="handleMove(i)"
                         (dndCanceled)="(copy !== 'target') || wordObjs.splice(i, 1)"
                         [dndEffectAllowed]="item.effectAllowed"
+                        [ngStyle]="styles"
                     ></li>
                 </ul>
             </div>

--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -24,7 +24,10 @@ import {
     nullable,
     withDefault,
 } from "../../../static/scripts/tim/plugin/attributes";
-import {shuffleStrings} from "../../../static/scripts/tim/plugin/util";
+import {
+    parseStyles,
+    shuffleStrings,
+} from "../../../static/scripts/tim/plugin/util";
 import {AngularPluginBase} from "../../../static/scripts/tim/plugin/angular-plugin-base.directive";
 import {TimUtilityModule} from "../../../static/scripts/tim/ui/tim-utility.module";
 import {vctrlInstance} from "../../../static/scripts/tim/document/viewctrlinstance";
@@ -58,7 +61,14 @@ const DragAll = t.intersection([
         info: Info,
         markup: DragMarkup,
         preview: t.boolean,
-        state: nullable(t.type({c: t.array(t.string)})),
+        state: nullable(
+            t.intersection([
+                t.type({c: t.array(t.string)}),
+                t.partial({
+                    styles: nullable(t.record(t.string, t.string)),
+                }),
+            ])
+        ),
     }),
 ]);
 
@@ -91,6 +101,7 @@ interface WordObject {
                     [dndDisableIf]="wordObjs.length >= max"
                     [dndEffectAllowed]="effectAllowed"
                     (dndDrop)="handleDrop($event)"
+                    [ngStyle]="styles"
                 >
                     <li class="dndPlaceholder" dndPlaceholderRef></li>
                     <li *ngFor="let item of wordObjs; let i = index"
@@ -134,6 +145,7 @@ export class DragComponent
     private forceSave = false;
     private shuffle?: boolean;
     private vctrl = vctrlInstance;
+    styles: Record<string, string> = {};
 
     getAttributeType(): typeof DragAll {
         return DragAll;
@@ -173,6 +185,9 @@ export class DragComponent
 
         if (!this.attrsall.preview) {
             this.vctrl?.addTimComponent(this);
+        }
+        if (this.attrsall.state?.styles) {
+            this.styles = parseStyles(this.attrsall.state.styles);
         }
     }
 

--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -47,6 +47,8 @@ const DragMarkup = t.intersection([
         shuffle: t.boolean,
         followid: t.string,
         autoSave: withDefault(t.boolean, false),
+        ignorestyles: t.boolean,
+        clearstyles: t.boolean,
     }),
     GenericPluginMarkup,
     t.type({
@@ -187,7 +189,7 @@ export class DragComponent
         if (!this.attrsall.preview) {
             this.vctrl?.addTimComponent(this);
         }
-        if (this.attrsall.state?.styles) {
+        if (this.attrsall.state?.styles && !this.markup.ignorestyles) {
             this.styles = parseStyles(this.attrsall.state.styles);
         }
     }
@@ -315,12 +317,15 @@ export class DragComponent
         };
 
         const r = await this.postAnswer<{
-            web: {result: string; error?: string};
+            web: {result: string; error?: string; clear?: boolean};
         }>(params);
 
         if (r.ok) {
             const data = r.result;
             this.error = data.web.error;
+            if (data.web.clear) {
+                this.styles = {};
+            }
         } else {
             this.error = r.result.error.error;
         }

--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -317,13 +317,13 @@ export class DragComponent
         };
 
         const r = await this.postAnswer<{
-            web: {result: string; error?: string; clear?: boolean};
+            web: {result: string; error?: string};
         }>(params);
 
         if (r.ok) {
             const data = r.result;
             this.error = data.web.error;
-            if (data.web.clear) {
+            if (this.markup.clearstyles) {
                 this.styles = {};
             }
         } else {

--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -63,7 +63,7 @@ const DragAll = t.intersection([
         preview: t.boolean,
         state: nullable(
             t.intersection([
-                t.type({c: t.array(t.string)}),
+                t.type({c: nullable(t.array(t.string))}),
                 t.partial({
                     styles: nullable(t.record(t.string, t.string)),
                 }),

--- a/timApp/modules/drag/drag_main.py
+++ b/timApp/modules/drag/drag_main.py
@@ -23,6 +23,7 @@ from tim_common.utils import Missing
 @dataclass
 class DragStateModel:
     c: list[str]
+    styles: dict[str, str] | Missing = missing
 
 
 @dataclass

--- a/timApp/modules/drag/drag_main.py
+++ b/timApp/modules/drag/drag_main.py
@@ -103,9 +103,9 @@ def answer(args: DragAnswerModel) -> PluginAnswerResp:
 
     nosave = args.input.nosave
     if not nosave:
-        save = {"c": words}
+        save: dict[str, list[str] | dict[str, str]] = {"c": words}
         if not args.markup.clearstyles and args.state is not None:
-            if args.state.styles:
+            if args.state.styles and type(args.state.styles) is dict:
                 save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"

--- a/timApp/modules/drag/drag_main.py
+++ b/timApp/modules/drag/drag_main.py
@@ -102,6 +102,8 @@ def answer(args: DragAnswerModel) -> PluginAnswerResp:
     nosave = args.input.nosave
     if not nosave:
         save = {"c": words}
+        if args.state is not None and args.state.styles:
+            save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"
 

--- a/timApp/modules/drag/drag_main.py
+++ b/timApp/modules/drag/drag_main.py
@@ -22,7 +22,7 @@ from tim_common.utils import Missing
 
 @dataclass
 class DragStateModel:
-    c: list[str]
+    c: list[str] | None
     styles: dict[str, str] | Missing = missing
 
 

--- a/timApp/modules/drag/drag_main.py
+++ b/timApp/modules/drag/drag_main.py
@@ -40,6 +40,8 @@ class DragMarkupModel(GenericMarkupModel):
     type: str | Missing = missing
     words: list[str] | Missing = missing
     autoSave: bool | Missing = missing
+    clearstyles: bool | Missing = missing
+    ignorestyles: bool | Missing = missing
 
 
 @dataclass
@@ -102,10 +104,13 @@ def answer(args: DragAnswerModel) -> PluginAnswerResp:
     nosave = args.input.nosave
     if not nosave:
         save = {"c": words}
-        if args.state is not None and args.state.styles:
-            save["styles"] = args.state.styles
+        if not args.markup.clearstyles and args.state is not None:
+            if args.state.styles:
+                save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"
+        if args.markup.clearstyles:
+            web["clear"] = True
 
     return result
 

--- a/timApp/modules/drag/drag_main.py
+++ b/timApp/modules/drag/drag_main.py
@@ -109,8 +109,6 @@ def answer(args: DragAnswerModel) -> PluginAnswerResp:
                 save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"
-        if args.markup.clearstyles:
-            web["clear"] = True
 
     return result
 

--- a/timApp/modules/fields/dropdown.py
+++ b/timApp/modules/fields/dropdown.py
@@ -2,10 +2,11 @@
 Module for serving dropdown item-plugin.
 """
 from dataclasses import dataclass, asdict
+from typing import Union
 
 from flask import render_template_string
 from marshmallow import validates
-from marshmallow.utils import missing
+from marshmallow.utils import missing, _Missing
 
 from tim_common.markupmodels import GenericMarkupModel
 from tim_common.pluginserver_flask import (
@@ -22,7 +23,7 @@ from tim_common.utils import Missing
 @dataclass
 class DropdownStateModel:
     c: str | None
-    styles: dict[str, str] | Missing = missing
+    styles: dict[str, str] | _Missing = missing
 
 
 @dataclass
@@ -98,9 +99,9 @@ def answer(args: DropdownAnswerModel) -> PluginAnswerResp:
     # plugin can ask not to save the word
     nosave = args.input.nosave
     if not nosave:
-        save = {"c": selectedword}
+        save: dict[str, str | dict[str, str]] = {"c": selectedword}
         if not args.markup.clearstyles and args.state is not None:
-            if args.state.styles:
+            if args.state.styles and type(args.state.styles) is dict:
                 save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"

--- a/timApp/modules/fields/dropdown.py
+++ b/timApp/modules/fields/dropdown.py
@@ -23,7 +23,7 @@ from tim_common.utils import Missing
 @dataclass
 class DropdownStateModel:
     c: str | None
-    styles: dict[str, str] | _Missing = missing
+    styles: dict[str, str] | Missing = missing
 
 
 @dataclass

--- a/timApp/modules/fields/dropdown.py
+++ b/timApp/modules/fields/dropdown.py
@@ -35,6 +35,8 @@ class DropdownMarkupModel(GenericMarkupModel):
     autosave: bool | Missing = missing
     answers: bool | Missing = missing
     tag: str | Missing | None = missing
+    clearstyles: bool | Missing = missing
+    ignorestyles: bool | Missing = missing
 
 
 @dataclass
@@ -97,10 +99,13 @@ def answer(args: DropdownAnswerModel) -> PluginAnswerResp:
     nosave = args.input.nosave
     if not nosave:
         save = {"c": selectedword}
-        if args.state is not None and args.state.styles:
-            save["styles"] = args.state.styles
+        if not args.markup.clearstyles and args.state is not None:
+            if args.state.styles:
+                save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"
+        if args.markup.clearstyles:
+            web["clear"] = True
     else:
         save = {"c": ""}
         result["save"] = save

--- a/timApp/modules/fields/dropdown.py
+++ b/timApp/modules/fields/dropdown.py
@@ -97,6 +97,8 @@ def answer(args: DropdownAnswerModel) -> PluginAnswerResp:
     nosave = args.input.nosave
     if not nosave:
         save = {"c": selectedword}
+        if args.state is not None and args.state.styles:
+            save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"
     else:

--- a/timApp/modules/fields/dropdown.py
+++ b/timApp/modules/fields/dropdown.py
@@ -104,8 +104,6 @@ def answer(args: DropdownAnswerModel) -> PluginAnswerResp:
                 save["styles"] = args.state.styles
         result["save"] = save
         web["result"] = "saved"
-        if args.markup.clearstyles:
-            web["clear"] = True
     else:
         save = {"c": ""}
         result["save"] = save

--- a/timApp/modules/fields/dropdown.py
+++ b/timApp/modules/fields/dropdown.py
@@ -22,6 +22,7 @@ from tim_common.utils import Missing
 @dataclass
 class DropdownStateModel:
     c: str
+    styles: dict[str, str] | Missing = missing
 
 
 @dataclass

--- a/timApp/modules/fields/dropdown.py
+++ b/timApp/modules/fields/dropdown.py
@@ -21,7 +21,7 @@ from tim_common.utils import Missing
 
 @dataclass
 class DropdownStateModel:
-    c: str
+    c: str | None
     styles: dict[str, str] | Missing = missing
 
 

--- a/timApp/modules/fields/js/dropdown-plugin.component.ts
+++ b/timApp/modules/fields/js/dropdown-plugin.component.ts
@@ -59,7 +59,7 @@ const DropdownAll = t.intersection([
         preview: t.boolean,
         state: nullable(
             t.intersection([
-                t.type({c: t.string}),
+                t.type({c: nullable(t.string)}),
                 t.partial({
                     styles: nullable(t.record(t.string, t.string)),
                 }),

--- a/timApp/modules/fields/js/dropdown-plugin.component.ts
+++ b/timApp/modules/fields/js/dropdown-plugin.component.ts
@@ -212,7 +212,7 @@ export class DropdownPluginComponent
         }
 
         const r = await this.postAnswer<{
-            web: {result: string; error?: string; clear?: boolean};
+            web: {result: string; error?: string};
         }>(params);
 
         if (r.ok) {
@@ -220,7 +220,7 @@ export class DropdownPluginComponent
             this.updateListeners(ChangeType.Saved);
             const data = r.result;
             this.error = data.web.error;
-            if (data.web.clear) {
+            if (this.markup.clearstyles) {
                 this.styles = {};
             }
         } else {

--- a/timApp/modules/fields/js/dropdown-plugin.component.ts
+++ b/timApp/modules/fields/js/dropdown-plugin.component.ts
@@ -23,7 +23,7 @@ import {
     nullable,
     withDefault,
 } from "tim/plugin/attributes";
-import {getFormBehavior, shuffleStrings} from "tim/plugin/util";
+import {getFormBehavior, parseStyles, shuffleStrings} from "tim/plugin/util";
 import {defaultErrorMessage} from "tim/util/utils";
 import {BrowserModule, DomSanitizer} from "@angular/platform-browser";
 import {HttpClient, HttpClientModule} from "@angular/common/http";
@@ -57,7 +57,14 @@ const DropdownAll = t.intersection([
         info: Info,
         markup: DropdownMarkup,
         preview: t.boolean,
-        state: nullable(t.type({c: t.string})),
+        state: nullable(
+            t.intersection([
+                t.type({c: t.string}),
+                t.partial({
+                    styles: nullable(t.record(t.string, t.string)),
+                }),
+            ])
+        ),
     }),
 ]);
 
@@ -84,7 +91,8 @@ const DropdownAll = t.intersection([
                 [(ngModel)]="selectedWord"
                 (ngModelChange)="updateSelection()"
                 [ngClass]="{warnFrame: isUnSaved()}"
-                [disabled]="attrsall['preview']">
+                [disabled]="attrsall['preview']"
+                [ngStyle]="styles">
             <option *ngFor="let item of wordList" [value]="item">{{getItemText(item)}}</option>
         </select>
     </div>
@@ -112,6 +120,7 @@ export class DropdownPluginComponent
     private shuffle?: boolean;
     private changes = false;
     connectionErrorMessage?: string;
+    styles: Record<string, string> = {};
 
     constructor(
         el: ElementRef<HTMLElement>,
@@ -146,6 +155,9 @@ export class DropdownPluginComponent
         this.radio = this.markup.radio;
         if (this.markup.answers) {
             // TODO: Implement showing and hiding the answer browser if it is deemed useful.
+        }
+        if (this.attrsall.state?.styles) {
+            this.styles = parseStyles(this.attrsall.state.styles);
         }
     }
 
@@ -298,6 +310,7 @@ export class DropdownPluginComponent
                     )}`;
                     this.error = message;
                 }
+                this.styles = parseStyles(content.styles);
             }
             this.changes = false;
             this.updateListeners(ChangeType.Saved);

--- a/timApp/modules/fields/js/numericfield-plugin.component.ts
+++ b/timApp/modules/fields/js/numericfield-plugin.component.ts
@@ -23,7 +23,7 @@ import {
     nullable,
     withDefault,
 } from "tim/plugin/attributes";
-import {getFormBehavior} from "tim/plugin/util";
+import {getFormBehavior, parseStyles} from "tim/plugin/util";
 import {defaultErrorMessage, valueOr} from "tim/util/utils";
 import {BrowserModule, DomSanitizer} from "@angular/platform-browser";
 import {HttpClient, HttpClientModule} from "@angular/common/http";
@@ -419,19 +419,8 @@ export class NumericfieldPluginComponent
         );
     }
 
-    /**
-     * Parses "styles" from the plugin answer that were saved by tableForm
-     * For now only backgroundColor is supported
-     * See TODOs at textfield
-     */
     applyStyling(styles: Record<string, string>) {
-        if (Object.keys(styles).length == 0) {
-            this.styles = {};
-            return;
-        }
-        if (styles.backgroundColor) {
-            this.styles.backgroundColor = styles.backgroundColor;
-        }
+        this.styles = parseStyles(styles);
     }
 
     /**

--- a/timApp/modules/fields/js/numericfield-plugin.component.ts
+++ b/timApp/modules/fields/js/numericfield-plugin.component.ts
@@ -258,7 +258,7 @@ export class NumericfieldPluginComponent
         }
         this.initialValue = this.numericvalue;
         if (this.attrsall.state?.styles && !this.markup.ignorestyles) {
-            this.applyStyling(this.attrsall.state.styles);
+            this.styles = parseStyles(this.attrsall.state.styles);
         }
     }
 
@@ -289,7 +289,7 @@ export class NumericfieldPluginComponent
     resetField(): undefined {
         return this.zone.run(() => {
             this.initCode();
-            this.applyStyling({});
+            this.styles = {};
             this.errormessage = undefined;
             this.redAlert = false;
             return undefined;
@@ -319,7 +319,7 @@ export class NumericfieldPluginComponent
                 }
 
                 if (!this.markup.ignorestyles && content.styles) {
-                    this.applyStyling(content.styles);
+                    this.styles = parseStyles(content.styles);
                 }
             }
             this.initialValue = this.numericvalue;
@@ -417,10 +417,6 @@ export class NumericfieldPluginComponent
         return (
             ros === "plaintext" && window.location.pathname.startsWith("/view/")
         );
-    }
-
-    applyStyling(styles: Record<string, string>) {
-        this.styles = parseStyles(styles);
     }
 
     /**
@@ -524,7 +520,7 @@ export class NumericfieldPluginComponent
                 this.saveResponse.saved = true;
             }
             if (this.markup.clearstyles) {
-                this.applyStyling({});
+                this.styles = {};
             }
             this.saveResponse.message = this.errormessage;
             if (this.vctrl && !this.saveCalledExternally) {

--- a/timApp/modules/fields/js/numericfield-plugin.component.ts
+++ b/timApp/modules/fields/js/numericfield-plugin.component.ts
@@ -503,7 +503,6 @@ export class NumericfieldPluginComponent
             web: {
                 result: string;
                 error?: string;
-                clear?: boolean;
                 value: TFieldContent;
             };
         }>(params);
@@ -524,7 +523,7 @@ export class NumericfieldPluginComponent
                 this.redAlert = false;
                 this.saveResponse.saved = true;
             }
-            if (data.web.clear) {
+            if (this.markup.clearstyles) {
                 this.applyStyling({});
             }
             this.saveResponse.message = this.errormessage;

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -540,7 +540,7 @@ export class TextfieldPluginComponent
             params.input.nosave = true;
         }
         const r = await this.postAnswer<{
-            web: {result: string; error?: string; clear?: boolean};
+            web: {result: string; error?: string};
         }>(params);
         this.isRunning = false;
         if (r.ok) {
@@ -554,7 +554,7 @@ export class TextfieldPluginComponent
             this.redAlert = false;
             this.saveResponse.saved = true;
             this.saveResponse.message = this.errormessage;
-            if (data.web.clear) {
+            if (this.markup.clearstyles) {
                 this.applyStyling({});
             }
 

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -23,7 +23,7 @@ import {
     nullable,
     withDefault,
 } from "tim/plugin/attributes";
-import {getFormBehavior} from "tim/plugin/util";
+import {getFormBehavior, parseStyles} from "tim/plugin/util";
 import {defaultErrorMessage, timeout, valueOr} from "tim/util/utils";
 import {BrowserModule, DomSanitizer} from "@angular/platform-browser";
 import {HttpClient, HttpClientModule} from "@angular/common/http";
@@ -462,22 +462,8 @@ export class TextfieldPluginComponent
         return false;
     }
 
-    /**
-     * Parses "styles" from the plugin answer that were saved by tableForm
-     * For now only backgroundColor is supported
-     * TODO: Extend styling for all attributes in timTable's cellStyles?
-     *  For now tableForm is only able to define backgroundColor or textAlign
-     *  Could also define (and import) generic tim-wide inputstyles
-     * TODO: Could also just apply given styles as they are
-     */
     applyStyling(styles: Record<string, string>) {
-        if (!styles || Object.keys(styles).length == 0) {
-            this.styles = {};
-            return;
-        }
-        if (styles.backgroundColor) {
-            this.styles.backgroundColor = styles.backgroundColor;
-        }
+        this.styles = parseStyles(styles);
     }
 
     /**

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -254,7 +254,7 @@ export class TextfieldPluginComponent
             this.initCode();
         }
         if (this.attrsall.state?.styles && !this.markup.ignorestyles) {
-            this.applyStyling(this.attrsall.state.styles);
+            this.styles = parseStyles(this.attrsall.state.styles);
         }
         if (this.markup.textarea && this.markup.autogrow) {
             this.autoGrow();
@@ -292,7 +292,7 @@ export class TextfieldPluginComponent
     resetField(): undefined {
         return this.zone.run(() => {
             this.initCode();
-            this.applyStyling({});
+            this.styles = {};
             this.errormessage = undefined;
             return undefined;
         });
@@ -329,7 +329,7 @@ export class TextfieldPluginComponent
                     this.errormessage = message;
                 }
                 if (!this.markup.ignorestyles) {
-                    this.applyStyling(content.styles);
+                    this.styles = parseStyles(content.styles);
                 }
             }
             this.changes = false;
@@ -462,10 +462,6 @@ export class TextfieldPluginComponent
         return false;
     }
 
-    applyStyling(styles: Record<string, string>) {
-        this.styles = parseStyles(styles);
-    }
-
     /**
      * Method to check grading input type for textfield.
      * Used as e.g. grading checker for hyv | hyl | 1 | 2 | 3 | 4 | 5.
@@ -555,7 +551,7 @@ export class TextfieldPluginComponent
             this.saveResponse.saved = true;
             this.saveResponse.message = this.errormessage;
             if (this.markup.clearstyles) {
-                this.applyStyling({});
+                this.styles = {};
             }
 
             if (this.vctrl && !this.saveCalledExternally) {

--- a/timApp/modules/fields/numericfield.py
+++ b/timApp/modules/fields/numericfield.py
@@ -165,8 +165,6 @@ def answer(args: NumericfieldAnswerModel) -> PluginAnswerResp:
         result["save"] = save
         web["result"] = "saved"
         web["value"] = c
-        if args.markup.clearstyles:
-            web["clear"] = True
 
     return result
 

--- a/timApp/modules/fields/textfield.py
+++ b/timApp/modules/fields/textfield.py
@@ -121,8 +121,6 @@ def answer(args: TextfieldAnswerModel) -> PluginAnswerResp:
                 save = {"c": c, "styles": args.state.styles}
         result["save"] = save
         web["result"] = "saved"
-        if args.markup.clearstyles:
-            web["clear"] = True
 
     return result
 

--- a/timApp/plugin/plugin.py
+++ b/timApp/plugin/plugin.py
@@ -122,10 +122,7 @@ NO_ANSWERBROWSER_PLUGINS = {
     "calendar",
 }
 
-ALLOW_STYLES_PLUGINS = {
-    "textfield",
-    "numericfield",
-}
+ALLOW_STYLES_PLUGINS = {"textfield", "numericfield", "drag", "dropdown"}
 
 WANT_FIELDS = {"csPlugin"}
 

--- a/timApp/static/scripts/tim/plugin/util.ts
+++ b/timApp/static/scripts/tim/plugin/util.ts
@@ -374,3 +374,19 @@ export function inIframe() {
         return true;
     }
 }
+
+/**
+ * Parses "styles" from the plugin answer that were saved by tableForm
+ * For now only backgroundColor is supported
+ * @param styles style object to parse. If not supported, return empty object
+ */
+export function parseStyles(styles: Record<string, string>) {
+    const output: Record<string, string> = {};
+    if (!styles || Object.keys(styles).length == 0) {
+        return output;
+    }
+    if (styles.backgroundColor) {
+        output.backgroundColor = styles.backgroundColor;
+    }
+    return output;
+}


### PR DESCRIPTION
Lisää dragille ja dropdownille tuen styles-arvolle, jolloin niitä voi värjätä tableformin (tai jsrunnerin) kautta

Lisäksi lisää samat väriattribuutit kuin mitä textfield/numericfield käytti jo aiemmin eli

- ignorestyles: kenttä ei värjäydy vaikka styles-arvossa on jotain (jos esim tableFormilla merkitsee vastauksia eikä halua sekoittaa vastaajia), oletus false

- clearstyles: värit katoaa kun vastaaja tekee uuden vastauksen. Normaalisti väri on pysyvä, eli tableformin kautta pysyvä värimerkintä ei katoa vaikka tekee uuden vastauksen. Oletus false

https://timdevs01-3.it.jyu.fi/view/dragdropstyles