### PR TITLE
Set default width for draggable-block

### DIFF
--- a/timApp/static/stylesheets/style.scss
+++ b/timApp/static/stylesheets/style.scss
@@ -52,6 +52,8 @@ tim-dialog-frame {
     z-index: 1200 !important;
     position: static;
     background-color: var(--bg-color);
+    // need calc here because vanilla Sass does not support min(), max() etc. with differing units
+    width: calc(max(800px, 20em));
 
     &.draggable-attached {
         width: initial !important;

--- a/timApp/static/stylesheets/style.scss
+++ b/timApp/static/stylesheets/style.scss
@@ -54,7 +54,6 @@ tim-dialog-frame {
     background-color: var(--bg-color);
 
     &.draggable-detached {
-        // need calc here because vanilla Sass does not support min(), max() etc. with differing units
         width: $paragraph-preferred-width;
     }
 

--- a/timApp/static/stylesheets/style.scss
+++ b/timApp/static/stylesheets/style.scss
@@ -54,7 +54,7 @@ tim-dialog-frame {
     background-color: var(--bg-color);
 
     &.draggable-detached {
-        width: $paragraph-preferred-width;
+        width: var(--paragraph-preferred-width);
     }
 
     &.draggable-attached {

--- a/timApp/static/stylesheets/style.scss
+++ b/timApp/static/stylesheets/style.scss
@@ -52,8 +52,11 @@ tim-dialog-frame {
     z-index: 1200 !important;
     position: static;
     background-color: var(--bg-color);
-    // need calc here because vanilla Sass does not support min(), max() etc. with differing units
-    width: calc(max(800px, 20em));
+
+    &.draggable-detached {
+        // need calc here because vanilla Sass does not support min(), max() etc. with differing units
+        width: $paragraph-preferred-width;
+    }
 
     &.draggable-attached {
         width: initial !important;


### PR DESCRIPTION
Fixes `draggable-block`s being initialized to (almost) 100% of window width when they are detached from the document.