### PR TITLE
Hide Velp menu when printing the document

### DIFF
--- a/timApp/static/templates/velpSelection.html
+++ b/timApp/static/templates/velpSelection.html
@@ -1,4 +1,4 @@
-<div  tim-draggable-fixed="" class="velpFixed" save="%%PAGEID%%velpMenu" click="true" caption="Velp menu" id="velpSelection">
+<div  tim-draggable-fixed="" class="velpFixed hidden-print" save="%%PAGEID%%velpMenu" click="true" caption="Velp menu" id="velpSelection">
   <div class="velpMenu draggable-content" >
 
     <uib-tabset active="$ctrl.active" class="velpFill">


### PR DESCRIPTION
Lisää Velp menun templateen .hidden-print bootstrap-tyylin, joka piilottaa Velp menun näkyvistä dokumenttia tulostaessa.