### PR TITLE
Table savefocus

### DIFF
--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -246,7 +246,7 @@ class TableFormHtmlModel(
 
     def get_browser_json(self) -> dict:
         r = super().get_browser_json()
-        if self.markup.open:
+        if self.markup.open and self.markup.table is not False:
             doc_id = TaskId.parse_doc_id(self.taskID)
             d = get_doc_or_abort(doc_id)
             user = User.get_by_name(self.current_user_id)

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -1031,10 +1031,6 @@ export class TableFormComponent
         if (taskId == undefined) {
             return;
         }
-        const timTable = this.getTimTable();
-        if (timTable == null) {
-            return;
-        }
 
         const reportParams = {
             // TODO: support for relevant attrs (realnames, usernames, emails...)
@@ -1053,46 +1049,49 @@ export class TableFormComponent
             reportFilter: this.markup.reportFilter,
         };
         let filterParams;
-        const selUsers = timTable.getCheckedRows(0, false);
-        const users = TableFormComponent.makeUserArray(
-            selUsers,
-            userNameColIndex
-        );
+        const timTable = this.getTimTable();
+        if (timTable != null) {
+            const selUsers = timTable.getCheckedRows(0, false);
+            const users = TableFormComponent.makeUserArray(
+                selUsers,
+                userNameColIndex
+            );
 
-        if (selUsers.length > 0) {
-            filterParams = {userFilter: users};
-        } else {
-            const filterFields: string[] = [];
-            const filterValues: string[] = [];
+            if (selUsers.length > 0) {
+                filterParams = {userFilter: users};
+            } else {
+                const filterFields: string[] = [];
+                const filterValues: string[] = [];
 
-            const xOffset = memberShipEndColIndex + 1;
+                const xOffset = memberShipEndColIndex + 1;
 
-            timTable.filters.forEach((value, index) => {
-                if (!value) {
-                    return;
-                }
-                switch (index) {
-                    case realNameColIndex:
-                        filterFields.push("realname");
-                        break;
-                    case userNameColIndex:
-                        filterFields.push("username");
-                        break;
-                    case emailColIndex:
-                        filterFields.push("email");
-                        break;
-                    case memberShipAddColIndex:
-                        filterFields.push("membership_add");
-                        break;
-                    case memberShipEndColIndex:
-                        filterFields.push("membership_end");
-                        break;
-                    default:
-                        filterFields.push(this.fields[index - xOffset]);
-                }
-                filterValues.push(value);
-            });
-            filterParams = {filterFields, filterValues};
+                timTable.filters.forEach((value, index) => {
+                    if (!value) {
+                        return;
+                    }
+                    switch (index) {
+                        case realNameColIndex:
+                            filterFields.push("realname");
+                            break;
+                        case userNameColIndex:
+                            filterFields.push("username");
+                            break;
+                        case emailColIndex:
+                            filterFields.push("email");
+                            break;
+                        case memberShipAddColIndex:
+                            filterFields.push("membership_add");
+                            break;
+                        case memberShipEndColIndex:
+                            filterFields.push("membership_end");
+                            break;
+                        default:
+                            filterFields.push(this.fields[index - xOffset]);
+                    }
+                    filterValues.push(value);
+                });
+                filterParams = {filterFields, filterValues};
+            }
         }
 
         const win = window.open(

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -564,7 +564,7 @@ export class TableFormComponent
             }
         }
         if (this.markup.showToolbar !== undefined) {
-            this.data.hide.toolbar = this.markup.showToolbar;
+            this.data.hide.toolbar = !this.markup.showToolbar;
         }
 
         this.userfilter = "";

--- a/timApp/static/scripts/tim/plugin/timTable/tim-table-editor-toolbar-dialog.component.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/tim-table-editor-toolbar-dialog.component.ts
@@ -182,10 +182,12 @@ export class TimTableEditorToolbarDialogComponent extends AngularDialogComponent
     /**
      * Hides the toolbar and removes the instance.
      */
-    public hideThis() {
+    public hideThis(keepEditorOpen?: boolean) {
         this.close();
         setToolbarInstance(undefined);
-        this.callbacks.closeEditor(false);
+        if (!keepEditorOpen) {
+            this.callbacks.closeEditor(false);
+        }
     }
 
     public hideIfActiveTable(table: TimTableComponent) {

--- a/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
@@ -1188,6 +1188,10 @@ export class TimTableComponent
             if (!this.eventListenersActive) {
                 return;
             } // No need to look anything when already inactive
+            if (this.currentCell?.editorOpen) {
+                return;
+            }
+
             const target = e.target;
 
             if (target) {

--- a/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
@@ -2317,11 +2317,17 @@ export class TimTableComponent
     }
 
     handleClickCancelSmallEditor() {
+        if (this.currentCell?.editorOpen) {
+            return;
+        }
         this.closeSmallEditor();
         this.c();
     }
 
     async handleClickAcceptSmallEditor() {
+        if (this.currentCell?.editorOpen) {
+            return;
+        }
         await this.saveAndCloseSmallEditor();
         this.c();
     }

--- a/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
@@ -4585,7 +4585,7 @@ export class TimTableComponent
         if (userChange && this.data.nonUserSpecific) {
             return false;
         }
-        return this.edited;
+        return this.edited || this.currentCell != undefined;
     }
 
     // save: () => Promise<{saved: boolean, message: (string | undefined)}>;

--- a/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
@@ -1170,7 +1170,7 @@ export class TimTableComponent
         return !!this.currentCell;
     }
 
-    private onClick(e: OnClickArg) {
+    private async onClick(e: OnClickArg) {
         if (this.mouseInTable) {
             if (
                 this.isInEditMode() &&
@@ -1204,7 +1204,7 @@ export class TimTableComponent
                     return;
                 }
                 this.activeCell = undefined;
-                this.saveCurrentCell();
+                await this.saveCurrentCell();
                 this.c();
 
                 // Do not hide the toolbar if the user clicks on another TimTable

--- a/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
@@ -1199,8 +1199,8 @@ export class TimTableComponent
                 if ($(target).parents(".timTableEditor").length > 0) {
                     return;
                 }
-
                 this.activeCell = undefined;
+                this.saveCurrentCell();
                 this.c();
 
                 // Do not hide the toolbar if the user clicks on another TimTable

--- a/timApp/static/scripts/tim/plugin/timTable/toolbarUtils.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/toolbarUtils.ts
@@ -90,6 +90,6 @@ export async function showTableEditorToolbar(p: ITimTableEditorToolbarParams) {
 
 export function hideToolbar(closingTable: TimTableComponent) {
     if (instance) {
-        instance.hideThis();
+        instance.hideThis(instance.activeTable != closingTable);
     }
 }

--- a/timApp/tests/browser/test_tableform.py
+++ b/timApp/tests/browser/test_tableform.py
@@ -1,0 +1,49 @@
+from selenium.webdriver import ActionChains, Keys
+
+from timApp.tests.browser.browsertest import BrowserTest
+
+
+class TableFormTest(BrowserTest):
+    def test_input_saving_and_canceling(self):
+        self.login_browser_quick_test1()
+        self.login_test1()
+        d = self.create_doc(
+            initial_par="""
+``` {#text1 plugin="textfield"}
+```
+``` {#tableForm plugin="tableForm"}
+showInView: true
+groups: []
+fields:
+ - text1
+autosave: true
+```
+"""
+        )
+        self.goto_document(d)
+        td = self.find_element_avoid_staleness("#tableForm tbody td:nth-of-type(6)")
+        td.click()
+        td.click()
+        ActionChains(self.drv).send_keys("1").perform()
+        ActionChains(self.drv).send_keys(Keys.ENTER).perform()
+        ActionChains(self.drv).send_keys("2").perform()
+        self.find_element("#tableForm .buttonAcceptEdit").click()
+        ActionChains(self.drv).send_keys("3").perform()
+        ActionChains(self.drv).send_keys(Keys.ESCAPE).perform()
+        td.click()
+        self.find_element_avoid_staleness("#tableForm .buttonCloseSmallEditor").click()
+        td.click()
+        ActionChains(self.drv).send_keys("4").perform()
+        self.get_uninteractable_element().click()
+        self.wait_until_hidden("tableform tim-loading")
+        answers = self.get_task_answers(f"{d.id}.text1", self.test_user_1)
+        self.assertEqual(len(answers), 3)
+        self.assertEqual(
+            answers[0]["content"], '{"c": "4"}'
+        )  # editor closed by clicking outside the table
+        self.assertEqual(
+            answers[1]["content"], '{"c": "2"}'
+        )  # editor accepted with ok icon
+        self.assertEqual(
+            answers[2]["content"], '{"c": "1"}'
+        )  # editor accepted with enter button

--- a/timApp/tests/browser/test_timtable.py
+++ b/timApp/tests/browser/test_timtable.py
@@ -875,3 +875,40 @@ table:
         self.wait_until_hidden("#tabletask .csRunMenu span")
         td = self.find_element_avoid_staleness("#tabletask td")
         self.assertEqual("Hello", td.text)
+
+    def test_focus_callbacks(self):
+        # Ensure toolbar closing callbacks make one and only one autosave
+        self.login_browser_quick_test1()
+        self.login_test1()
+        d = self.create_doc(
+            initial_par="""
+``` {#tableForm plugin="tableForm"}
+showInView: true
+fields:
+ - text1
+groups: []
+showToolbar: false
+```
+``` {plugin="timTable" #tabletask}
+task: true
+autosave: true
+table:
+    countRow: 1
+    countCol: 1
+    rows:
+      - row:
+        - cell: ''
+```
+        """
+        )
+        self.goto_document(d)
+        td = self.find_element_avoid_staleness("#tabletask td")
+        td.click()
+        td.click()
+        ActionChains(self.drv).send_keys("Hello").perform()
+        td = self.find_element_avoid_staleness("#tableForm tbody td:nth-of-type(6)")
+        td.click()
+        self.wait_until_hidden("tim-table-editor-toolbar-dialog")
+        self.wait_until_present_and_vis("answerbrowser .prevAnswer")
+        answers = self.get_task_answers(f"{d.id}.tabletask", self.test_user_1)
+        self.assertEqual(len(answers), 1)


### PR DESCRIPTION
https://timdevs01-3.it.jyu.fi/view/tableform_save

Muuttaa timTablen solun tallennuslogiikkaa niin että solun muutokset hyväksytään automaattisesti mikäli pieni editori suljetaan siirtämällä focus johonkin toiseen elementtiin sivulla. Tämä ei ole yhtä vahva autosavelogiikka kuin textfieldillä, jossa kenttä tallennetaan esim osoiteriville siirtymisestä.

Lisäksi pieni optimointi sille ettei tableFormissa haeta rivejä turhaan mikäli taulukkoa ei ole vaan plugin on vain reporttipainiketta varten.