### PR TITLE
Fix modelanswer valid answer count, don't call current view user "selected user"

### DIFF
--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1439,7 +1439,9 @@ export class AnswerBrowserComponent
         if (r.result.data.modelAnswer) {
             this.modelAnswer = r.result.data.modelAnswer;
             this.onlyValid = false;
-            this.onOnlyValidChanged();
+            if (this.answers.length > 0) {
+                this.onOnlyValidChanged();
+            }
         }
         this.showNewTask = this.isAndSetShowNewTask();
         if (this.taskInfo.buttonNewTask) {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1439,6 +1439,7 @@ export class AnswerBrowserComponent
         if (r.result.data.modelAnswer) {
             this.modelAnswer = r.result.data.modelAnswer;
             this.onlyValid = false;
+            this.onOnlyValidChanged();
         }
         this.showNewTask = this.isAndSetShowNewTask();
         if (this.taskInfo.buttonNewTask) {

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -59,8 +59,10 @@
                     <span *ngIf="filteredAnswers.length > 0" class="answer-index-count">{{ filteredAnswers.length - findSelectedAnswerIndex() }}/<a i18n-title tabindex="0"
                                                                                                   title="Newest answer" (click)="setNewest()">{{ filteredAnswers.length }}</a></span>
                         <span *ngIf="filteredAnswers.length == 0">
-                            <ng-container i18n *ngIf="!isGlobal()">(no valid answers from the selected user)</ng-container>
-                            <ng-container i18n *ngIf="isGlobal()">(no valid answers)</ng-container>
+                                <ng-container i18n *ngIf="!isGlobal() && viewctrl.teacherMode; else emptyCurrentuser">(no valid answers from the selected user)</ng-container>
+                            <ng-template #emptyCurrentuser>
+                                <ng-container #emptyCurrentuser i18n *ngIf="isGlobal() || !viewctrl.teacherMode">(no valid answers)</ng-container>
+                            </ng-template>
                         </span>
                         <label class="checkbox-inline onlyValid" *ngIf="anyInvalid">
                             <input type="checkbox" [(ngModel)]="onlyValid" (ngModelChange)="onOnlyValidChanged()">{{markupSettings.validOnlyText}}</label>


### PR DESCRIPTION
Korjaa bugin jossa modelanswer-attribuutti, joka pakottaa valid only-ruksin pois päältä, saa answerbrowserin näyttämään väärää vastausten lukumäärää

https://timdevs01-3.it.jyu.fi/view/modelanswer-validonly vs https://tim.jyu.fi/view/users/sijualle/kokeiluja/modelanswer-validonly

Lisäksi view-näkymässä ei puhuta enää "valitusta käyttäjästä"