### PR TITLE
Update global and invalid answer browsing

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1714,14 +1714,16 @@ def get_answers(task_id: str, user_id: int) -> Response:
         raise RouteException(str(e))
     d = get_doc_or_abort(tid.doc_id)
     curr_user = get_current_user_object()
+    user_answers: list[Answer]
     if tid.is_global:
         verify_view_access(d)
         user_context = user_context_with_logged_in(curr_user)
-        user_answers = (
+        aq = (
             Answer.query.filter_by(task_id=tid.doc_task)
             .order_by(Answer.id.desc())
-            .all()
+            .first()
         )
+        user_answers = [aq] if aq else []
         user = curr_user
     else:
         user = User.get_by_id(user_id)
@@ -1736,7 +1738,7 @@ def get_answers(task_id: str, user_id: int) -> Response:
 
         elif d.document.get_settings().get("need_view_for_answers", False):
             verify_view_access(d)
-        user_answers: list[Answer] = user.get_answers_for_task(tid.doc_task).all()
+        user_answers = user.get_answers_for_task(tid.doc_task).all()
         user_context = user_context_with_logged_in(user)
     try:
         p = find_plugin_from_document(d.document, tid, user_context, default_view_ctx)

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -12,7 +12,7 @@ from flask import request
 from marshmallow import validates_schema, ValidationError
 from marshmallow.utils import missing
 from sqlalchemy import func
-from sqlalchemy.orm import lazyload
+from sqlalchemy.orm import lazyload, joinedload
 from werkzeug.exceptions import NotFound
 
 from timApp.answer.answer import Answer
@@ -1721,6 +1721,7 @@ def get_answers(task_id: str, user_id: int) -> Response:
         aq = (
             Answer.query.filter_by(task_id=tid.doc_task)
             .order_by(Answer.id.desc())
+            .options(joinedload(Answer.users_all))
             .first()
         )
         user_answers = [aq] if aq else []

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1718,13 +1718,12 @@ def get_answers(task_id: str, user_id: int) -> Response:
     if tid.is_global:
         verify_view_access(d)
         user_context = user_context_with_logged_in(curr_user)
-        aq = (
+        user_answers = (
             Answer.query.filter_by(task_id=tid.doc_task)
             .order_by(Answer.id.desc())
             .options(joinedload(Answer.users_all))
-            .first()
+            .all()
         )
-        user_answers = [aq] if aq else []
         user = curr_user
     else:
         user = User.get_by_id(user_id)

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1713,21 +1713,31 @@ def get_answers(task_id: str, user_id: int) -> Response:
     except PluginException as e:
         raise RouteException(str(e))
     d = get_doc_or_abort(tid.doc_id)
-    user = User.get_by_id(user_id)
-    if user is None:
-        raise RouteException("Non-existent user")
     curr_user = get_current_user_object()
-    if user_id != get_current_user_id():
-        if not verify_seeanswers_access(d, require=False):
-            if not is_peerreview_enabled(d):
-                raise AccessDenied()
-            if not has_review_access(d, curr_user, None, user):
-                raise AccessDenied()
-
-    elif d.document.get_settings().get("need_view_for_answers", False):
+    if tid.is_global:
         verify_view_access(d)
-    user_answers: list[Answer] = user.get_answers_for_task(tid.doc_task).all()
-    user_context = user_context_with_logged_in(user)
+        user_context = user_context_with_logged_in(curr_user)
+        user_answers = (
+            Answer.query.filter_by(task_id=tid.doc_task)
+            .order_by(Answer.id.desc())
+            .all()
+        )
+        user = curr_user
+    else:
+        user = User.get_by_id(user_id)
+        if user is None:
+            raise RouteException("Non-existent user")
+        if user_id != get_current_user_id():
+            if not verify_seeanswers_access(d, require=False):
+                if not is_peerreview_enabled(d):
+                    raise AccessDenied()
+                if not has_review_access(d, curr_user, None, user):
+                    raise AccessDenied()
+
+        elif d.document.get_settings().get("need_view_for_answers", False):
+            verify_view_access(d)
+        user_answers: list[Answer] = user.get_answers_for_task(tid.doc_task).all()
+        user_context = user_context_with_logged_in(user)
     try:
         p = find_plugin_from_document(d.document, tid, user_context, default_view_ctx)
     except TaskNotFoundException:

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7822,6 +7822,22 @@
           <context context-type="linenumber">122,123</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2676706401198603854" datatype="html">
+        <source> Showing answers from all users </source>
+        <target state="translated"> Näytetään vastaukset kaikilta käyttäjiltä </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5909030173248328323" datatype="html">
+        <source>(no answers)</source>
+        <target state="translated">(ei vastauksia)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">85,86</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7838,6 +7838,22 @@
           <context context-type="linenumber">85,86</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8674199162420664562" datatype="html">
+        <source>(no valid answers from the selected user)</source>
+        <target state="translated">(ei valideja vastauksia valitulta käyttäjältä)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3893232156030891915" datatype="html">
+        <source>(no valid answers)</source>
+        <target state="translated">(ei valideja vastauksia)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7728,6 +7728,22 @@
           <context context-type="linenumber">85,86</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8674199162420664562" datatype="html">
+        <source>(no valid answers from the selected user)</source>
+        <target state="translated">(inga giltiga svar från den valda användaren)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3893232156030891915" datatype="html">
+        <source>(no valid answers)</source>
+        <target state="translated">(inga giltiga svar)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7190,7 +7190,7 @@
       </trans-unit>
       <trans-unit id="3548964054422536140" datatype="html">
         <source>Unlock task. You will have <x id="INTERPOLATION" equiv-text="{{accessDuration}}"/> seconds to answer to this task.</source>
-        <target state="translated"> Lås upp uppgift. Du kommer att ha <x id="INTERPOLATION" equiv-text="{{accessDuration}}"/> sekunder på dig att svara på denna uppgift.</target>
+        <target state="translated">Lås upp uppgift. Du kommer att ha <x id="INTERPOLATION" equiv-text="{{accessDuration}}"/> sekunder på dig att svara på denna uppgift.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/plugin-loader.component.ts</context>
           <context context-type="linenumber">85,86</context>
@@ -7198,7 +7198,7 @@
       </trans-unit>
       <trans-unit id="7716919100863031420" datatype="html">
         <source>Unlock task</source>
-        <target state="translated">Lås upp uppgift.</target>
+        <target state="translated">Lås upp uppgift</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/plugin-loader.component.ts</context>
           <context context-type="linenumber">86</context>
@@ -7710,6 +7710,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/templates/answerBrowser.html</context>
           <context context-type="linenumber">122,123</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2676706401198603854" datatype="html">
+        <source> Showing answers from all users </source>
+        <target state="translated"> Visar svar från alla användare </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5909030173248328323" datatype="html">
+        <source>(no answers)</source>
+        <target state="translated">(inga svar)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">85,86</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -110,7 +110,7 @@ export type TFieldContent = t.TypeOf<typeof FieldContent>;
        <textarea
                [rows]="rows"
                *ngIf="isTextArea()"
-               class="form-control textarea"
+               class="textarea"
                [(ngModel)]="userword"
                [ngModelOptions]="{standalone: true}"
                (blur)="autoSave()"

--- a/timApp/plugin/pluginControl.py
+++ b/timApp/plugin/pluginControl.py
@@ -584,7 +584,7 @@ def pluginify(
             plugin.values.pop("modelAnswer", None)
             if not plugin.task_id:
                 continue
-            if plugin.task_id.is_global:
+            if plugin.task_id.is_global and not custom_answer:
                 glb_task_ids.append(plugin.task_id)
                 glb_plugins_to_change.append(plugin)
             elif plugin.known.useCurrentUser and user_ctx.is_different:

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -155,8 +155,8 @@ export class AnswerBrowserComponent
     @Input() public taskId!: TaskId;
     @ViewChild("modelAnswerDiv") modelAnswerRef?: ElementRef<HTMLDivElement>;
     @ViewChild("feedback") feedBackElement?: ElementRef<HTMLDivElement>;
-    loading: number;
-    updating = false;
+    loading: number; // Answerbrowser is fetching data
+    updating = false; // Plugin html is reloading
     viewctrl!: Require<ViewCtrl>;
     user: IUser | undefined;
     private fetchedUser: IUser | undefined;

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -326,7 +326,7 @@ export class AnswerBrowserComponent
         // Answer changes are handled by viewctrl, so don't bother querying them here
         // TODO: Make a route to handle getAnswers on global task. Currently global task has its' answerBrowser
         //  always hidden and queries as they are now do not handle global task correctly, causing useless plugin update
-        if (!this.formMode && !this.isGlobal()) {
+        if (!this.formMode) {
             const answs = await this.getAnswers();
             if (answs && answs.length > 0) {
                 this.answers = answs;
@@ -335,7 +335,9 @@ export class AnswerBrowserComponent
                     this.handleAnswerFetch(this.answers);
                 }
             }
-            await this.checkUsers(); // load users, answers have already been loaded for the currently selected user
+            if (!this.isGlobal()) {
+                await this.checkUsers(); // load users, answers have already been loaded for the currently selected user
+            }
             const el = this.loader.loaderElement;
             // Lazily wait before loading users. Allow tapping on plugin or the loader
             // (in case the plugin has iframes that capture events)
@@ -928,8 +930,7 @@ export class AnswerBrowserComponent
                     : undefined,
                 saveTeacher:
                     this.saveTeacher ||
-                    (this.viewctrl.teacherMode &&
-                        (this.loader.isInFormMode() || this.isGlobal())), // TODO: Check if correct
+                    (this.viewctrl.teacherMode && this.loader.isInFormMode()), // TODO: Check if correct
                 points: this.points,
                 giveCustomPoints: this.giveCustomPoints,
                 userId: userId,

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -83,8 +83,8 @@ import {HttpClient, HttpClientModule} from "@angular/common/http";
  * - if globalField:
  *     - pick the answer from anybody (wins useCurrentUser)
  *     - save to current user
- *     - use hidden answerBrowser without changing users
- *     - TODO: if hideBrowser: false, then show browser
+ *     - show answers from everyone, never change user
+ *     - if hideBrowser, then save teacher's fix on by default
  *
  */
 
@@ -325,8 +325,6 @@ export class AnswerBrowserComponent
 
         // If task is in form_mode, only last (already loaded) answer should matter.
         // Answer changes are handled by viewctrl, so don't bother querying them here
-        // TODO: Make a route to handle getAnswers on global task. Currently global task has its' answerBrowser
-        //  always hidden and queries as they are now do not handle global task correctly, causing useless plugin update
         if (!this.formMode) {
             const answs = await this.getAnswers();
             if (answs && answs.length > 0) {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -156,6 +156,7 @@ export class AnswerBrowserComponent
     @ViewChild("modelAnswerDiv") modelAnswerRef?: ElementRef<HTMLDivElement>;
     @ViewChild("feedback") feedBackElement?: ElementRef<HTMLDivElement>;
     loading: number;
+    updating = false;
     viewctrl!: Require<ViewCtrl>;
     user: IUser | undefined;
     private fetchedUser: IUser | undefined;
@@ -1181,6 +1182,7 @@ export class AnswerBrowserComponent
     }
 
     private async handleAnswerFetch(data: IAnswer[], newSelectedId?: number) {
+        this.updating = true;
         if (
             (data.length > 0 &&
                 (this.hasUserChanged() ||
@@ -1213,6 +1215,7 @@ export class AnswerBrowserComponent
             }
             await this.updateFilteredAndSetNewest();
         }
+        this.updating = false;
         this.cdr.detectChanges();
     }
 

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -156,6 +156,7 @@ export class AnswerBrowserComponent
     @ViewChild("modelAnswerDiv") modelAnswerRef?: ElementRef<HTMLDivElement>;
     @ViewChild("feedback") feedBackElement?: ElementRef<HTMLDivElement>;
     loading: number;
+    updating = false;
     viewctrl!: Require<ViewCtrl>;
     user: IUser | undefined;
     private fetchedUser: IUser | undefined;
@@ -1181,6 +1182,8 @@ export class AnswerBrowserComponent
     }
 
     private async handleAnswerFetch(data: IAnswer[], newSelectedId?: number) {
+        this.updating = true;
+        this.cdr.detectChanges();
         if (
             (data.length > 0 &&
                 (this.hasUserChanged() ||
@@ -1213,6 +1216,7 @@ export class AnswerBrowserComponent
             }
             await this.updateFilteredAndSetNewest();
         }
+        this.updating = false;
         this.cdr.detectChanges();
     }
 

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -930,7 +930,10 @@ export class AnswerBrowserComponent
                     : undefined,
                 saveTeacher:
                     this.saveTeacher ||
-                    (this.viewctrl.teacherMode && this.loader.isInFormMode()), // TODO: Check if correct
+                    (this.viewctrl.teacherMode &&
+                        (this.loader.isInFormMode() ||
+                            (this.isGlobal() && this.hidden))),
+                // TODO: Check if saveTeacher should be enabled always when hidden browser and teachermode
                 points: this.points,
                 giveCustomPoints: this.giveCustomPoints,
                 userId: userId,

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -156,7 +156,6 @@ export class AnswerBrowserComponent
     @ViewChild("modelAnswerDiv") modelAnswerRef?: ElementRef<HTMLDivElement>;
     @ViewChild("feedback") feedBackElement?: ElementRef<HTMLDivElement>;
     loading: number;
-    updating = false;
     viewctrl!: Require<ViewCtrl>;
     user: IUser | undefined;
     private fetchedUser: IUser | undefined;
@@ -1182,8 +1181,6 @@ export class AnswerBrowserComponent
     }
 
     private async handleAnswerFetch(data: IAnswer[], newSelectedId?: number) {
-        this.updating = true;
-        this.cdr.detectChanges();
         if (
             (data.length > 0 &&
                 (this.hasUserChanged() ||
@@ -1216,7 +1213,6 @@ export class AnswerBrowserComponent
             }
             await this.updateFilteredAndSetNewest();
         }
-        this.updating = false;
         this.cdr.detectChanges();
     }
 

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -892,6 +892,8 @@ export class AnswerBrowserComponent
     async setNewest() {
         if (this.filteredAnswers.length > 0) {
             this.selectedAnswer = this.filteredAnswers[0];
+        } else {
+            this.selectedAnswer = undefined;
         }
         await this.changeAnswer();
     }

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1204,11 +1204,7 @@ export class AnswerBrowserComponent
                     this.updatePoints();
                 }
             }
-            if (!this.selectedAnswer && !this.forceBrowser()) {
-                this.dimPlugin();
-            } else {
-                await this.changeAnswer();
-            }
+            await this.changeAnswer();
         } else {
             this.answers = data;
             if (this.answers.length === 0 && this.viewctrl.teacherMode) {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -335,6 +335,8 @@ export class AnswerBrowserComponent
                 if (!updated) {
                     this.handleAnswerFetch(this.answers);
                 }
+            } else if (this.viewctrl.teacherMode) {
+                this.dimPlugin();
             }
             if (!this.isGlobal()) {
                 await this.checkUsers(); // load users, answers have already been loaded for the currently selected user

--- a/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
+++ b/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
@@ -215,7 +215,6 @@ export class PluginLoaderComponent implements AfterViewInit, OnDestroy, OnInit {
             m?.hideBrowser ||
             this.viewctrl?.docSettings.hideBrowser ||
             this.isUseCurrentUser() ||
-            this.isGlobal() ||
             this.isInFormMode()
         ) {
             this.hideBrowser = true;

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -1,8 +1,8 @@
-<div>
+<div [class.updating]="updating">
     <tim-alert *ngFor="let alert of alerts; let i = index" [severity]="alert.type" [closeable]="true" (closing)="closeAlert(i)">
         <div [innerHTML]="alert.msg | purify"></div>
     </tim-alert>
-    <label *ngIf="hidden && anyInvalid && !formMode" class="checkbox-inline">
+    <label *ngIf="hidden && anyInvalid && !formMode" class="checkbox-inline onlyValid">
         <input type="checkbox" [(ngModel)]="onlyValid" (ngModelChange)="onOnlyValidChanged()">{{markupSettings.validOnlyText}}</label>
     <div *ngIf="!hidden">
         <div *ngIf="viewctrl.teacherMode && users && users.length > 0" class="flex">
@@ -59,7 +59,7 @@
                     <span class="answer-index-count">{{ filteredAnswers.length - findSelectedAnswerIndex() }}/<a i18n-title tabindex="0"
                                                                                                   title="Newest answer"
                                                                                                   (click)="setNewest()">{{ filteredAnswers.length }}</a></span>
-                        <label class="checkbox-inline" *ngIf="anyInvalid">
+                        <label class="checkbox-inline onlyValid" *ngIf="anyInvalid">
                             <input type="checkbox" [(ngModel)]="onlyValid" (ngModelChange)="onOnlyValidChanged()">{{markupSettings.validOnlyText}}</label>
                         <span *ngIf="showTeacher()"> | <a i18n (click)="getAllAnswers()">All answers</a>
                     </span>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -1,4 +1,4 @@
-<div [class.loading]="loading">
+<div [class.updating]="updating">
     <tim-alert *ngFor="let alert of alerts; let i = index" [severity]="alert.type" [closeable]="true" (closing)="closeAlert(i)">
         <div [innerHTML]="alert.msg | purify"></div>
     </tim-alert>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -31,7 +31,7 @@
                 <a href="mailto:{{user?.email}}">email</a>
             </div>
         </div>
-        <div *ngIf="viewctrl.teacherMode && isGlobal()" class="flex">
+        <div *ngIf="isGlobal()" class="flex">
             Showing answers from all users
         </div>
         <div *ngIf="!hasUserChanged() || loading">

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -31,6 +31,9 @@
                 <a href="mailto:{{user?.email}}">email</a>
             </div>
         </div>
+        <div *ngIf="viewctrl.teacherMode && isGlobal()" class="flex">
+            Showing answers from all users
+        </div>
         <div *ngIf="!hasUserChanged() || loading">
                         <span class="flex align-center">
             <div *ngIf="answers.length > 0">
@@ -77,7 +80,10 @@
                 href="{{ getReviewLink() }}">Review</a>
                 </span>
              <div *ngIf="answers.length == 0 && viewctrl.teacherMode">
-                <span i18n *ngIf="!hasUserChanged()">(no answers from the selected user)</span>
+                 <ng-container *ngIf="!hasUserChanged()">
+                    <span i18n *ngIf="!isGlobal()">(no answers from the selected user)</span>
+                    <span i18n *ngIf="isGlobal()">(no answers from any users)</span>
+                 </ng-container>
                  <span *ngIf="hasUserChanged()"> <tim-loading></tim-loading> </span>
              </div>
                  <div class="flex ab-option-row">

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -127,6 +127,8 @@
                         <label class="checkbox-inline">
                             <input type="checkbox" [(ngModel)]="isValidAnswer"><ng-container i18n="@@abIsValidCheckbox">Valid</ng-container>
                         </label>
+                            </span>
+                    <span>
                         <button i18n-title title="Save validity"
                                 (click)="saveValidity()"
                                 class="timButton btn-xs"

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -31,7 +31,7 @@
                 <a href="mailto:{{user?.email}}">email</a>
             </div>
         </div>
-        <div *ngIf="isGlobal()" class="flex">
+        <div i18n *ngIf="isGlobal()" class="flex">
             Showing answers from all users
         </div>
         <div *ngIf="!hasUserChanged() || loading">
@@ -82,7 +82,7 @@
              <div *ngIf="answers.length == 0 && viewctrl.teacherMode">
                  <ng-container *ngIf="!hasUserChanged()">
                     <span i18n *ngIf="!isGlobal()">(no answers from the selected user)</span>
-                    <span i18n *ngIf="isGlobal()">(no answers from any users)</span>
+                    <span i18n *ngIf="isGlobal()">(no answers)</span>
                  </ng-container>
                  <span *ngIf="hasUserChanged()"> <tim-loading></tim-loading> </span>
              </div>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -1,4 +1,4 @@
-<div [class.updating]="updating">
+<div [class.updating]="updating" [class.loading]="loading">
     <tim-alert *ngFor="let alert of alerts; let i = index" [severity]="alert.type" [closeable]="true" (closing)="closeAlert(i)">
         <div [innerHTML]="alert.msg | purify"></div>
     </tim-alert>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -37,8 +37,8 @@
         <div *ngIf="!hasUserChanged() || loading">
                         <span class="flex align-center">
             <div *ngIf="answers.length > 0">
-                <div *ngIf="showBrowseAnswers" class="flex align-center">
-                    <div>
+                <div *ngIf="showBrowseAnswers" class="flex align-center ab-option-row">
+                    <div *ngIf="filteredAnswers.length > 0">
                         <div class="input-group input-group-xs">
                 <span class="input-group-btn">
                     <button i18n-title title="Previous answer" class="btn btn-primary prevAnswer"
@@ -56,18 +56,20 @@
                         </div>
                     </div>
                     <div class="no-shrink">
-                    <span class="answer-index-count">{{ filteredAnswers.length - findSelectedAnswerIndex() }}/<a i18n-title tabindex="0"
-                                                                                                  title="Newest answer"
-                                                                                                  (click)="setNewest()">{{ filteredAnswers.length }}</a></span>
+                    <span *ngIf="filteredAnswers.length > 0" class="answer-index-count">{{ filteredAnswers.length - findSelectedAnswerIndex() }}/<a i18n-title tabindex="0"
+                                                                                                  title="Newest answer" (click)="setNewest()">{{ filteredAnswers.length }}</a></span>
+                        <span *ngIf="filteredAnswers.length == 0">
+                            <ng-container i18n *ngIf="!isGlobal()">(no valid answers from the selected user)</ng-container>
+                            <ng-container i18n *ngIf="isGlobal()">(no valid answers)</ng-container>
+                        </span>
                         <label class="checkbox-inline onlyValid" *ngIf="anyInvalid">
                             <input type="checkbox" [(ngModel)]="onlyValid" (ngModelChange)="onOnlyValidChanged()">{{markupSettings.validOnlyText}}</label>
                         <span *ngIf="showTeacher()"> | <a i18n (click)="getAllAnswers()">All answers</a>
                     </span>
                         <button i18n-title class="timButton" *ngIf="showNewTask" title="Change to new task" (click)="newTask()">{{ buttonNewTask }}</button>
-                        <span *ngIf="selectedAnswer">
-                        | <a i18n i18n-title title="Link to currently selected answer"
-                             (click)="$event.preventDefault()"
-                             href="{{ getAnswerLink() }}">Link</a>
+                        <span *ngIf="selectedAnswer">| <a i18n i18n-title title="Link to currently selected answer"
+                                                          (click)="$event.preventDefault()"
+                                                          href="{{ getAnswerLink() }}">Link</a>
                         (<a i18n-title title="Link to currently selected answer without other document content"
                             target="_blank"
                             href="{{ getAnswerLink(true) }}">only</a>)&nbsp;

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -142,7 +142,7 @@
                             </div>
                             <span *ngIf="showTeacher()">
                                 <label class="checkbox-inline">
-                                    <input type="checkbox" (ngModelChange)="toggleInput()" [(ngModel)]="saveTeacher"><ng-container i18n>Save teacher's fix</ng-container>
+                                    <input type="checkbox" (change)="toggleInput()" [(ngModel)]="saveTeacher"><ng-container i18n>Save teacher's fix</ng-container>
                                 </label>
                             </span>
                             <div class="flex" *ngIf="selectedAnswer">

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -1,4 +1,4 @@
-<div [class.updating]="updating">
+<div [class.loading]="loading">
     <tim-alert *ngFor="let alert of alerts; let i = index" [severity]="alert.type" [closeable]="true" (closing)="closeAlert(i)">
         <div [innerHTML]="alert.msg | purify"></div>
     </tim-alert>

--- a/timApp/tests/browser/test_answerbrowser.py
+++ b/timApp/tests/browser/test_answerbrowser.py
@@ -1,5 +1,7 @@
 from timApp.document.docentry import DocEntry
 from timApp.tests.browser.browsertest import BrowserTest, PREV_ANSWER
+from timApp.timdb.sqa import db
+from timApp.user.usergroup import UserGroup
 from timApp.util.utils import static_tim_doc
 
 
@@ -17,3 +19,91 @@ class AnswerBrowserTest(BrowserTest):
         self.find_element_avoid_staleness(selector, click=True)
         self.wait_and_click(PREV_ANSWER)
         self.should_not_exist("answerbrowser .alert-danger")
+
+    def test_dim(self):
+        self.login_browser_quick_test1()
+        self.login_test1()
+        ug = UserGroup.create("testusers23")
+        ug.users.append(self.test_user_2)
+        ug.users.append(self.test_user_3)
+        ug.admin_doc = self.create_doc().block
+        d = self.create_doc(
+            initial_par="""
+``` {#GLO_Y plugin="textfield"}
+form: false
+```
+``` {#GLO_N plugin="textfield"}
+form: false
+```
+``` {#normal_Y plugin="textfield"}
+form: false
+```
+``` {#normal_N plugin="textfield"}
+form: false
+```
+``` {#runner plugin="jsrunner"}
+showInView: true
+groups: [testusers23]
+updateFields:
+ - GLO_Y
+ - GLO_N
+ - normal_Y
+ - normal_N
+fields: []
+program: |!!
+!!
+```
+
+""",
+            settings={"group": "testusers23"},
+        )
+        self.add_answer(d, "normal_Y", "tu2_normal", user=self.test_user_2)
+        self.add_answer(d, "GLO_Y", "tu3_global", user=self.test_user_3)
+        self.add_answer(d, "normal_Y", "tu3_normal", user=self.test_user_3)
+        db.session.commit()
+
+        self.goto_document(d, "teacher")
+
+        def wait_fields_loaded():
+            def wait_field_load(tid: str):
+                self.wait_until_present_and_vis(f"#{tid} .textfieldNoSaveDiv input")
+
+            wait_field_load("GLO_Y")
+            wait_field_load("GLO_N")
+            wait_field_load("normal_Y")
+            wait_field_load("normal_N")
+
+        wait_fields_loaded()
+        velp_hider = self.find_element("velp-selection i.glyphicon-minus")
+        velp_hider.click()
+
+        # Should dim if no answers from target (or any users if global)
+        def check_opacities():
+            def check_opacity(tid: str, dimmed: bool):
+                self.find_element_and_move_to(f"#{tid} .textfieldNoSaveDiv input")
+                self.wait_until_present_and_vis(f"#{tid} answerbrowser")
+                self.wait_until_hidden(f"#{tid} answerbrowser .loading")
+                self.wait_until_hidden(f"#{tid} answerbrowser .updating")
+                if dimmed:
+                    self.find_element(f'#{tid} [style*="opacity: 0.3"]')
+                else:
+                    self.wait_until_hidden(f'#{tid} [style*="opacity: 0.3"]')
+
+            check_opacity("GLO_Y", False)
+            check_opacity("GLO_N", True)
+            check_opacity("normal_Y", False)
+            check_opacity("normal_N", True)
+
+        # initial answerbrowser load triggers dimming
+        check_opacities()
+        tu_3_selector = self.find_element('div[title = "Test user 3"]')
+        tu_3_selector.click()
+        # user change triggers dimming
+        check_opacities()
+        self.goto_document(d, "teacher")
+        wait_fields_loaded()
+        runner = self.find_element_avoid_staleness("js-runner .timButton")
+        runner.click()
+        self.wait_until_hidden("js-runner tim-loading")
+        # updatefields triggers dimming
+        check_opacities()

--- a/timApp/tests/browser/test_teacher.py
+++ b/timApp/tests/browser/test_teacher.py
@@ -1,3 +1,4 @@
+from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
 from selenium.webdriver.common.by import By
 
 from timApp.tests.browser.browsertest import BrowserTest
@@ -110,13 +111,24 @@ initword: empty
                 velp_hider.click()
             tu_2_selector = self.find_element('div[title = "Test user 2"]')
             tu_2_selector.click()
-            self.find_element_and_move_to(input_selector)
-            self.wait_until_present_and_vis("answerbrowser .onlyValid input")
-            valid_only = self.find_element("answerbrowser .onlyValid input")
-            self.assertTrue(valid_only.is_selected())
-            self.wait_until_hidden("answerbrowser .updating")
-            ele = self.find_element_and_move_to(input_selector)
-            self.assertEqual(ele.get_attribute("value"), "empty")
+
+            def focus_and_check_task():
+                self.find_element_and_move_to(input_selector)
+                self.wait_until_present_and_vis("answerbrowser .onlyValid input")
+                valid_only = self.find_element("answerbrowser .onlyValid input")
+                self.assertTrue(valid_only.is_selected())
+                self.wait_until_hidden("answerbrowser .loading")
+                ele = self.find_element_and_move_to(input_selector)
+                self.assertEqual(ele.get_attribute("value"), "empty")
+
+            try:
+                focus_and_check_task()
+            except (
+                StaleElementReferenceException,
+                TimeoutException,
+            ):
+                self.get_uninteractable_element().click()
+                focus_and_check_task()
 
         do_test(True)
         do_test(False)

--- a/timApp/tests/browser/test_teacher.py
+++ b/timApp/tests/browser/test_teacher.py
@@ -76,3 +76,47 @@ form: false
             "#t .textfieldNoSaveDiv input"
         ).get_attribute("value")
         self.assertEqual(d2_ans_table[selected_username], selected_answer)
+
+    def test_userchange_only_invalid_answers(self):
+        # Check that changing to user with invalid answers only does not show previous user's answer
+        self.login_browser_quick_test1()
+        self.login_test1()
+        ug = UserGroup.create("testusers1")
+        ug.users.append(self.test_user_1)
+        ug.users.append(self.test_user_2)
+        ug.admin_doc = self.create_doc().block
+        d1 = self.create_doc(
+            initial_par="""
+#- {plugin=textfield #t}
+form: false
+initword: empty
+                """,
+            settings={"group": "testusers1"},
+        )
+        self.add_answer(d1, "t", "tu1 valid")
+        self.add_answer(d1, "t", "tu2 invalid", valid=False, user=self.test_user_2)
+        db.session.commit()
+
+        def do_test(focus_first: bool):
+            self.goto_document(d1, "teacher")
+            input_selector = "#t .textfieldNoSaveDiv input"
+            self.wait_until_present_and_vis(input_selector)
+            ele = self.find_element(input_selector)
+            self.assertEqual(ele.get_attribute("value"), "tu1 valid")
+            if focus_first:
+                self.find_element_and_move_to(input_selector)
+                self.wait_until_present_and_vis("answerbrowser .point-form")
+                velp_hider = self.find_element("velp-selection i.glyphicon-minus")
+                velp_hider.click()
+            tu_2_selector = self.find_element('div[title = "Test user 2"]')
+            tu_2_selector.click()
+            self.find_element_and_move_to(input_selector)
+            self.wait_until_present_and_vis("answerbrowser .onlyValid input")
+            valid_only = self.find_element("answerbrowser .onlyValid input")
+            self.assertTrue(valid_only.is_selected())
+            self.wait_until_hidden("answerbrowser .updating")
+            ele = self.find_element_and_move_to(input_selector)
+            self.assertEqual(ele.get_attribute("value"), "empty")
+
+        do_test(True)
+        do_test(False)

--- a/timApp/tests/browser/test_teacher.py
+++ b/timApp/tests/browser/test_teacher.py
@@ -117,7 +117,7 @@ initword: empty
                 self.wait_until_present_and_vis("answerbrowser .onlyValid input")
                 valid_only = self.find_element("answerbrowser .onlyValid input")
                 self.assertTrue(valid_only.is_selected())
-                self.wait_until_hidden("answerbrowser .loading")
+                self.wait_until_hidden("answerbrowser .updating")
                 ele = self.find_element_and_move_to(input_selector)
                 self.assertEqual(ele.get_attribute("value"), "empty")
 

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -2339,8 +2339,10 @@ useCurrentUser: true
         self.assertEqual({"c": "testuser2@GLO_d"}, get_plugin_answer(plugs[3]))
         self.assertEqual({"c": "testuser2@e"}, get_plugin_answer(plugs[4]))
 
+        # testuser1 did not answer b -> 0 answers despite useCurrentUser
         self.assertEqual(0, len(self.get_task_answers(f"{d.id}.b")))
-        self.assertEqual(0, len(self.get_task_answers(f"{d.id}.GLO_d")))
+        # testuser1 did not answer d -> getAnswers returns testuser2's answers too because task is global
+        self.assertEqual(1, len(self.get_task_answers(f"{d.id}.GLO_d")))
 
     def test_accessfield(self):
         """Invalidate answer if accessField target has answer c: 1"""


### PR DESCRIPTION
Korjaa bugin jossa globaali kenttä harmaantui jos kirjautuneella käyttäjällä ei ollut vastauksia kentässä jsrunnerin/tableformin kautta tulevassa kentän päivityksessä, ja toteuttaa iänikuisen tipin ajoilta jääneen todon siitä että globaalissa kentässä voisi selata vastauksia.

https://timdevs01-3.it.jyu.fi/teacher/global_updatefield (kannattaa kirjautua admin1:llä) vs https://tim.jyu.fi/teacher/users/sijualle/kokeiluja/global_updatefield

Korjaa myös #3278

https://timdevs01-3.it.jyu.fi/teacher/validonlybug vs https://tim.jyu.fi/teacher/users/sijualle/kokeiluja/validonlybug

Lisäksi tehtävän harmaantumiselle pientä viilausta (opettajannäkymässä harmaantuu johdonmukaisemmin aina jos ei vastauksia ellei save techer's fix ruksittu), ja textfieldin rows-attribuutti vaikuttaa taas textArean korkeuteen