### PR TITLE
Drawio setdata

### DIFF
--- a/timApp/modules/cs/js/jsframe.ts
+++ b/timApp/modules/cs/js/jsframe.ts
@@ -783,7 +783,7 @@ export class JsframeComponent
         }
 
         this.iframeload.resolve();
-        if (this.markup.initListener && !this.attrsall.preview) {
+        if (this.markup.initListener) {
             this.addListener();
         }
     }

--- a/timApp/modules/cs/js/jsframe.ts
+++ b/timApp/modules/cs/js/jsframe.ts
@@ -137,7 +137,8 @@ type MessageFromFrame =
     | {
           msg: "frameInited" | "frameClosed";
           fullscreen: boolean;
-      };
+      }
+    | {msg: "Inited"};
 
 /**
  * Returns the given data (un)wrapped so that there is exactly one layer of "c".
@@ -482,7 +483,9 @@ export class JsframeComponent
         } else {
             let html = this.markup.srchtml ?? "";
             html = html.replace("</body>", communicationJS + "\n</body>");
-            html = html.replace("// INITDATA", this.initData);
+            if (!this.isDrawio()) {
+                html = html.replace("// INITDATA", this.initData);
+            }
             // const datasrc = btoa(html);
             const type = this.attrsall.markup.type;
             const datasrc = this.b64EncodeUnicode(
@@ -753,6 +756,10 @@ export class JsframeComponent
                     document.body.classList.remove("fullscreen-frame");
                     this.c();
                 }
+            }
+            if (d.msg === "Inited" && this.isDrawio()) {
+                const data = this.getDataFromMarkup();
+                this.setData(data);
             }
         };
         const f = this.getFrame();

--- a/timApp/modules/cs/jsframe.py
+++ b/timApp/modules/cs/jsframe.py
@@ -12,6 +12,7 @@ JSREADYOPTIONS = {}
 
 class JSframe(Language):
     ttype = "jsframe"
+    load_original_data = True
 
     def get_default_before_open(self):
         return '<div class="defBeforeOpen"><p>Open JS-frame</p></div>'
@@ -113,12 +114,13 @@ class JSframe(Language):
 
         src = src.replace("##HOST_URL##", ma.get("hosturl", os.environ["TIM_HOST"]))
 
-        original_data = get_by_id(ma, "data", None)
-        if original_data:
-            src = src.replace(
-                "//ORIGINALDATA",
-                self.jsobject + "originalData = " + json.dumps(original_data) + ";",
-            )
+        if self.load_original_data:
+            original_data = get_by_id(ma, "data", None)
+            if original_data:
+                src = src.replace(
+                    "//ORIGINALDATA",
+                    self.jsobject + "originalData = " + json.dumps(original_data) + ";",
+                )
 
         javascript = get_by_id(ma, "javascript", None)
         if javascript:
@@ -185,6 +187,7 @@ SVGTEXT_PROG = re.compile(">([^>]*)</text")
 
 class DrawIO(JSframe):
     ttype = "drawio"
+    load_original_data = False
 
     def modify_query(self):
         """

--- a/timApp/modules/cs/jsframehtml/simpleDrawIO.html
+++ b/timApp/modules/cs/jsframehtml/simpleDrawIO.html
@@ -237,10 +237,7 @@
             }
         };
 
-        var globaldata = null;
         window.onload = function () {
-            if (TIMJS.initData) globaldata = TIMJS.initData;
-            setData(globaldata);
             load();
         }
 
@@ -255,7 +252,7 @@
             if (!data) {
                 return;
             }
-            if (!data.c || Object.entries(data.c).length === 0) {
+            if (!data.c) {
                 // "undo" call in plugin might call setData with undefined c so we need separate check
                 document.getElementById('diagram').innerHTML = null;
                 return;


### PR DESCRIPTION
Muokkaa drawion latauslogiikkaa niin että iframen html:ssä ei viedä piirrosdataa, sillä esim chrome tuntuu luovuttavan jos iframen src-attribuutti on liian pitkä. Sen sijaan piirrosdata viestitään iframelle vasta sen käynnistyttyä

https://timdevs01-3.it.jyu.fi/view/drawio-image