### PR TITLE
Add warnings about missing task ids

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7870,6 +7870,14 @@
           <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5145731315765024579" datatype="html">
+        <source>Plugin is missing task id</source>
+        <target state="translated">Tehtävästä puuttuu tehtävätunniste</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/plugin-loader.component.ts</context>
+          <context context-type="linenumber">624</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7862,6 +7862,14 @@
           <context context-type="linenumber">40,41</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8053311864205132091" datatype="html">
+        <source>Task id missing and required to answer this task.</source>
+        <target state="translated">Tehtävätunniste puuttuu ja tarvitaan tähän tehtävään vastaamiseen.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/util/utils.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7752,6 +7752,14 @@
           <context context-type="linenumber">40,41</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8053311864205132091" datatype="html">
+        <source>Task id missing and required to answer this task.</source>
+        <target state="translated">Uppgifts-id saknas och krävs för att svara på denna uppgift.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/util/utils.ts</context>
+          <context context-type="linenumber">28</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7760,6 +7760,14 @@
           <context context-type="linenumber">28</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5145731315765024579" datatype="html">
+        <source>Plugin is missing task id</source>
+        <target state="translated">Plugin saknar uppgifts-id</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/plugin-loader.component.ts</context>
+          <context context-type="linenumber">624</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -9,7 +9,6 @@ import {
 import {HttpClient, HttpHeaders} from "@angular/common/http";
 import type {SafeResourceUrl} from "@angular/platform-browser";
 import {DomSanitizer} from "@angular/platform-browser";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import * as t from "io-ts";
 import $ from "jquery";
 import type {
@@ -2108,7 +2107,6 @@ ${fhtml}
             }
         }
 
-        this.vctrl = vctrlInstance!;
         this.hide = this.attrsall.markup.hide ?? {};
         //  if ( typeof this.markup.borders !== 'undefined' ) this.markup.borders = true;
         this.createTemplateButtons();

--- a/timApp/modules/cs/js/jsframe.ts
+++ b/timApp/modules/cs/js/jsframe.ts
@@ -338,6 +338,7 @@ export class JsframeComponent
 
     ngOnInit() {
         super.ngOnInit();
+        this.requiresTaskId = this.isDrawio() && this.isTask();
         this.viewctrl = vctrlInstance!;
         this.button = this.buttonText();
         const aa = this.attrsall;
@@ -400,9 +401,6 @@ export class JsframeComponent
                 await this.viewctrl.documentUpdate;
                 this.viewctrl.addParMenuEntry(this, this.getPar()!);
             })();
-            if (this.isTask() && !this.getTaskId()) {
-                this.error = "Task-mode on but TaskId is missing!";
-            }
             this.initFrameData = unwrapAllC(this.markup.data);
         }
     }

--- a/timApp/modules/cs/js/jsframe.ts
+++ b/timApp/modules/cs/js/jsframe.ts
@@ -338,7 +338,6 @@ export class JsframeComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.requiresTaskId = this.isDrawio() && this.isTask();
         this.viewctrl = vctrlInstance!;
         this.button = this.buttonText();
         const aa = this.attrsall;
@@ -397,6 +396,9 @@ export class JsframeComponent
             })();
         }
         if (this.isDrawio()) {
+            if (!this.isTask()) {
+                this.requiresTaskId = false;
+            }
             (async () => {
                 await this.viewctrl.documentUpdate;
                 this.viewctrl.addParMenuEntry(this, this.getPar()!);

--- a/timApp/modules/cs/js/jsframe.ts
+++ b/timApp/modules/cs/js/jsframe.ts
@@ -173,6 +173,7 @@ export interface Iframesettings {
     selector: "jsframe-runner",
     template: `
         <div [ngClass]="{'warnFrame': isUnSaved(), 'csRunDiv': borders}" class="math que jsframe no-popup-menu">
+            <tim-markup-error *ngIf="markupError" [data]="markupError"></tim-markup-error>
             <h4 *ngIf="header" [innerHtml]="header | purify"></h4>
             <p *ngIf="stem" class="stem" [innerHtml]="stem | purify"></p>
             <p *ngIf="!isOpen" class="stem" [innerHtml]="beforeOpen"></p>

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -10,7 +10,6 @@ import {
 } from "tim/plugin/attributes";
 import {windowAsAny} from "tim/util/utils";
 import type {ITimComponent, ViewCtrl} from "tim/document/viewctrl";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {HttpClientModule} from "@angular/common/http";
 import {FormsModule} from "@angular/forms";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
@@ -210,7 +209,6 @@ export class StackPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
         this.button = this.buttonText();
         const aa = this.attrsall;
         this.userCode = aa.usercode ?? this.markup.by ?? "";
@@ -234,7 +232,7 @@ export class StackPluginComponent
         if (this.markup.open) {
             this.runGetTask();
         }
-        this.vctrl = vctrlInstance!;
+
         if (!this.attrsall.preview) {
             this.vctrl.addTimComponent(this);
         }

--- a/timApp/modules/cs/js/util/file-select.ts
+++ b/timApp/modules/cs/js/util/file-select.ts
@@ -81,35 +81,39 @@ let nextId = 0;
 @Component({
     selector: "file-select",
     template: `
+        <ng-container *ngIf="uploadUrl">
         <div *ngIf="!dragAndDrop && stem">{{stem}}:</div>
-        <input #input [disabled]="!!progress" type="file" 
-               [hidden]="dragAndDrop" 
-               [id]="inputId" 
-               (change)="onFileChange($event)" 
-               (attr.multiple)="multiple" 
-               [accept]="accept"/>
-        <notification *ngIf="!dragAndDrop" class="error" #error></notification>
-        <ng-container *ngIf="dragAndDrop">
-            <label i18n-title title="Drag-and-drop or Click to browse" [for]="inputId" *ngIf="dragAndDrop"
-                    class="drag-and-drop"
-                    (drop)="onDrop($event)"
-                    (dragover)="onDragOver($event)"
-                    (click)="clearStatus();">
-                <div>
+            <input #input [disabled]="!!progress" type="file"
+                   [hidden]="dragAndDrop"
+                   [id]="inputId"
+                   (change)="onFileChange($event)"
+                   (attr.multiple)="multiple"
+                   [accept]="accept"/>
+            <notification *ngIf="!dragAndDrop" class="error" #error></notification>
+            <ng-container *ngIf="dragAndDrop">
+                <label i18n-title title="Drag-and-drop or Click to browse" [for]="inputId" *ngIf="dragAndDrop"
+                       class="drag-and-drop"
+                       (drop)="onDrop($event)"
+                       (dragover)="onDragOver($event)"
+                       (click)="clearStatus();">
                     <div>
-                        <p *ngIf="!progress && loadInfo.length == 0 && error.length == 0">{{stem}}</p>
-                        <ng-container *ngIf="progress">
-                            <tim-loading></tim-loading>
-                            <p *ngIf="numFiles > 1">File {{numUploaded+1}} / {{numFiles}}</p>
-                            <p>{{progress}}</p>
-                        </ng-container>
-                        <notification #loadInfo></notification>
-                        <notification class="error" #error></notification>
-                        <notification class="warning" #warning></notification>
+                        <div>
+                            <p *ngIf="!progress && loadInfo.length == 0 && error.length == 0">{{stem}}</p>
+                            <ng-container *ngIf="progress">
+                                <tim-loading></tim-loading>
+                                <p *ngIf="numFiles > 1">File {{numUploaded + 1}} / {{numFiles}}</p>
+                                <p>{{progress}}</p>
+                            </ng-container>
+                            <notification #loadInfo></notification>
+                            <notification class="error" #error></notification>
+                            <notification class="warning" #warning></notification>
+                        </div>
                     </div>
-                </div>
-            </label>
-        </ng-container>`,
+                </label>
+            </ng-container>
+        </ng-container>
+        <p *ngIf="!uploadUrl" i18n class="error">No file upload or observers present. This is a programming/configuration error.</p>
+`,
 })
 export class FileSelectComponent {
     // TODO: translations

--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -149,7 +149,7 @@ export class DragComponent
     effectAllowed: EffectAllowed = "copyMove";
     private forceSave = false;
     private shuffle?: boolean;
-    private vctrl = vctrlInstance;
+
     styles: Record<string, string> = {};
     saveFailed = false;
 

--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -22,7 +22,6 @@ import {
 import {parseStyles, shuffleStrings} from "tim/plugin/util";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {PurifyModule} from "tim/util/purify.module";
 import type {DocIdDotName} from "tim/plugin/taskid";
 import {defaultErrorMessage, isIOS} from "tim/util/utils";

--- a/timApp/modules/feedback/js/feedback.ts
+++ b/timApp/modules/feedback/js/feedback.ts
@@ -10,7 +10,7 @@ import type {
     OnInit,
 } from "@angular/core";
 import {Component, NgModule} from "@angular/core";
-import type {ITimComponent, ViewCtrl} from "tim/document/viewctrl";
+import type {ITimComponent} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
     Info,
@@ -24,7 +24,6 @@ import {HttpClientModule} from "@angular/common/http";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 
@@ -158,7 +157,7 @@ export class FeedbackPluginComponent
     implements ITimComponent, OnInit, OnDestroy
 {
     error?: string;
-    private vctrl!: ViewCtrl;
+
     private userAnswer: string[] = [];
     feedback = "";
     private questionItemIndex!: number;
@@ -186,7 +185,7 @@ export class FeedbackPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         this.addToCtrl();
         this.vctrl.listen("editModeChange", this.editModeChanged);
         this.setPluginWords();

--- a/timApp/modules/fields/js/cbcountfield-plugin.component.ts
+++ b/timApp/modules/fields/js/cbcountfield-plugin.component.ts
@@ -4,11 +4,7 @@
 import * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap} from "@angular/core";
 import {Component, ElementRef, NgModule, NgZone} from "@angular/core";
-import type {
-    ISetAnswerResult,
-    ITimComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
+import type {ISetAnswerResult, ITimComponent} from "tim/document/viewctrl";
 import {ChangeType, FormModeOption} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
@@ -25,7 +21,6 @@ import {FormsModule} from "@angular/forms";
 import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 import {FieldBasicData} from "./textfield-plugin.component";
@@ -113,7 +108,7 @@ export class CbcountfieldPluginComponent
     private result?: string;
     isRunning = false;
     userword: boolean = false;
-    private vctrl!: ViewCtrl;
+
     private initialValue: boolean = false;
     errormessage?: string;
     hideSavedText = true;
@@ -169,7 +164,7 @@ export class CbcountfieldPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         const uw = valueOr(
             this.attrsall.state?.c,
             this.markup.initword ?? ""

--- a/timApp/modules/fields/js/cbfield-plugin.component.ts
+++ b/timApp/modules/fields/js/cbfield-plugin.component.ts
@@ -4,11 +4,7 @@
 import * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap} from "@angular/core";
 import {Component, ElementRef, NgModule, NgZone} from "@angular/core";
-import type {
-    ISetAnswerResult,
-    ITimComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
+import type {ISetAnswerResult, ITimComponent} from "tim/document/viewctrl";
 import {ChangeType, FormModeOption} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
@@ -23,7 +19,6 @@ import {HttpClient, HttpClientModule} from "@angular/common/http";
 import {FormsModule} from "@angular/forms";
 import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
@@ -108,7 +103,7 @@ export class CbfieldPluginComponent
     private result?: string;
     isRunning = false;
     userword: boolean = false;
-    private vctrl!: ViewCtrl;
+
     private initialValue: boolean = false;
     errormessage?: string;
     hideSavedText = true;
@@ -162,7 +157,7 @@ export class CbfieldPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         const uw = valueOr(
             this.attrsall.state?.c,
             this.markup.initword ?? ""

--- a/timApp/modules/fields/js/dropdown-plugin.component.ts
+++ b/timApp/modules/fields/js/dropdown-plugin.component.ts
@@ -4,11 +4,7 @@
 import * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap} from "@angular/core";
 import {Component, ElementRef, NgModule, NgZone} from "@angular/core";
-import type {
-    ISetAnswerResult,
-    ITimComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
+import type {ISetAnswerResult, ITimComponent} from "tim/document/viewctrl";
 import {ChangeType, FormModeOption} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
@@ -25,7 +21,6 @@ import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 
@@ -124,7 +119,7 @@ export class DropdownPluginComponent
     wordList?: string[];
     selectedWord?: string;
     private initialWord?: string;
-    private vctrl!: ViewCtrl;
+
     private forceSave = false;
     radio?: boolean;
     private shuffle?: boolean;
@@ -164,7 +159,7 @@ export class DropdownPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         this.selectedWord = this.attrsall.state?.c ?? undefined;
         this.shuffle = this.markup.shuffle;
         if (this.shuffle && this.markup.words) {

--- a/timApp/modules/fields/js/goaltable-plugin.component.ts
+++ b/timApp/modules/fields/js/goaltable-plugin.component.ts
@@ -4,7 +4,7 @@
 import * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap} from "@angular/core";
 import {Component, ElementRef, NgModule, NgZone} from "@angular/core";
-import type {ITimComponent, ViewCtrl} from "tim/document/viewctrl";
+import type {ITimComponent} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
     Info,
@@ -16,7 +16,6 @@ import {HttpClient, HttpClientModule} from "@angular/common/http";
 import {FormsModule} from "@angular/forms";
 import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";

--- a/timApp/modules/fields/js/goaltable-plugin.component.ts
+++ b/timApp/modules/fields/js/goaltable-plugin.component.ts
@@ -135,7 +135,6 @@ export class GoalTablePluginComponent
     >
     implements ITimComponent
 {
-    private vctrl!: ViewCtrl;
     isRunning = false;
     private error: {message?: string; stacktrace?: string} = {};
     result: string = "";
@@ -178,7 +177,7 @@ export class GoalTablePluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         const aa = this.attrsall;
         const lang = this.markup.lang || "fi";
         this.lang = lang;

--- a/timApp/modules/fields/js/multisave.ts
+++ b/timApp/modules/fields/js/multisave.ts
@@ -23,7 +23,6 @@ import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {HttpClient, HttpClientModule} from "@angular/common/http";
 import {FormsModule} from "@angular/forms";
 import {DomSanitizer} from "@angular/platform-browser";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {showConfirm} from "tim/ui/showConfirmDialog";
 import {slugify} from "tim/util/slugify";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
@@ -196,7 +195,7 @@ export class MultisaveComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         if (this.markup.listener && this.vctrl) {
             this.vctrl.addChangeListener(this);
         }

--- a/timApp/modules/fields/js/multisave.ts
+++ b/timApp/modules/fields/js/multisave.ts
@@ -195,7 +195,7 @@ export class MultisaveComponent
 
     ngOnInit() {
         super.ngOnInit();
-
+        this.requiresTaskId = false;
         if (this.markup.listener && this.vctrl) {
             this.vctrl.addChangeListener(this);
         }

--- a/timApp/modules/fields/js/multisave.ts
+++ b/timApp/modules/fields/js/multisave.ts
@@ -131,6 +131,7 @@ export class MultisaveComponent
     private unsavedTimComps: Set<string> = new Set<string>();
     private hasUnsavedTargets: boolean = false;
     unsavedTasksWithAliases: {component: ITimComponent; alias?: string}[] = [];
+    requiresTaskId = false;
 
     constructor(
         el: ElementRef<HTMLElement>,
@@ -195,7 +196,6 @@ export class MultisaveComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.requiresTaskId = false;
         if (this.markup.listener && this.vctrl) {
             this.vctrl.addChangeListener(this);
         }

--- a/timApp/modules/fields/js/numericfield-plugin.component.ts
+++ b/timApp/modules/fields/js/numericfield-plugin.component.ts
@@ -10,11 +10,7 @@ import {
     NgZone,
     ViewChild,
 } from "@angular/core";
-import type {
-    ISetAnswerResult,
-    ITimComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
+import type {ISetAnswerResult, ITimComponent} from "tim/document/viewctrl";
 import {ChangeType, FormModeOption} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
@@ -30,7 +26,6 @@ import {FormsModule} from "@angular/forms";
 import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
@@ -141,7 +136,7 @@ export class NumericfieldPluginComponent
     private result?: string;
     isRunning = false;
     numericvalue?: number;
-    private vctrl!: ViewCtrl;
+
     private initialValue?: number;
     errormessage?: string;
     hideSavedText = true;
@@ -253,7 +248,7 @@ export class NumericfieldPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         const state = this.attrsall.state?.c;
         if (state === undefined || state === null) {
             this.initCode();

--- a/timApp/modules/fields/js/rbfield-plugin.component.ts
+++ b/timApp/modules/fields/js/rbfield-plugin.component.ts
@@ -4,11 +4,7 @@
 import * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap, OnDestroy} from "@angular/core";
 import {Component, ElementRef, NgModule, NgZone} from "@angular/core";
-import type {
-    ISetAnswerResult,
-    ITimComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
+import type {ISetAnswerResult, ITimComponent} from "tim/document/viewctrl";
 import {ChangeType, FormModeOption, RegexOption} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
@@ -25,7 +21,6 @@ import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 import {FieldBasicData} from "./textfield-plugin.component";
@@ -112,7 +107,7 @@ export class RbfieldPluginComponent
     private result?: string;
     isRunning = false;
     userword: string = "0";
-    private vctrl!: ViewCtrl;
+
     private initialValue: string = "0";
     errormessage?: string;
     private hideSavedText = true;
@@ -162,7 +157,7 @@ export class RbfieldPluginComponent
     ngOnInit() {
         super.ngOnInit();
         this.rbName = this.rbname;
-        this.vctrl = vctrlInstance!;
+
         const uw = valueOr(
             this.attrsall.state?.c,
             this.markup.initword ?? "0"

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -4,11 +4,7 @@
 import * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap} from "@angular/core";
 import {Component, ElementRef, NgModule, NgZone} from "@angular/core";
-import type {
-    ISetAnswerResult,
-    ITimComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
+import type {ISetAnswerResult, ITimComponent} from "tim/document/viewctrl";
 import {ChangeType, FormModeOption} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
@@ -23,7 +19,6 @@ import {HttpClient, HttpClientModule} from "@angular/common/http";
 import {FormsModule} from "@angular/forms";
 import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
@@ -169,7 +164,7 @@ export class TextfieldPluginComponent
     isRunning = false;
     userword = "";
     userWordBlobUrlStore?: {word: string; blobUrl: string};
-    private vctrl!: ViewCtrl;
+
     private initialValue = "";
     errormessage?: string;
     hideSavedText = true;
@@ -252,7 +247,7 @@ export class TextfieldPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         this.userword = valueOr(
             this.attrsall.state?.c,
             this.markup.initword ?? ""

--- a/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
+++ b/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
@@ -4,7 +4,7 @@
 import type * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap} from "@angular/core";
 import {Component, Input, NgModule} from "@angular/core";
-import type {IJsRunner, ViewCtrl} from "tim/document/viewctrl";
+import type {IJsRunner} from "tim/document/viewctrl";
 import {RegexOption} from "tim/document/viewctrl";
 import {copyToClipboard} from "tim/util/utils";
 import {HttpClientModule} from "@angular/common/http";
@@ -13,7 +13,6 @@ import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 import type {
@@ -84,7 +83,7 @@ export class JsRunnerPluginComponent
     md: string = "";
     html: string = "";
     fieldlist: string = "";
-    private vctrl!: ViewCtrl;
+
     scriptErrors?: ErrorList;
     isopen: boolean = true;
     private visible: number = -1;
@@ -136,7 +135,7 @@ export class JsRunnerPluginComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         this.userOpt = this.markup.includeUsers;
         if (this.markup.fieldhelper && this.isVisible()) {
             this.isopen = this.markup.open ?? false;

--- a/timApp/modules/svn/js/images.component.ts
+++ b/timApp/modules/svn/js/images.component.ts
@@ -7,7 +7,6 @@ import {
     ViewChild,
     ViewEncapsulation,
 } from "@angular/core";
-import type {ViewCtrl} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
     Info,
@@ -19,7 +18,6 @@ import {valueDefu} from "tim/util/utils";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {FormsModule} from "@angular/forms";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {HttpClientModule} from "@angular/common/http";
 import {PurifyModule} from "tim/util/purify.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
@@ -156,7 +154,7 @@ export class ImagesComponent extends AngularPluginBase<
     @ViewChild("images") images?: ElementRef<HTMLImageElement>;
     width?: number;
     height?: number;
-    private vctrl?: ViewCtrl;
+
     imagesOn: boolean = true;
     fileIndex = 1;
     files: {name: string; caption: string; alt: string}[] = [];
@@ -167,7 +165,7 @@ export class ImagesComponent extends AngularPluginBase<
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance;
+
         this.width = this.markup.width;
         this.height = this.markup.height;
         this.noFlicker = this.markup.noFlicker || this.markup.autoplay != 0;

--- a/timApp/modules/svn/js/images.component.ts
+++ b/timApp/modules/svn/js/images.component.ts
@@ -165,7 +165,7 @@ export class ImagesComponent extends AngularPluginBase<
 
     ngOnInit() {
         super.ngOnInit();
-
+        this.requiresTaskId = false;
         this.width = this.markup.width;
         this.height = this.markup.height;
         this.noFlicker = this.markup.noFlicker || this.markup.autoplay != 0;

--- a/timApp/modules/svn/js/images.component.ts
+++ b/timApp/modules/svn/js/images.component.ts
@@ -162,10 +162,10 @@ export class ImagesComponent extends AngularPluginBase<
     intervalId: number = 0;
     noFlicker: boolean = false;
     nearFiles: number = 1;
+    requiresTaskId = false;
 
     ngOnInit() {
         super.ngOnInit();
-        this.requiresTaskId = false;
         this.width = this.markup.width;
         this.height = this.markup.height;
         this.noFlicker = this.markup.noFlicker || this.markup.autoplay != 0;

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -350,7 +350,7 @@ export class VideoComponent extends AngularPluginBase<
 
     ngOnInit() {
         super.ngOnInit();
-
+        this.requiresTaskId = false;
         this.start = toSeconds(this.markup.start);
         this.end = toSeconds(this.markup.end);
         this.bookmarks[0] = this.start ?? 0;

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -1,7 +1,6 @@
 ﻿import * as t from "io-ts";
 import type {ApplicationRef, DoBootstrap} from "@angular/core";
 import {Component, ElementRef, NgModule, ViewChild} from "@angular/core";
-import type {ViewCtrl} from "tim/document/viewctrl";
 import {
     GenericPluginMarkup,
     Info,
@@ -18,7 +17,6 @@ import {
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {FormsModule} from "@angular/forms";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {HttpClientModule} from "@angular/common/http";
 import {PurifyModule} from "tim/util/purify.module";
 import {getKeyCode, KEY_LEFT, KEY_RIGHT} from "tim/util/keycodes";
@@ -343,7 +341,7 @@ export class VideoComponent extends AngularPluginBase<
     startt!: string | null;
     width?: number;
     height?: number;
-    private vctrl?: ViewCtrl;
+
     iframesettings?: Iframesettings;
     isPdf = false;
     videosettings?: {src: string; crossOrigin: string | null};
@@ -352,7 +350,7 @@ export class VideoComponent extends AngularPluginBase<
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance;
+
         this.start = toSeconds(this.markup.start);
         this.end = toSeconds(this.markup.end);
         this.bookmarks[0] = this.start ?? 0;

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -347,10 +347,10 @@ export class VideoComponent extends AngularPluginBase<
     videosettings?: {src: string; crossOrigin: string | null};
     playbackRateString = "";
     advVideo: boolean = false;
+    requiresTaskId = false;
 
     ngOnInit() {
         super.ngOnInit();
-        this.requiresTaskId = false;
         this.start = toSeconds(this.markup.start);
         this.end = toSeconds(this.markup.end);
         this.bookmarks[0] = this.start ?? 0;

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -1569,11 +1569,7 @@ export class ViewCtrl implements IController {
         //     }
         //     this.ldrs.set(loader.taskId + index, loader);
         // } else { this.ldrs.set(loader.taskId, loader); }
-        if (loader.taskId) {
-            this.ldrs.set(loader.taskId, loader);
-        } else {
-            this.registerPluginLoaderWithoutTaskId(loader);
-        }
+        this.ldrs.set(loader.taskId, loader);
     }
 
     registerPluginLoaderWithoutTaskId(loader: PluginLoaderComponent) {

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -1558,6 +1558,7 @@ export class ViewCtrl implements IController {
     }
 
     private ldrs = new Map<string, PluginLoaderComponent>();
+    private loadersWithoutTaskIds = new Map<string, PluginLoaderComponent>(); // key: parid
 
     registerPluginLoader(loader: PluginLoaderComponent) {
         // // TODO: see todos at registerAnswerBrowser
@@ -1568,12 +1569,27 @@ export class ViewCtrl implements IController {
         //     }
         //     this.ldrs.set(loader.taskId + index, loader);
         // } else { this.ldrs.set(loader.taskId, loader); }
-        this.ldrs.set(loader.taskId, loader);
+        if (loader.taskId) {
+            this.ldrs.set(loader.taskId, loader);
+        } else {
+            this.registerPluginLoaderWithoutTaskId(loader);
+        }
+    }
+
+    registerPluginLoaderWithoutTaskId(loader: PluginLoaderComponent) {
+        const parId = loader.id.split(".")[2];
+        if (parId) {
+            this.loadersWithoutTaskIds.set(parId, loader);
+        }
     }
 
     getPluginLoader(taskId: string) {
         taskId = this.normalizeTaskId(taskId);
         return this.ldrs.get(taskId);
+    }
+
+    getPluginLoaderWithoutTaskid(parId: string) {
+        return this.loadersWithoutTaskIds.get(parId);
     }
 
     private anns = new EntityRegistry<string, AnnotationComponent>();

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -22,7 +22,6 @@ import {isLeft} from "fp-ts/Either";
 import {getErrors} from "tim/plugin/errors";
 import {vctrlInstance} from "tim/document/viewctrlinstance";
 import type {ViewCtrl} from "tim/document/viewctrl";
-import angular from "angular";
 
 /**
  * Plugin with initialization data passed from the server via JSON.
@@ -150,11 +149,10 @@ export abstract class AngularPluginBase<
 
     ngAfterContentInit() {
         if (this.requiresTaskId && !this.taskid) {
-            // TODO: generic error elemnent in all plugin templates
-            const parId = angular
-                .element(this.getRootElement())
-                .parents(".par")
-                .attr("id");
+            // TODO: generic error element in all plugin templates
+            const parId = this.getRootElement()
+                .closest(".par")
+                ?.getAttribute("id");
             if (parId) {
                 const ldr = this.vctrl.getPluginLoaderWithoutTaskid(parId);
                 if (ldr) {

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -7,7 +7,7 @@ import type {
 import type {Type} from "io-ts";
 import {HttpClient, HttpHeaders} from "@angular/common/http";
 import type {AngularError, Failure} from "tim/util/utils";
-import {defaultTaskIdMissingMessage, toPromise} from "tim/util/utils";
+import {toPromise} from "tim/util/utils";
 import type {PluginMarkupErrors} from "tim/plugin/util";
 import {getDefaults, PluginBaseCommon, PluginMeta} from "tim/plugin/util";
 import {DomSanitizer} from "@angular/platform-browser";
@@ -218,7 +218,7 @@ export abstract class AngularPluginBase<
                 ok: false,
                 result: {
                     error: {
-                        error: defaultTaskIdMissingMessage,
+                        error: $localize`Task id missing and required to answer this task.`,
                     },
                 },
             } as Failure<AngularError>;

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -6,6 +6,7 @@ import type {
 } from "tim/plugin/attributes";
 import type {Type} from "io-ts";
 import {HttpClient, HttpHeaders} from "@angular/common/http";
+import type {AngularError, Failure} from "tim/util/utils";
 import {toPromise} from "tim/util/utils";
 import type {PluginMarkupErrors} from "tim/plugin/util";
 import {getDefaults, PluginBaseCommon, PluginMeta} from "tim/plugin/util";
@@ -193,7 +194,14 @@ export abstract class AngularPluginBase<
     ) {
         const tid = this.pluginMeta.getTaskId();
         if (!tid) {
-            throw Error("Task id missing.");
+            return {
+                ok: false,
+                result: {
+                    error: {
+                        error: "Task id missing.",
+                    },
+                },
+            } as Failure<AngularError>;
         }
         const dt = tid.docTaskIdFull();
         const {url, data} = prepareAnswerRequest(

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -7,7 +7,7 @@ import type {
 import type {Type} from "io-ts";
 import {HttpClient, HttpHeaders} from "@angular/common/http";
 import type {AngularError, Failure} from "tim/util/utils";
-import {toPromise} from "tim/util/utils";
+import {defaultTaskIdMissingMessage, toPromise} from "tim/util/utils";
 import type {PluginMarkupErrors} from "tim/plugin/util";
 import {getDefaults, PluginBaseCommon, PluginMeta} from "tim/plugin/util";
 import {DomSanitizer} from "@angular/platform-browser";
@@ -198,7 +198,7 @@ export abstract class AngularPluginBase<
                 ok: false,
                 result: {
                     error: {
-                        error: "Task id missing.",
+                        error: defaultTaskIdMissingMessage,
                     },
                 },
             } as Failure<AngularError>;

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -20,6 +20,8 @@ import {
 import type {IAnswerSaveEvent} from "tim/answer/answer-browser.component";
 import {isLeft} from "fp-ts/Either";
 import {getErrors} from "tim/plugin/errors";
+import {vctrlInstance} from "tim/document/viewctrlinstance";
+import type {ViewCtrl} from "tim/document/viewctrl";
 
 /**
  * Plugin with initialization data passed from the server via JSON.
@@ -47,6 +49,8 @@ export abstract class AngularPluginBase<
     @Input() readonly json!: string;
     @Input() readonly plugintype?: string;
     @Input() readonly taskid?: string;
+    protected vctrl!: ViewCtrl;
+    protected requiresTaskId = true;
 
     markupError?: PluginMarkupErrors;
     protected pluginMeta: PluginMeta;
@@ -140,6 +144,7 @@ export abstract class AngularPluginBase<
                 this.taskid
             );
         }
+        this.vctrl = vctrlInstance!;
     }
 
     async tryResetChanges(e?: Event) {

--- a/timApp/static/scripts/tim/plugin/calendar/calendar.component.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/calendar.component.ts
@@ -409,6 +409,7 @@ export class CalendarComponent
 
     private segmentMinutes!: number;
     minimumEventHeight!: number;
+    requiresTaskId = false;
 
     constructor(
         el: ElementRef<HTMLElement>,
@@ -747,7 +748,6 @@ export class CalendarComponent
     ngOnInit() {
         this.icsURL = "";
         super.ngOnInit();
-        this.requiresTaskId = false;
         this.viewMode =
             CalendarView[capitalizeFirstLetter(this.viewOptions.mode)];
         if (this.viewOptions.date) {

--- a/timApp/static/scripts/tim/plugin/calendar/calendar.component.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/calendar.component.ts
@@ -747,7 +747,7 @@ export class CalendarComponent
     ngOnInit() {
         this.icsURL = "";
         super.ngOnInit();
-
+        this.requiresTaskId = false;
         this.viewMode =
             CalendarView[capitalizeFirstLetter(this.viewOptions.mode)];
         if (this.viewOptions.date) {

--- a/timApp/static/scripts/tim/plugin/imagex/imagex.component.ts
+++ b/timApp/static/scripts/tim/plugin/imagex/imagex.component.ts
@@ -22,13 +22,8 @@ import {
     valueOr,
 } from "tim/util/utils";
 import {editorChangeValue} from "tim/editor/editorScope";
-import type {
-    ITimComponent,
-    IVelpableComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
+import type {ITimComponent, IVelpableComponent} from "tim/document/viewctrl";
 import {ChangeType} from "tim/document/viewctrl";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import type {
     IDrawOptions,

--- a/timApp/static/scripts/tim/plugin/imagex/imagex.component.ts
+++ b/timApp/static/scripts/tim/plugin/imagex/imagex.component.ts
@@ -1431,7 +1431,7 @@ export class ImageXComponent
     private tries = 0;
     public previewColor = "";
     public isRunning: boolean = false;
-    private vctrl!: ViewCtrl;
+
     public replyImage?: string;
     public replyHTML?: string;
     private bgCanvas!: HTMLCanvasElement;
@@ -1485,7 +1485,7 @@ export class ImageXComponent
 
     async ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         if (!this.attrsall.preview) {
             this.vctrl.addTimComponent(this, this.markup.tag);
         }

--- a/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
+++ b/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
@@ -172,7 +172,7 @@ export class PluginLoaderComponent implements AfterViewInit, OnDestroy, OnInit {
 
     async ngOnInit() {
         this.viewctrl = vctrlInstance;
-        if (this.viewctrl && !this.preview) {
+        if (this.viewctrl && !this.preview && this.taskId) {
             this.viewctrl.registerPluginLoader(this);
         }
         if (!this.taskId) {

--- a/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
+++ b/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
@@ -621,7 +621,7 @@ export class PluginLoaderComponent implements AfterViewInit, OnDestroy, OnInit {
     }
 
     warnAboutMissingTaskId() {
-        this.error = "Plugin is missing task id";
+        this.error = $localize`Plugin is missing task id`;
     }
 
     getPrerequisiteLockedText() {

--- a/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
+++ b/timApp/static/scripts/tim/plugin/plugin-loader.component.ts
@@ -175,6 +175,9 @@ export class PluginLoaderComponent implements AfterViewInit, OnDestroy, OnInit {
         if (this.viewctrl && !this.preview) {
             this.viewctrl.registerPluginLoader(this);
         }
+        if (!this.taskId) {
+            this.viewctrl?.registerPluginLoaderWithoutTaskId(this);
+        }
         const r = TaskId.tryParse(this.taskId);
         if (r.ok) {
             this.parsedTaskId = r.result;
@@ -615,6 +618,10 @@ export class PluginLoaderComponent implements AfterViewInit, OnDestroy, OnInit {
             }
         }
         return false;
+    }
+
+    warnAboutMissingTaskId() {
+        this.error = "Plugin is missing task id";
     }
 
     getPrerequisiteLockedText() {

--- a/timApp/static/scripts/tim/plugin/qst/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst/qst.component.ts
@@ -18,12 +18,11 @@ import {
     AnswerSheetModule,
     makePreview,
 } from "tim/document/question/answer-sheet.component";
-import type {ITimComponent, ViewCtrl} from "tim/document/viewctrl";
+import type {ITimComponent} from "tim/document/viewctrl";
 import {ChangeType} from "tim/document/viewctrl";
 import type {AnswerTable, IQuestionMarkup} from "tim/lecture/lecturetypes";
 import {AskedJsonJsonCodec} from "tim/lecture/lecturetypes";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {PurifyModule} from "tim/util/purify.module";
 import {showQuestionAskDialog} from "tim/lecture/showLectureDialogs";
 import type {ParContext} from "tim/document/structure/parContext";
@@ -110,7 +109,7 @@ export class QstComponent
     log?: string;
     isRunning: boolean = false;
     result?: string;
-    private vctrl!: ViewCtrl;
+
     preview!: IPreviewParams; // ngOnInit
     button: string = "";
     private savedAnswer?: AnswerTable;
@@ -170,7 +169,7 @@ export class QstComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         if (!this.pluginMeta.isPreview()) {
             this.vctrl.addTimComponent(this);
         }

--- a/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
+++ b/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
@@ -24,11 +24,7 @@ import type {Subscription} from "rxjs";
 import {Subject} from "rxjs";
 import {debounceTime, distinctUntilChanged} from "rxjs/operators";
 import {PurifyModule} from "tim/util/purify.module";
-import {
-    defaultErrorMessage,
-    defaultTaskIdMissingMessage,
-    defaultTimeout,
-} from "tim/util/utils";
+import {defaultErrorMessage, defaultTimeout} from "tim/util/utils";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import type {ITimComponent, IVelpableComponent} from "tim/document/viewctrl";
 import type {IUser} from "tim/user/IUser";
@@ -237,7 +233,6 @@ export class ReviewCanvasComponent
         if (taskId?.docId) {
             this.uploadUrl = `/pluginUpload/${taskId.docId}/${taskId.name}/`;
         } else {
-            this.userErrorMessage = defaultTaskIdMissingMessage;
             this.enabled = false;
             return;
         }

--- a/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
+++ b/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
@@ -30,12 +30,7 @@ import {
     defaultTimeout,
 } from "tim/util/utils";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
-import type {
-    ITimComponent,
-    IVelpableComponent,
-    ViewCtrl,
-} from "tim/document/viewctrl";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
+import type {ITimComponent, IVelpableComponent} from "tim/document/viewctrl";
 import type {IUser} from "tim/user/IUser";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {
@@ -199,7 +194,7 @@ export class ReviewCanvasComponent
     private modelChangeSub!: Subscription;
     changes = false;
     private loadedImages = 0;
-    private vctrl!: ViewCtrl;
+
     enabled = true;
 
     fileSelect?: FileSelectManagerComponent;
@@ -234,7 +229,7 @@ export class ReviewCanvasComponent
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         if (!this.attrsall.preview) {
             this.vctrl.addTimComponent(this, this.markup.tag);
         }

--- a/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
+++ b/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
@@ -24,7 +24,11 @@ import type {Subscription} from "rxjs";
 import {Subject} from "rxjs";
 import {debounceTime, distinctUntilChanged} from "rxjs/operators";
 import {PurifyModule} from "tim/util/purify.module";
-import {defaultErrorMessage, defaultTimeout} from "tim/util/utils";
+import {
+    defaultErrorMessage,
+    defaultTaskIdMissingMessage,
+    defaultTimeout,
+} from "tim/util/utils";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import type {
     ITimComponent,
@@ -238,7 +242,7 @@ export class ReviewCanvasComponent
         if (taskId?.docId) {
             this.uploadUrl = `/pluginUpload/${taskId.docId}/${taskId.name}/`;
         } else {
-            this.userErrorMessage = "Task id is missing";
+            this.userErrorMessage = defaultTaskIdMissingMessage;
             this.enabled = false;
             return;
         }

--- a/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
+++ b/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
@@ -128,7 +128,7 @@ const PluginFields = t.intersection([
         <a *ngIf="uploadedFiles.length > 0 && !isUnSaved() && downloadPDFUrl" [href]="downloadPDFUrl" target="_blank">{{downloadPDFText()}}</a>
         <p stem *ngIf="stem" [innerHTML]="stem | purify"></p>
         <div *ngIf="!inReviewView()">
-            <ng-container body>
+            <ng-container *ngIf="enabled" body>
                 <div class="form-inline small">
                     <div style="position: relative;" *ngFor="let item of uploadedFiles; let i = index">
                         <div class="uploadContainer" #wraps>
@@ -165,7 +165,7 @@ const PluginFields = t.intersection([
                 <span *ngIf="connectionErrorMessage" class="error" [innerHTML]="connectionErrorMessage"></span>
                 <span *ngIf="userErrorMessage" class="error" [innerHTML]="userErrorMessage"></span>
             </div>
-            <button class="timButton" (click)="save()" i18n>Save answer</button>
+            <button *ngIf="enabled" class="timButton" (click)="save()" i18n>Save answer</button>
         </div>
         <p footer *ngIf="footer" [textContent]="footer"></p>
     `,
@@ -196,6 +196,7 @@ export class ReviewCanvasComponent
     changes = false;
     private loadedImages = 0;
     private vctrl!: ViewCtrl;
+    enabled = true;
 
     fileSelect?: FileSelectManagerComponent;
     uploadUrl?: string;
@@ -236,6 +237,10 @@ export class ReviewCanvasComponent
         const taskId = this.pluginMeta.getTaskId();
         if (taskId?.docId) {
             this.uploadUrl = `/pluginUpload/${taskId.docId}/${taskId.name}/`;
+        } else {
+            this.userErrorMessage = "Task id is missing";
+            this.enabled = false;
+            return;
         }
 
         this.modelChangeSub = this.modelChanged

--- a/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
+++ b/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
@@ -14,10 +14,8 @@ import {HttpClient, HttpClientModule} from "@angular/common/http";
 import {FormsModule} from "@angular/forms";
 import type {OnClickArg} from "tim/document/eventhandlers";
 import {onClick} from "tim/document/eventhandlers";
-import type {ViewCtrl} from "tim/document/viewctrl";
 import type {IRights} from "tim/user/IRights";
 import {genericglobals} from "tim/util/globals";
-import {vctrlInstance} from "tim/document/viewctrlinstance";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {AnswerSheetModule} from "tim/document/question/answer-sheet.component";
 import {PurifyModule} from "tim/util/purify.module";
@@ -150,7 +148,7 @@ export class TimMenuPluginComponent extends AngularPluginBase<
     typeof TimMenuAll
 > {
     menu: ITimMenuItem[] = [];
-    private vctrl!: ViewCtrl;
+
     openingSymbol: string = "";
     private hoverOpen: boolean = true;
     separator: string = "";
@@ -187,7 +185,7 @@ export class TimMenuPluginComponent extends AngularPluginBase<
 
     ngOnInit() {
         super.ngOnInit();
-        this.vctrl = vctrlInstance!;
+
         if (this.vctrl == null || this.vctrl.isSlideOrShowSlideView()) {
             return;
         }

--- a/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
+++ b/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
@@ -169,6 +169,7 @@ export class TimMenuPluginComponent extends AngularPluginBase<
     private previouslyScrollingDown: boolean = true;
     private userPrefersHoverDisabled: boolean = false;
     private touchMode: boolean = false; // If a touch event has been detected in HTML body.
+    requiresTaskId = false;
 
     getDefaultMarkup() {
         return {};
@@ -185,7 +186,6 @@ export class TimMenuPluginComponent extends AngularPluginBase<
 
     ngOnInit() {
         super.ngOnInit();
-        this.requiresTaskId = false;
         if (this.vctrl == null || this.vctrl.isSlideOrShowSlideView()) {
             return;
         }

--- a/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
+++ b/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
@@ -185,7 +185,7 @@ export class TimMenuPluginComponent extends AngularPluginBase<
 
     ngOnInit() {
         super.ngOnInit();
-
+        this.requiresTaskId = false;
         if (this.vctrl == null || this.vctrl.isSlideOrShowSlideView()) {
             return;
         }

--- a/timApp/static/scripts/tim/util/utils.ts
+++ b/timApp/static/scripts/tim/util/utils.ts
@@ -343,7 +343,7 @@ interface Success<T> {
     result: T;
 }
 
-interface Failure<T> {
+export interface Failure<T> {
     ok: false;
     result: T;
 }
@@ -351,7 +351,7 @@ interface Failure<T> {
 export type Result<T, U> = Success<T> | Failure<U>;
 
 type AngularJSError = {data: {error: string}; status?: number};
-type AngularError = {error: {error: string}; status?: number};
+export type AngularError = {error: {error: string}; status?: number};
 
 export function mapSuccess<T, U, M>(
     r: Result<T, U>,

--- a/timApp/static/scripts/tim/util/utils.ts
+++ b/timApp/static/scripts/tim/util/utils.ts
@@ -25,6 +25,7 @@ export const UnknownRecord = t.record(t.string, t.unknown);
 const UnknownRecordOrArray = t.union([UnknownRecord, t.array(t.unknown)]);
 
 export const defaultErrorMessage = "Syntax error or no reply from server?";
+export const defaultTaskIdMissingMessage = $localize`Task id missing and required to answer this task.`;
 export const defaultWuffMessage = $localize`Something went wrong. TIM admins have been notified about the issue.`;
 export const defaultTimeout = 20000;
 

--- a/timApp/static/scripts/tim/util/utils.ts
+++ b/timApp/static/scripts/tim/util/utils.ts
@@ -25,7 +25,6 @@ export const UnknownRecord = t.record(t.string, t.unknown);
 const UnknownRecordOrArray = t.union([UnknownRecord, t.array(t.unknown)]);
 
 export const defaultErrorMessage = "Syntax error or no reply from server?";
-export const defaultTaskIdMissingMessage = $localize`Task id missing and required to answer this task.`;
 export const defaultWuffMessage = $localize`Something went wrong. TIM admins have been notified about the issue.`;
 export const defaultTimeout = 20000;
 

--- a/timApp/tests/browser/test_csplugin.py
+++ b/timApp/tests/browser/test_csplugin.py
@@ -283,6 +283,39 @@ postprogram: |!!
         self.assertEqual("Laske: 10 + -3", self.find_element(".stem").text)
         self.assertEqual("4/3", self.find_element(".answer-index-count").text)
 
+    def test_missing_taskid_warning(self):
+        self.login_browser_quick_test1()
+        self.login_test1()
+        d = self.create_doc(
+            initial_par="""
+#- {plugin=csPlugin}
+type: text
+"""
+        )
+        self.goto_document(d)
+        self.wait_until_present_and_vis("tim-plugin-loader .alert")
+        loader_warning = "Plugin is missing task id"
+        # Default warning is visible by default
+        self.assertEqual(
+            loader_warning,
+            self.find_element("tim-plugin-loader .alert").text,
+        )
+        self.find_element("cs-runner .csRunMenu button").click()
+        self.wait_until_present_and_vis("cs-runner .error")
+        # Fallback warning shows if user answers a task without taskid
+        self.assertEqual(
+            "Task id missing and required to answer this task.",
+            self.find_element("cs-runner .error").text,
+        )
+        self.find_element(".edit-menu-button").click()
+        self.drv.find_elements(By.CSS_SELECTOR, ".flex-grow-5")[3].click()
+        self.wait_until_present_and_vis(".previewcontent tim-plugin-loader .alert")
+        # Warnings should appear in preview too
+        self.assertEqual(
+            loader_warning,
+            self.find_element(".previewcontent tim-plugin-loader .alert").text,
+        )
+
 
 class StackRandomTest(BrowserTest):
     def test_csplugin_answernr_stack1(self):

--- a/timApp/tests/browser/test_fields.py
+++ b/timApp/tests/browser/test_fields.py
@@ -103,13 +103,15 @@ copy: target
         )
         self.goto_document(d)
 
-        def send_input(task: str, input: str | None):
+        def send_input(task: str, input: str | None, autosave=True):
             self.wait_until_present_and_vis(f"#{task} input")
             field = self.find_element_and_move_to(f"#{task} input")
-            self.wait_until_hidden(f"#{task} button")
             if input:
                 field.send_keys(input)
-                ActionChains(self.drv).send_keys(Keys.ENTER).perform()
+                if autosave:
+                    self.get_uninteractable_element().click()
+                else:
+                    ActionChains(self.drv).send_keys(Keys.ENTER).perform()
             else:
                 field.click()
             # Tooltip triggers on save
@@ -137,6 +139,8 @@ copy: target
 
         send_input("textfield", "Hello")
         send_input("numericfield", "400")
+        send_input("textfield", "Hello again", False)
+        send_input("numericfield", "400004", False)
         send_input("cbfield", None)
         send_input("cbcountfield", None)
         send_input("rbfield", None)


### PR DESCRIPTION
Perusidea: kaikki pluginit laitetaan varoittamaan puuttuvasta task-id:stä.

Oletuksena kaikki `AngularPluginBase`n perivät pluginit varoittavat mikäli task-id puuttuu. Jotkut plugintyypit (kuten showVideo tai jsframe ilman drawiota) eivät varoita. Tuota joutunee vielä kartoittamaan että löytyykö vielä plugineita joissa ei käytetä task-id:tä.

https://timdevs01-3.it.jyu.fi/view/no_tids