### PR TITLE
Fix rare encoding bug in MD to HTML parsing

### DIFF
--- a/timApp/markdown/markdownconverter.py
+++ b/timApp/markdown/markdownconverter.py
@@ -757,7 +757,7 @@ def insert_heading_numbers(
                 heading_format,
                 initial_counts=initial_heading_counts,
             )
-    final_html = etree.tostring(tree)
+    final_html = etree.tostring(tree, encoding="utf-8")
     return final_html
 
 


### PR DESCRIPTION
Fix rare encoding bug in MD to HTML parsing by changing lxml's etree.tostring()'s encoding scheme from default ASCII to UTF-8.

The bug has already been reported at <https://bugs.launchpad.net/lxml/+bug/1945048>, but it will likely not be resolved any time soon.