### PR TITLE
Qst dialogresult

### DIFF
--- a/timApp/static/scripts/tim/document/question/questions.ts
+++ b/timApp/static/scripts/tim/document/question/questions.ts
@@ -9,6 +9,7 @@ import {getMinimalUnbrokenSelection} from "tim/document/editing/unbrokenSelectio
 import {to2} from "tim/util/utils";
 import {documentglobals} from "tim/util/globals";
 import {$timeout} from "tim/util/ngimport";
+import {IQuestionDialogResult} from "tim/document/question/question-edit-dialog.component";
 import {ViewCtrl} from "../viewctrl";
 
 export class QuestionHandler {
@@ -54,18 +55,22 @@ export class QuestionHandler {
         if (!result.ok || !result.result) {
             return;
         }
-        if (result.result.type === "points") {
+        await this.handleQstEditResult(result.result, par);
+    }
+
+    async handleQstEditResult(result: IQuestionDialogResult, par: ParContext) {
+        if (result.type === "points") {
             throw new Error("unexpected result type from dialog");
         }
         const position: EditPosition = {
             type: EditType.Edit,
             pars: getMinimalUnbrokenSelection(par, par),
         };
-        if (result.result.deleted) {
+        if (result.deleted) {
             this.viewctrl.editingHandler.handleDelete(position);
         } else {
             await this.viewctrl.editingHandler.addSavedParToDom(
-                result.result.data,
+                result.data,
                 position
             );
         }

--- a/timApp/static/scripts/tim/plugin/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst.component.ts
@@ -6,6 +6,7 @@ import {
     DoBootstrap,
     ElementRef,
     NgModule,
+    NgZone,
 } from "@angular/core";
 import {FormsModule} from "@angular/forms";
 import {HttpClient, HttpClientModule} from "@angular/common/http";
@@ -120,6 +121,7 @@ export class QstComponent
         el: ElementRef<HTMLElement>,
         http: HttpClient,
         domSanitizer: DomSanitizer,
+        private zone: NgZone,
         private cdr: ChangeDetectorRef
     ) {
         super(el, http, domSanitizer);
@@ -267,10 +269,12 @@ export class QstComponent
                 this.vctrl.lectureCtrl.lastQuestion = result.result.question;
             }
             if (result.result.editResult) {
-                this.vctrl.questionHandler.handleQstEditResult(
-                    result.result.editResult,
-                    par
-                );
+                this.zone.runOutsideAngular(() => {
+                    this.vctrl.questionHandler.handleQstEditResult(
+                        result.result.editResult!,
+                        par
+                    );
+                });
             }
         }
     }

--- a/timApp/static/scripts/tim/plugin/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst.component.ts
@@ -30,6 +30,7 @@ import {vctrlInstance} from "../document/viewctrlinstance";
 import {PurifyModule} from "../util/purify.module";
 import {showQuestionAskDialog} from "../lecture/showLectureDialogs";
 import {pluginMap} from "../main";
+import {ParContext} from "../document/structure/parContext";
 import {GenericPluginMarkup, getTopLevelFields, nullable} from "./attributes";
 import {AngularPluginBase} from "./angular-plugin-base.directive";
 
@@ -250,19 +251,27 @@ export class QstComponent
     }
 
     questionClicked() {
-        this.showQuestionNew(this.getPar()!.originalPar.id);
+        this.showQuestionNew(this.getPar()!);
     }
 
-    private async showQuestionNew(parId: string) {
+    private async showQuestionNew(par: ParContext) {
         const result = await to2(
             showQuestionAskDialog({
                 docId: this.vctrl.docId,
-                parId: parId,
+                parId: par.originalPar.id,
                 showAsk: this.vctrl.lectureCtrl.lectureSettings.inLecture,
             })
         );
         if (result.ok) {
-            this.vctrl.lectureCtrl.lastQuestion = result.result;
+            if (result.result.question) {
+                this.vctrl.lectureCtrl.lastQuestion = result.result.question;
+            }
+            if (result.result.editResult) {
+                this.vctrl.questionHandler.handleQstEditResult(
+                    result.result.editResult,
+                    par
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Päivittää qst-kappaletta ilman tarvetta sivun uudelleenlautukselle vaikka muutokset tehtäisiin qst-pluginin (?-merkki) kautta. Tällä hetkellä ne päivittyvät heti vain jos qst:n muokkaus tehdään "edit question"-painikkeen kautta

https://timdevs01-3.it.jyu.fi/lecture/qst-lecture

vs 

https://tim.jyu.fi/lecture/users/sijualle/kokeiluja/qstlec