### PR TITLE
Use field styles in plaintext mode

### DIFF
--- a/timApp/modules/fields/js/numericfield-plugin.component.ts
+++ b/timApp/modules/fields/js/numericfield-plugin.component.ts
@@ -336,8 +336,10 @@ export class NumericfieldPluginComponent
                     message = 'Value at "c" was not a valid number';
                 }
 
-                if (!this.markup.ignorestyles && content.styles) {
-                    this.styles = parseStyles(content.styles);
+                if (!this.markup.ignorestyles) {
+                    this.styles = content.styles
+                        ? parseStyles(content.styles)
+                        : {};
                 }
             }
             this.initialValue = this.numericvalue;

--- a/timApp/modules/fields/js/numericfield-plugin.component.ts
+++ b/timApp/modules/fields/js/numericfield-plugin.component.ts
@@ -108,7 +108,7 @@ const NumericfieldAll = t.intersection([
                     {{buttonText()}}
                </button>
       </span>
-      <span *ngIf="isPlainText()" class="plaintext" [style.width.em]="cols">{{numericvalue}}</span>
+      <span *ngIf="isPlainText()" class="plaintext" [style.width.em]="cols" [ngStyle]="styles">{{numericvalue}} </span>
      </span></label>
     </div>
     <button class="timButton"

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -132,7 +132,7 @@ export type TFieldContent = t.TypeOf<typeof FieldContent>;
                     {{buttonText()}}
                </button>
          </span>
-         <span *ngIf="isPlainText() && !isDownloadButton" [innerHtml]="userword | purify" class="plaintext" [style.width.em]="cols" style="max-width: 100%"></span>
+         <span *ngIf="isPlainText() && !isDownloadButton" [innerHtml]="userword | purify" class="plaintext" [style.width.em]="cols" style="max-width: 100%" [ngStyle]="styles"></span>
          <a *ngIf="isDownloadButton" class="timButton" [href]="userWordBlobUrl" [download]="downloadButtonFile">{{downloadButton}}</a>
          </span></label>
     </form>


### PR DESCRIPTION
Text- ja numericfield tottelee värimäärityksiään myös plaintext-näkymässä

https://timdevs01-3.it.jyu.fi/view/field-styles