### PR TITLE
Add a wait to prevent double toolbars in test_focus_callbacks

### DIFF
--- a/timApp/tests/browser/test_timtable.py
+++ b/timApp/tests/browser/test_timtable.py
@@ -904,6 +904,7 @@ table:
         self.goto_document(d)
         td = self.find_element_avoid_staleness("#tabletask td")
         td.click()
+        self.wait_until_present_and_vis("tim-table-editor-toolbar-dialog")
         td.click()
         ActionChains(self.drv).send_keys("Hello").perform()
         td = self.find_element_avoid_staleness("#tableForm tbody td:nth-of-type(6)")


### PR DESCRIPTION
Parantaa timtablen focus-testiä niin että solua muokatessa odotetaan timtablen toolbarin aukeamista. Jos solun muokkauksen aloittaa tuplaklikkamalla robottinopeudella niin toolbar kerkeää aueta kahdesti ja sitten loput testistä hajoaa