### PR TITLE
Accessfield invalid

### DIFF
--- a/timApp/auth/accesshelper.py
+++ b/timApp/auth/accesshelper.py
@@ -740,7 +740,11 @@ def check_access_from_field(
     tid = TaskId.parse(field_to_check, require_doc_id=False)
     if not tid.doc_id:
         tid = TaskId.parse(str(task_id.doc_id) + "." + field_to_check)
-    prev = current_user.get_answers_for_task(tid.doc_task).first()
+    prev = (
+        current_user.answers.filter_by(task_id=tid.doc_task, valid=True)
+        .order_by(Answer.id.desc())
+        .first()
+    )
     if not prev:
         return True
     try:

--- a/timApp/tests/server/test_jsrunner.py
+++ b/timApp/tests/server/test_jsrunner.py
@@ -1359,6 +1359,33 @@ tools.println(tools.getValue("t2.count"));
             },
         )
 
+    def test_answerlimit_override(self):
+        self.login_test1()
+        d = self.create_jsrun(
+            """
+groups: []
+fields:
+ - counter
+program: |!!
+let val = tools.getDouble('counter')
+tools.setDouble('counter',val+1)
+!!
+        """
+        )
+        d.document.add_text(
+            """
+``` {#counter plugin="numericfield"}
+answerLimit: 0
+```
+        """
+        )
+        self.post_answer("numericfield", f"{d.id}.counter", user_input={"c": "3"})
+        self.do_jsrun(d)
+        self.post_answer("numericfield", f"{d.id}.counter", user_input={"c": "4"})
+        self.do_jsrun(d)
+        # Tasks with answerlimit 0 are currently used as fields where valid input can only be done via jsrunner
+        self.verify_answer_content(f"{d.id}.counter", "c", 2, self.test_user_1, 4)
+
 
 class JsRunnerGroupTest(JsRunnerTestBase):
     def test_jsrunner_group(self):

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -2387,15 +2387,9 @@ accessField:
         resp = self.post_answer(
             "textfield", f"{d.id}.question", user_input={"c": "testuser2@d.2"}
         )
-        self.assertEqual(
-            {
-                "web": {"result": "saved"},
-                "savedNew": 5,
-                "valid": False,
-                "error": access_error_default,
-            },
-            resp,
-        )
+        self.assertEqual(access_error_default, resp["error"])
+        self.assertFalse(resp["valid"])
+        self.assertEqual(3, len(self.get_task_answers(f"{d.id}.question")))
         # int 1 is not valid answer via cbfield answer route, but might be set by jsrunner
         save_answer(
             [self.test_user_2],
@@ -2409,14 +2403,10 @@ accessField:
             f"{d.id}.question_ext_accessfield",
             user_input={"c": "testuser2@d_ext"},
         )
+        self.assertEqual("You already locked your access to this task", resp["error"])
+        self.assertFalse(resp["valid"])
         self.assertEqual(
-            {
-                "web": {"result": "saved"},
-                "savedNew": 7,
-                "valid": False,
-                "error": "You already locked your access to this task",
-            },
-            resp,
+            1, len(self.get_task_answers(f"{d.id}.question_ext_accessfield"))
         )
 
     def test_accessfield_invalid_answer(self):
@@ -2449,26 +2439,13 @@ accessField:
         resp = self.post_answer(
             "textfield", f"{d.id}.question", user_input={"c": "fail"}
         )
-        self.assertEqual(
-            {
-                "web": {"result": "saved"},
-                "savedNew": 4,
-                "valid": False,
-                "error": access_error_default,
-            },
-            resp,
-        )
+        self.assertEqual(access_error_default, resp["error"])
+        self.assertFalse(resp["valid"])
         self.post_answer("textfield", f"{d.id}.access", user_input={"c": "0"})
         # latest invalid answer 0 on access source does not override valid answer 1
         resp = self.post_answer(
             "textfield", f"{d.id}.question", user_input={"c": "fail again"}
         )
-        self.assertEqual(
-            {
-                "web": {"result": "saved"},
-                "savedNew": 6,
-                "valid": False,
-                "error": access_error_default,
-            },
-            resp,
-        )
+        self.assertEqual(access_error_default, resp["error"])
+        self.assertFalse(resp["valid"])
+        self.assertEqual(3, len(self.get_task_answers(f"{d.id}.question")))


### PR DESCRIPTION
Muuttaa accessFieldiä (=tehtävän lukitseminen toisen tehtävän vastauksen avulla) niin että lukitsevasta kentästä tarkistetaan vain validit vastaukset.

https://timdevs01-3.it.jyu.fi/view/accessfield_points

vrt

https://tim.jyu.fi/view/users/sijualle/kokeiluja/accessfield_points

Ylin checkbox on accessField, ja sen validia arvoa ei pitäisi voida muuttaa muulla kuin erikseen tarjotuilla jsrunnereilla.

Lisäksi testi sille että answerLimit 0 voidaan ohittaa jsrunnerilla. Myöhemmin tarvinnee jonkun järkevämmän tavan tehdä kenttä jonka syöte saadaan vain opettajan tarjoamien jsrunnerien kautta, mutta tällä hetkellä tuotannossa on pari kurssia joiden tehtävissä nojataan tuon kikan varaan.