### PR TITLE
Enable toggle margin left in DIA-mini style

### DIFF
--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -1477,7 +1477,6 @@ tim-rights-editor {
 }
 
 // Global access from switch-button.component.ts
-// !important needed here to prevent document style from overriding with margin: auto
 .toggle-margin-left {
 
     margin-left: 0;

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -1477,8 +1477,9 @@ tim-rights-editor {
 }
 
 // Global access from switch-button.component.ts
+// !important needed here to prevent document style from overriding with margin: auto
 .toggle-margin-left {
-    margin-left: 0;
+    margin-left: 0 !important;
 }
 
 // Style for translation-tab in parEditor

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -1479,7 +1479,12 @@ tim-rights-editor {
 // Global access from switch-button.component.ts
 // !important needed here to prevent document style from overriding with margin: auto
 .toggle-margin-left {
-    margin-left: 0 !important;
+
+    margin-left: 0;
+
+    .paragraphs {
+        margin-left: 0;
+    }
 }
 
 // Style for translation-tab in parEditor


### PR DESCRIPTION
Applies the `toggle-margin-left` to the main content strip `.paragraphs` with the DIA mini stylesheet so the sidebarmenu's content align button works.