### PR TITLE
Fix typos, add spell checking to CI

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,12 @@
+name: Check spelling
+
+on: push
+
+jobs:
+  check_spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check spelling of repository files
+        uses: crate-ci/typos@v1.13.6

--- a/cli/commands/npmi.py
+++ b/cli/commands/npmi.py
@@ -10,7 +10,7 @@ Run `npm install` to install TIM dependencies.
 
 The version of NPM that is used is determined by the OS.
 On Windows, the NPM that is installed on the system is used.
-On Linux, NPM packaged withing TIM image is used.
+On Linux, NPM packaged within TIM image is used.
 """,
 }
 

--- a/timApp/admin/translationservice_cli.py
+++ b/timApp/admin/translationservice_cli.py
@@ -39,7 +39,7 @@ def add_all_new() -> None:
 
 def add_all_tr_services_to_session(log: bool = False) -> None:
     """
-    Add all supported translation services to be commited to database.
+    Add all supported translation services to be committed to database.
     Note: session.commit must be called afterwards to save the changes!
 
     Supported translation services must be implemented and are also listed in

--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -909,7 +909,7 @@ def get_points_by_rule(
         if rule.total:
             s = groupsums[
                 0
-            ]  # TODO: find indesies from total, total is a list of names to count
+            ]  # TODO: find indices from total, total is a list of names to count
             task_groups["task_sum"] = round_if_not_none(s[0])
             task_groups["velp_sum"] = round_if_not_none(s[1])
             task_groups["total_sum"] = round_if_not_none(s[2])

--- a/timApp/answer/feedbackanswer.py
+++ b/timApp/answer/feedbackanswer.py
@@ -257,7 +257,7 @@ def print_feedback_report(doc_path: str):
     elif name == "both":
         fullname = True
 
-    # Dialect names for the csv-writer delimitors.
+    # Dialect names for the csv-writer delimiters.
     if format == "tab":
         dialect = "excel-tab"
     elif format == "comma":

--- a/timApp/auth/saml/attributes.py
+++ b/timApp/auth/saml/attributes.py
@@ -21,13 +21,13 @@ class SAMLUserAttributes:
               https://wiki.eduuni.fi/display/CSCHAKA/funetEduPersonSchema2dot4
     """
 
-    response_attribues: dict[str, Any]
+    response_attributes: dict[str, Any]
     """
     Raw attribute data
     """
 
     def _get_attribute_safe(self, name: str) -> Optional[_T]:
-        return self.response_attribues.get(name, [None])[0]
+        return self.response_attributes.get(name, [None])[0]
 
     def _get_attribute(self, name: str) -> _T:
         value = self._get_attribute_safe(name)
@@ -106,7 +106,7 @@ class SAMLUserAttributes:
 
         :return: List of identity assurance profiles (IAPs)
         """
-        res = self.response_attribues.get("eduPersonAssurance")
+        res = self.response_attributes.get("eduPersonAssurance")
         if not isinstance(res, list):
             raise RouteException("eduPersonAssurance is not a list")
         return res
@@ -146,7 +146,7 @@ class SAMLUserAttributes:
 
         :return: A list of unique codes of the user
         """
-        return self.response_attribues.get("schacPersonalUniqueCode")
+        return self.response_attributes.get("schacPersonalUniqueCode")
 
     @property
     def derived_username(self) -> str:

--- a/timApp/auth/session/util.py
+++ b/timApp/auth/session/util.py
@@ -220,7 +220,7 @@ def distribute_session_verification(
     Distribute a session verification operation to the specified targets.
 
     .. note:: The function requires right distribution to be enabled.
-              Session verfication is distributed and verified with :ref:`timApp.defaultconfig.DIST_RIGHTS_SEND_SECRET`
+              Session verification is distributed and verified with :ref:`timApp.defaultconfig.DIST_RIGHTS_SEND_SECRET`
               and :ref:`timApp.defaultconfig.DIST_RIGHTS_RECEIVE_SECRET` configuration options.
 
     :param action: Action to perform. Usually either "verify" or "invalidate".

--- a/timApp/bookmark/bookmarks.py
+++ b/timApp/bookmark/bookmarks.py
@@ -43,7 +43,7 @@ class Bookmarks:
           }
         ]
 
-        This class mainly allows to handle bookmars in a more convenient way.
+        This class mainly allows to handle bookmarks in a more convenient way.
     """
 
     def __init__(self, user: User):

--- a/timApp/celery_sqlalchemy_scheduler/schedulers.py
+++ b/timApp/celery_sqlalchemy_scheduler/schedulers.py
@@ -78,7 +78,7 @@ class ModelEntry(ScheduleEntry):
             self.kwargs = loads(model.kwargs or "{}")
         except ValueError as exc:
             logger.exception(
-                "Removing schedule %s for argument deseralization error: %r",
+                "Removing schedule %s for argument deserialization error: %r",
                 self.name,
                 exc,
             )
@@ -165,7 +165,7 @@ class ModelEntry(ScheduleEntry):
     def _default_now(self):
         now = self.app.now()
         # The PyTZ datetime must be localised for the Django-Celery-Beat
-        # scheduler to work. Keep in mind that timezone arithmatic
+        # scheduler to work. Keep in mind that timezone arithmetic
         # with a localized timezone may be inaccurate.
         # return now.tzinfo.localize(now.replace(tzinfo=None))
         return now.replace(tzinfo=self.app.timezone)
@@ -480,5 +480,5 @@ class DatabaseScheduler(Scheduler):
     @property
     def info(self):
         """override"""
-        # return infomation about Schedule
+        # return information about Schedule
         return f"    . db -> {self.dburi}"

--- a/timApp/document/docparagraph.py
+++ b/timApp/document/docparagraph.py
@@ -1366,7 +1366,7 @@ def add_heading_numbers(
 ):
     d = ctx.doc
     macro_cache_file = f"/tmp/tim_auto_macros_{ctx.doc.doc_id}"
-    # TODO: Cache sould be picked up only once and used as a paramter
+    # TODO: Cache should be picked up only once and used as a parameter
     ps = commonmark.Parser()
     parsed = ps.parse(s)
     with shelve.open(macro_cache_file) as cache:

--- a/timApp/document/minutes/routes.py
+++ b/timApp/document/minutes/routes.py
@@ -79,7 +79,7 @@ def create_minute_extracts(doc: str) -> Response:
 
     # we detect an extract by searching the document's non-expanded markdown for the extract macro
     # all paragraphs between two such macros belong to the same extract
-    # the rest of the document after the last occurence of the macro belong to the last extract
+    # the rest of the document after the last occurrence of the macro belong to the last extract
 
     markdown_to_find = "%%lista("
     end_markdown = ")%%"

--- a/timApp/document/translation/translationparser.py
+++ b/timApp/document/translation/translationparser.py
@@ -255,12 +255,12 @@ class TranslationParser:
     def quoted_collect(self, content: dict) -> list[TranslateApproval]:
         """
         Collect and separate translatable and untranslatable areas within
-        quatation marks.
-        Quatation element is delimited by quatation marks.
+        quotation marks.
+        Quotation element is delimited by quotation marks.
 
         Pandoc: https://hackage.haskell.org/package/pandoc-types-1.22.1/docs/Text-Pandoc-Definition.html#t:Inline
 
-        :param content: The types of quatation marks used and the text (list
+        :param content: The types of quotation marks used and the text (list
          of inlines) from Inline element: [ QuoteType, [Inline] ].
         :return: List containing the parsed collection of Quoted content.
         """

--- a/timApp/document/yamlblock.py
+++ b/timApp/document/yamlblock.py
@@ -112,8 +112,8 @@ def get_code_block_str(md: str) -> str:
 
 def compare_same(s1: str, s2: str, n: int) -> bool:
     """
-    :param s1: string than can contain max n spaces at the begining
-    :param s2: string to oompare, no spaces in the begining
+    :param s1: string than can contain max n spaces at the beginning
+    :param s2: string to oompare, no spaces in the beginning
     :param n: how many spaces allowed to caintain still to be same
     :return: True is same False other
     """
@@ -138,8 +138,8 @@ def correct_obj(text: str) -> str:
     """
     """
      Problem analyze:
-        il = atribute line indent len,   fi = first line indent
-        indent = string that must be inserted to every line, len = it's lenght
+        il = attribute line indent len,   fi = first line indent
+        indent = string that must be inserted to every line, len = it's length
 
         |a1: @!            il = 0, fi = 0     il-fi+1  = 1 
         |a            => indent=" "   len 1 

--- a/timApp/markdown/autocounters.py
+++ b/timApp/markdown/autocounters.py
@@ -163,7 +163,7 @@ class AutoCounters:
         Set start of autonames
 
         :param base_name: base name for counters in this block
-        :return: emtpy string because used from filter
+        :return: empty string because used from filter
         """
         self.auto_name_base = base_name
         return ""
@@ -174,7 +174,7 @@ class AutoCounters:
 
         :param base_name: base name for counters in this block
         :param ctype: default type for counters in this block
-        :return: emtpy string because used from filter
+        :return: empty string because used from filter
         """
         if isinstance(base_name, int):
             base_name = None
@@ -256,7 +256,7 @@ class AutoCounters:
     def set_auto_number_headings(self, n: int) -> None:
         """
         Set from what level the headings are numbered.
-        Make also the dafault counter number template for that level
+        Make also the default counter number template for that level
         like "{h2}.{v}" if counting start from level 2.
 
         :param n: from what level to start heading counting
@@ -478,7 +478,7 @@ class AutoCounters:
             counter: TCounter | None = use_counters_type.counters.get(sname)
             use_counters_type.count += 1
             value: int = use_counters_type.count
-            if counter:  # shold not be
+            if counter:  # should not be
                 counter["s"] = self.error("Duplicate " + sname)
             else:
                 pure = self.get_type_text(ctype, sname, value, "pure", str(value))
@@ -499,9 +499,9 @@ class AutoCounters:
                     prefix = ""
                 counter = {
                     "v": value,  # just value, mostly numeric
-                    "p": pure,  # formated value
+                    "p": pure,  # formatted value
                     "s": show,  # show in place of counter
-                    "r": ref,  # normal refence format
+                    "r": ref,  # normal reference format
                     "t": text,  # with text
                     "l": long,  # long format, mostly for section header
                     "h": prefix + hname.replace(" ", "_"),  # Jump address
@@ -641,7 +641,7 @@ class AutoCounters:
     def get_label_placeholder(self) -> str:
         """
         returns next labels placeholder if there is labels
-        that can not be anchored to begining of the LaTeX environment
+        that can not be anchored to beginning of the LaTeX environment
         :return: placeholder for label that is replaced by
                  real labes after whole block is ready
         """
@@ -758,7 +758,7 @@ class AutoCounters:
         Return counter values as string to be appended to settings
 
         :param _dummy:  if used as filter
-        :return: counter values as settigs macro
+        :return: counter values as settings macro
         """
         result = """
 macros:        
@@ -824,9 +824,9 @@ macros:
         :param ctype: counter's type name
         :param name: name of counter
         :param value: value of counter to show
-        :param showtype: for what purpose value is formated
+        :param showtype: for what purpose value is formatted
         :param pure: pure value of counter
-        :return: formated show value
+        :return: formatted show value
         """
         vals = self.heading_vals
         if vals is None:
@@ -888,7 +888,7 @@ macros:
     def set_heading_vals(self, vals: dict) -> None:
         """
         This should be called every time when handling heading line.
-        Check whta counters should be reseted when heading numebrs changes
+        Check what counters should be reset when heading numbers changes
 
         :param vals: new values for current heading numbers
         :return: None

--- a/timApp/markdown/markdownconverter.py
+++ b/timApp/markdown/markdownconverter.py
@@ -143,7 +143,7 @@ def srange(s, i1, i2, step=1, *argv):
 # noinspection PyPep8Naming
 def Pz(i):
     """
-    Returns number as a string so that from 0 comes "", postive number comes like " + 1"
+    Returns number as a string so that from 0 comes "", positive number comes like " + 1"
     and negative comes like " - 1"
 
     :param i: number to convert
@@ -183,7 +183,7 @@ def week_to_date(week_nr, daynr=1, year=None, frmt=None):
     :param daynr: day of week to get date
     :param year: year to get date
     :param frmt: extended format string
-    :return: date object or formated string
+    :return: date object or formatted string
     """
     if week_nr <= 0:
         week_nr = date.today().isocalendar()[1]
@@ -205,7 +205,7 @@ def month_to_week(month, daynr=1, year=None):
     get week number for month
     see: timApp/tests/unit/test_datefilters.py
 
-    :param month: month numer starting from 1
+    :param month: month number starting from 1
     :param daynr: day number of month
     :param year: from what year
     :return: week number
@@ -229,7 +229,7 @@ def now(frmt=0):
     Or this week %% "%w" | now %%
 
     :param frmt: format for current date or delta for current date
-    :return: current date + (fmt as int) if fmt is int, otherwise current timestamp formated
+    :return: current date + (fmt as int) if fmt is int, otherwise current timestamp formatted
     """
     if isinstance(frmt, int):
         return datetime.now() + timedelta(days=frmt)
@@ -549,7 +549,7 @@ def par_list_to_html_list(
 
     texplain = settings.is_texplain()
     textplain = settings.is_textplain()
-    if texplain or textplain:  # add pre-markers to tex paragrpahs
+    if texplain or textplain:  # add pre-markers to tex paragraphs
         for i in range(0, len(texts)):
             text = texts[i]
             if text.find("```") != 0 and text.find("#") != 0:
@@ -631,10 +631,10 @@ def make_slide_fragments(html_text: str) -> str:
 
 # Checks if html element's content is surrounded with given string and edits it accordingly
 def check_and_edit_html_if_surrounded_with(
-    html_content: str, string_delimeter: str, editing_function
+    html_content: str, string_delimiter: str, editing_function
 ) -> str:
     # List of strings after splitting html from
-    html_list = html_content.split(string_delimeter)
+    html_list = html_content.split(string_delimiter)
     if len(html_list) < 2:
         return html_content
     else:

--- a/timApp/messaging/messagelist/emaillist.py
+++ b/timApp/messaging/messagelist/emaillist.py
@@ -382,7 +382,7 @@ def add_email(
     # TODO: The email_owner_pre_confirmation flag was made available for caller with the idea that when inviting to
     #  message list would be implemented, this would control whether the new user was invited or directly added.
     #  However, inviting will most likely be implemented with other means than Mailman's invite system, so the flag
-    #  might be unnecessary. When the invite to a messge list is implemented, check if this is still needed or if the
+    #  might be unnecessary. When the invite to a message list is implemented, check if this is still needed or if the
     #  flag is given the same constant value of True as the other two flags for pre_something.
 
     # We use pre_verify flag, because we assume email adder knows the address they are adding in. Otherwise they have

--- a/timApp/messaging/messagelist/messagelist_utils.py
+++ b/timApp/messaging/messagelist/messagelist_utils.py
@@ -569,7 +569,7 @@ def parse_mailman_message_address(
     original: dict, header: str
 ) -> list[EmailAndDisplayName] | None:
     """Parse (potentially existing) fields 'from' 'to', 'cc', or 'bcc' from a dict representing Mailman's email message.
-    The fields are in lists, with individual list indicies being lists themselves of the form
+    The fields are in lists, with individual list indices being lists themselves of the form
         ['Display Name', 'email@domain.fi']
 
     :param original: Original message.
@@ -654,7 +654,7 @@ def set_message_list_notify_owner_on_change(
 ) -> None:
     """Set the notify list owner on list change flag for a list, and update necessary channels with this information.
 
-    If the message list has an email list as a message channel, this will set the equilavent flag on the email list.
+    If the message list has an email list as a message channel, this will set the equivalent flag on the email list.
 
     :param message_list: The message list where the flag is being set.
     :param notify_owners_on_list_change_flag: An optional boolean flag. If True, then changes on the message list sends
@@ -682,7 +682,7 @@ def set_message_list_member_can_unsubscribe(
     """Set the list member's free unsubscription flag, and propagate that setting to channels that have own handling
     of unsubscription.
 
-    If the message list has an email list as a message channel, this will set the equilavent flag on the email list.
+    If the message list has an email list as a message channel, this will set the equivalent flag on the email list.
 
     :param message_list: Message list where the flag is being set.
     :param can_unsubscribe_flag: An optional boolean flag. For True, the member can unsubscribe on their own. For False,
@@ -761,7 +761,7 @@ def set_message_list_tim_users_can_join(
 
     :param message_list: Message list where the flag is being set.
     :param can_join_flag: An optional boolean flag. If True, then TIM users can directly join this list, no moderation
-    needed. If False, then TIM users can't direclty join the message list. If None, the current value is kept.
+    needed. If False, then TIM users can't directly join the message list. If None, the current value is kept.
     """
     if can_join_flag is None or message_list.tim_user_can_join == can_join_flag:
         return

--- a/timApp/messaging/messagelist/routes.py
+++ b/timApp/messaging/messagelist/routes.py
@@ -127,7 +127,7 @@ def test_name(name_candidate: str) -> None:
     """Check new message list's name candidate's name.
 
      The name has to meet naming rules, it has to be not already be in use and it cannot be a reserved name. If the
-     function retuns control to its caller, then name is viable to use for a message list. If at some point the name
+     function returns control to its caller, then name is viable to use for a message list. If at some point the name
      is not viable, then an exception is raised.
 
     :param name_candidate: The name candidate to check.
@@ -312,7 +312,7 @@ def parse_external_member(external_member_candidate: str) -> list[str] | None:
     or
         User Userington <user.userington@domain.fi>
 
-    :param external_member_candidate: A string represeting the external member.
+    :param external_member_candidate: A string representing the external member.
     :return: Return a list of the form [email, name_part_1, name_part_2, ...] if parsing was successful. Otherwise
     return None.
     """

--- a/timApp/messaging/timMessage/routes.py
+++ b/timApp/messaging/timMessage/routes.py
@@ -393,7 +393,7 @@ def create_tim_message(
     :param tim_message: InternalMessage object
     :param options: Options related to the message
     :param message_body: Message subject, contents and list of recipients
-    :param message_viewers: Groups that are allowed to view the message. If None, all recepients can.
+    :param message_viewers: Groups that are allowed to view the message. If None, all recipients can.
     :return: The created Document object
     """
     recipients = (

--- a/timApp/modules/cs/cassandra/cassandra.yaml
+++ b/timApp/modules/cs/cassandra/cassandra.yaml
@@ -273,7 +273,7 @@ commit_failure_policy: stop
 #
 # Valid values are either "auto" (omitting the value) or a value greater 0.
 #
-# Note that specifying a too large value will result in long running GCs and possbily
+# Note that specifying a too large value will result in long running GCs and possibly
 # out-of-memory errors. Keep the value at a small fraction of the heap.
 #
 # If you constantly see "prepared statements discarded in the last minute because
@@ -282,7 +282,7 @@ commit_failure_policy: stop
 # i.e. use bind markers for variable parts.
 #
 # Do only change the default value, if you really have more prepared statements than
-# fit in the cache. In most cases it is not neccessary to change this value.
+# fit in the cache. In most cases it is not necessary to change this value.
 # Constantly re-preparing statements is a performance penalty.
 #
 # Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater
@@ -809,7 +809,7 @@ snapshot_links_per_second: 0
 # number of rows per partition.  The competing goals are these:
 #
 # - a smaller granularity means more index entries are generated
-#   and looking up rows withing the partition by collation column
+#   and looking up rows within the partition by collation column
 #   is faster
 # - but, Cassandra will keep the collation index in memory for hot
 #   rows (as part of the key cache), so a larger granularity means
@@ -1212,7 +1212,7 @@ windows_timer_interval: 1
 
 # Enables encrypting data at-rest (on disk). Different key providers can be plugged in, but the default reads from
 # a JCE-style keystore. A single keystore can hold multiple keys, but the one referenced by
-# the "key_alias" is the only key that will be used for encrypt opertaions; previously used keys
+# the "key_alias" is the only key that will be used for encrypt operations; previously used keys
 # can still (and should!) be in the keystore and will be used on decrypt operations
 # (to handle the case of key rotation).
 #

--- a/timApp/modules/cs/cs.py
+++ b/timApp/modules/cs/cs.py
@@ -55,7 +55,7 @@ from tim_common.fileParams import (
     get_all_templates,
     file_to_string,
     get_template,
-    get_chache_keys,
+    get_cache_keys,
     clear_cache,
     replace_scripts,
     string_to_string_replace_url,
@@ -81,7 +81,7 @@ from ttype import TType
 #   markup tiedoston nimeksi 'csmarkup.json'
 #
 # Uuden kielen lisäämiseksi
-# 1. Mene tiedostoon languges.py ja kopioi sieltä luokka
+# 1. Mene tiedostoon languages.py ja kopioi sieltä luokka
 #        class Lang(Language):
 #      ja vaihda sille nimi, toteuta metodit ja täytä 'ttype' muuttuja.
 # 2. Tee tarvittava lisäys myös js/dir.js tiedoston kieliluetteloon.
@@ -715,7 +715,7 @@ def wait_file(f1):
     """Wait until the file is ready or 10 tries has been done.
 
     :param f1: filename to wait
-    :return: sthe file status if it became ready, otherwise False
+    :return: the file status if it became ready, otherwise False
 
     """
     count = 0
@@ -1020,20 +1020,20 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
         # print("do_POST MULTIHML ==========================================")
         t1 = time.perf_counter()
         t1t = time.time()
-        querys = multi_post_params(self)
+        queries = multi_post_params(self)
         do_headers(self, "application/json")
         is_tauno = self.path.find("/tauno") >= 0
         is_simcir = self.path.find("/simcir") >= 0
         is_parsons = self.path.find("/parsons") >= 0
         htmls = []
-        self.user_id = get_param(querys[0], "user_id", "--")
+        self.user_id = get_param(queries[0], "user_id", "--")
         if self.user_id != "--":
             print("UserId:", self.user_id)
         self.log()
-        # print(querys)
+        # print(queries)
 
         global_anonymous = False
-        for query in querys:
+        for query in queries:
             is_graphviz = get_graphviz_data(query) is not None
             try:
                 update_markup_from_file(query)
@@ -1330,7 +1330,7 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
 
         if self.path.find("refresh") >= 0:
             print(f"Cleaning cache")
-            keys, mem_cache_len, disk_cache_len = get_chache_keys()
+            keys, mem_cache_len, disk_cache_len = get_cache_keys()
             clear_cache()
             print(keys)
             self.wout(
@@ -1577,7 +1577,7 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
                             query.jso,
                             "markup",
                             "warnmessage",
-                            "Not recomended to use: " + warncondition,
+                            "Not recommended to use: " + warncondition,
                         )
 
                     # print(os.path.dirname(language.sourcefilename))

--- a/timApp/modules/cs/doxygen/Doxyfile
+++ b/timApp/modules/cs/doxygen/Doxyfile
@@ -1243,7 +1243,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are
 # not supported properly for IE 6.0, but are supported on all modern browsers.
 # Note that when changing this option you need to delete any form_*.png files
@@ -1788,7 +1788,7 @@ UML_LOOK               = NO
 # the class node. If there are many fields or methods and many nodes the
 # graph may become too big to be useful. The UML_LIMIT_NUM_FIELDS
 # threshold limits the number of items for each type to make the size more
-# managable. Set this to 0 for no limit. Note that the threshold may be
+# manageable. Set this to 0 for no limit. Note that the threshold may be
 # exceeded by 50% before the limit is enforced.
 
 UML_LIMIT_NUM_FIELDS   = 10

--- a/timApp/modules/cs/doxygen/def
+++ b/timApp/modules/cs/doxygen/def
@@ -1387,7 +1387,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #
@@ -1947,7 +1947,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/timApp/modules/cs/geogebra.py
+++ b/timApp/modules/cs/geogebra.py
@@ -160,7 +160,7 @@ Eval:
 </p>
 
 <ul>
-  <li>Get constraction:
+  <li>Get construction:
     <a href="javascript:;" onclick="setArea(ggbApplet.getBase64()); setHelp('ggbApplet.getBase64()')">GGB</a>
     <a href="javascript:;" onclick="setArea(ggbApplet.getXML()); setHelp('ggbApplet.getXML()')">XML</a>
     <a href="javascript:;" onclick="setArea(ggbApplet.getAllObjectNames()); setHelp('ggbApplet.getAllObjectNames()')">Names</a>
@@ -184,7 +184,7 @@ Eval:
 <textarea name="resultArea" id="resultArea" cols=90 rows=10></textarea>
 <ul>
    <li><a href="javascript:timgeo.copyArea(resultArea())">Copy area</a></li>
-   <li>Set constraction:
+   <li>Set construction:
       <a href="javascript:;" onclick="ggbApplet.setBase64(resultArea().value); setHelp('ggbApplet.setBase64(ggb)')">GGB</a>
       <a href="javascript:;" onclick="ggbApplet.setXML(resultArea().value); setHelp('ggbApplet.setXML(xml)')">XML</a>
       <a href="javascript:;" onclick="ggbApplet.reset(); setHelp('ggbApplet.reset()')">Reset</a>

--- a/timApp/modules/cs/geogebra/toolexample.html
+++ b/timApp/modules/cs/geogebra/toolexample.html
@@ -128,7 +128,7 @@ Eval:
 </p>
 
 <ul>
-  <li>Get constraction:
+  <li>Get construction:
     <a href="javascript:;" onclick="setArea(ggbApplet.getBase64()); setHelp('ggbApplet.getBase64()')">GGB</a>
     <a href="javascript:;" onclick="setArea(ggbApplet.getXML()); setHelp('ggbApplet.getXML()')">XML</a>
     <a href="javascript:;" onclick="setArea(ggbApplet.getAllObjectNames()); setHelp('ggbApplet.getAllObjectNames()')">Names</a>
@@ -149,7 +149,7 @@ Eval:
 <textarea name="resultArea" id="resultArea" cols=90 rows=10></textarea>
 <ul>
    <li><a href="javascript:timgeo.copyArea(resultArea())">Copy area</a></li>
-   <li>Set constraction:
+   <li>Set construction:
       <a href="javascript:;" onclick="ggbApplet.setBase64(resultArea().value); setHelp('ggbApplet.setBase64(ggb)')">GGB</a>
       <a href="javascript:;" onclick="ggbApplet.setXML(resultArea().value); setHelp('ggbApplet.setXML(xml)')">XML</a>
       <a href="javascript:;" onclick="ggbApplet.reset(); setHelp('ggbApplet.reset()')">Reset</a>

--- a/timApp/modules/cs/gethtml/GlowScript.html
+++ b/timApp/modules/cs/gethtml/GlowScript.html
@@ -221,7 +221,7 @@ function onMessage(event) {
 <!-- uncomment next to test directly in the frame or locally -->
 <!--
 <div><p>Write any VPython or GlowScript program below and press Run.
-You can also change the program and look what happends.</p>
+You can also change the program and look what happens.</p>
 </div>
 <div>
 <textarea id="sourcetext" rows = 5, cols="80">

--- a/timApp/modules/cs/git/gitea_aalto.py
+++ b/timApp/modules/cs/git/gitea_aalto.py
@@ -90,7 +90,7 @@ class GiteaAaltoLib(GiteaLib):
             if user["secret_id"] != "ok":
                 print("check_credentials returned non-ok on secret_id when registering")
                 raise Exception(
-                    "Interal Error: 1. Please refresh page. If this message persists, please contact course staff."
+                    "Internal Error: 1. Please refresh page. If this message persists, please contact course staff."
                 )
 
         if "password" in user and user["password"] != "ok":

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -168,7 +168,7 @@ interface LanguageType {
     ace: string; // ACE-editor type
     comment: string; // one line comment for language, if needs
     // beg and end symbols, separate by space
-    // for exaple "/* */"
+    // for example "/* */"
 }
 
 class LanguageTypes {
@@ -972,7 +972,7 @@ export class CsController extends CsBase implements ITimComponent {
     lastUserargs?: string;
     lastUserinput?: string;
     localcode?: string;
-    keepErros: boolean = false;
+    keepErrors: boolean = false;
     muokattu: boolean;
     noeditor!: boolean;
     oneruntime?: string;
@@ -982,7 +982,7 @@ export class CsController extends CsBase implements ITimComponent {
     preview!: JQuery<HTMLElement>;
     result?: string;
     runError?: string | boolean;
-    runned: boolean = false;
+    hasBeenRun: boolean = false;
     runSuccess: boolean;
     runTestGreen: boolean = false;
     runTestRed: boolean = false;
@@ -1439,7 +1439,7 @@ export class CsController extends CsBase implements ITimComponent {
      * Checks whether usercode/args/input differ from previously saved values
      */
     textChanged(): void {
-        if (!this.keepErros) {
+        if (!this.keepErrors) {
             this.runError = undefined;
         }
         const nowUnsaved = this.hasUnSavedInput();
@@ -1513,7 +1513,7 @@ export class CsController extends CsBase implements ITimComponent {
 
     get program() {
         const prg = this.attrsall.program ?? this.markup.program;
-        // IF just replace by code, then no need fo show full code
+        // IF just replace by code, then no need to show full code
         if (prg?.trim() === "REPLACEBYCODE") {
             return "";
         }
@@ -2319,7 +2319,7 @@ ${fhtml}
     anyChanged() {
         this.textChanged();
         this.fullCode = this.getCode();
-        if (this.runned && this.markup.autoupdate) {
+        if (this.hasBeenRun && this.markup.autoupdate) {
             if (this.autoupdateHandle) {
                 window.clearTimeout(this.autoupdateHandle);
             }
@@ -2443,7 +2443,7 @@ ${fhtml}
     }
 
     async runCodeCommon(nosave: boolean, _extraMarkUp?: IExtraMarkup) {
-        this.runned = true;
+        this.hasBeenRun = true;
         const ty = languageTypes.getRunType(this.selectedLanguage, "cs");
         if (ty === "md") {
             this.showMD();
@@ -3218,7 +3218,7 @@ ${fhtml}
 
         const usercode = this.usercode;
 
-        // TODO: begin and end texts as a parameter and then indext picked there
+        // TODO: begin and end texts as a parameter and then indent picked there
         let ind = "";
         if (extra) {
             ind = this.getSameIndent(this.usercode, 0);
@@ -3235,7 +3235,7 @@ ${fhtml}
     }
 
     checkByCodeRemove() {
-        // TODO: begin and end texts as a parameter and then indext picked there
+        // TODO: begin and end texts as a parameter and then indent picked there
         if (this.nocode || !(this.file || this.program)) {
             return;
         }
@@ -3894,8 +3894,8 @@ ${fhtml}
             <pre class="unitTestRed" *ngIf="runTestRed">{{comtestError}}</pre>
             <div class="csRunErrorClass csRunError" *ngIf="runError">
                 <p class="pull-right" *ngIf="!markup['noclose']">
-                    <label class="normalLabel" title="Keep erros until next run">Keep <input type="checkbox"
-                                                                                             [(ngModel)]="keepErros"/></label>
+                    <label class="normalLabel" title="Keep errors until next run">Keep <input type="checkbox"
+                                                                                             [(ngModel)]="keepErrors"/></label>
                     <tim-close-button (click)="closeError()"></tim-close-button>
                 </p>
                 <pre class="csRunError">{{error}}</pre>

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -437,7 +437,7 @@ export class StackPluginComponent
         }
         this.isRunning = true;
         if (!this.stackPeek) {
-            // remove extra fields from sceen
+            // remove extra fields from screen
             let divinput = this.element.find(".stackinputfeedback");
             divinput.remove();
             divinput = this.element.find(".stackprtfeedback");

--- a/timApp/modules/cs/js/truthTable.ts
+++ b/timApp/modules/cs/js/truthTable.ts
@@ -20,8 +20,8 @@ const allowedVariables = "abcdefghijklmpqrsuvwxy";
 
 export function truthTable(sentence: string) {
     let input = sentence.toLowerCase();
-    for (const [froms, tos] of replacements) {
-        input = input.split(froms).join(tos);
+    for (const [fromRepls, toRepls] of replacements) {
+        input = input.split(fromRepls).join(toRepls);
     }
 
     let header = "";

--- a/timApp/modules/cs/languages.py
+++ b/timApp/modules/cs/languages.py
@@ -1250,7 +1250,7 @@ class PY3(Language):
             )
         err = err.strip()
 
-        # TODO: Maybe export as genral copy_wav function
+        # TODO: Maybe export as general copy_wav function
         if self.wavsource and self.wavdest:
             rm_safe(self.wavdest)
             wav_ok, e = copy_file(

--- a/timApp/modules/cs/ptauno/taulukkoi.js
+++ b/timApp/modules/cs/ptauno/taulukkoi.js
@@ -310,10 +310,10 @@ Virtuaalikone.prototype.luo_muuttujat = function (parametrit) {
         if (pn[0]=='m') {
             /* muuttuja = */ this.lisää_muuttuja(pn.substring(1), parseInt(parametrit[pn]));
         } else if (pn[0]=='i') {
-            var inro = parseInt(parametrit[pn]);
-            var muuttuja = this.lisää_muuttuja(pn.substring(1), inro);
+            var iNro = parseInt(parametrit[pn]);
+            var muuttuja = this.lisää_muuttuja(pn.substring(1), iNro);
             
-            var solu = this.solu(inro);
+            var solu = this.solu(iNro);
             var io = new Indeksi(this, solu);
             io.indeksoi(muuttuja);
             io.div.innerHTML = muuttuja.nimi();

--- a/timApp/modules/cs/ptauno/taulukkoi2.js
+++ b/timApp/modules/cs/ptauno/taulukkoi2.js
@@ -417,12 +417,12 @@ Virtuaalikone.prototype.luoTaulukko = function (parametrit) {
     return new Taulukko(this); // XXX tää on niiiiin väärin...
 };
 
-Virtuaalikone.prototype.luoIndeksi = function (nimi,inro) {
-    var muuttuja = this.lisääMuuttuja(nimi, inro);
-    if (!inro) inro = muuttuja.diviArvo.arvo;
+Virtuaalikone.prototype.luoIndeksi = function (nimi,iNro) {
+    var muuttuja = this.lisääMuuttuja(nimi, iNro);
+    if (!iNro) iNro = muuttuja.diviArvo.arvo;
 
 
-    var solu = this.solu(inro);
+    var solu = this.solu(iNro);
     if (!solu) return;
 
     var io = new Indeksi(this, solu);
@@ -443,8 +443,8 @@ Virtuaalikone.prototype.luoMuuttujat = function (parametrit) {
         if (pn[0]=='m') {
             this.lisääMuuttuja(pn.substring(1), parseInt(parametrit[pn])||null,null, true);
         } else if (pn[0]=='i') {
-            var inro = parseInt(parametrit[pn]) || null;
-            this.luoIndeksi(pn.substring(1), inro);
+            var iNro = parseInt(parametrit[pn]) || null;
+            this.luoIndeksi(pn.substring(1), iNro);
         }
     }
 

--- a/timApp/modules/cs/run.py
+++ b/timApp/modules/cs/run.py
@@ -20,7 +20,7 @@ def wait_file(f1, tries=10):
 
     :param f1: filename to wait
     :param tries: number of tries
-    :return: sthe file status if it became ready, otherwise False
+    :return: the file status if it became ready, otherwise False
 
     """
     count = 0
@@ -53,7 +53,7 @@ def run(
     """Alkuperäinen ajaminen, jossa ajo suoritetaan tavallisen prosessina.
 
     :param args: run arguments for the command
-    :param cwd: dircetory to start
+    :param cwd: directory to start
     :param shell: run shell or not
     :param kill_tree: kill to source tree after run
     :param timeout: time to run in ms
@@ -98,7 +98,7 @@ def get_user_mappings(root_dir, mounts):
     Return list of needed docker volume mappings to map under user directory
     At the moment this is "static", so every new mapping need to be added
     to know_user_mappings by admin
-    :param root_dir: what is the root dircetory to map
+    :param root_dir: what is the root directory to map
     :param mounts: list of keys to mount
     :return: docker volume mount list
     """
@@ -158,15 +158,15 @@ def run2(
     save_run_cmd=None,
     save_test_run_cmd=None,
 ):
-    """Run that is done by opening a new docker instance to run the command.  A script rcmd.sh is needed to fullfill the
+    """Run that is done by opening a new docker instance to run the command.  A script rcmd.sh is needed to fulfill the
     run inside docker.
 
     :param args: run arguments for the command
-    :param cwd: in whinch directory the command should start
+    :param cwd: in which directory the command should start
     :param shell: maybe not needed any more???
     :param kill_tree: maybe not needed anymore
     :param timeout: how long the run is allowed to run
-    :param env: environment varibales for run
+    :param env: environment variables for run
     :param stdin: what file to use for stdin
     :param uargs: user arguments for the run
     :param code: which coding schema to use ("utf-8" is default)
@@ -176,7 +176,7 @@ def run2(
     :param no_x11: do not use X11
     :param dockercontainer: what container to run, container needs user with name agent
     :param compile_commandline: command line to compile code
-    :param escape_pipe: If True, pipe charracter | is escaped into '|'
+    :param escape_pipe: If True, pipe character | is escaped into '|'
     :param mounts: User-defined mounts
     :param extra_mappings: Extra non-user csplugin folder mappings
     :param escape_pipe: TODO: what
@@ -487,4 +487,4 @@ def get_imgsource(query):
     result = get_param(query, "imgsource", "")
     if result:
         return result
-    result = get_param(query, "bmpname", "")  # backwards compability
+    result = get_param(query, "bmpname", "")  # backwards compatibility

--- a/timApp/modules/cs/simcir/check/simcirtest.py
+++ b/timApp/modules/cs/simcir/check/simcirtest.py
@@ -164,7 +164,7 @@ class Logik:
             self.ulostulot = []
             self.ledit = []
             self.connectors = []  # data['connectors']
-            portti = "LED"  ## Mofify to support others some day, make a list of possible output types
+            portti = "LED"  ## Modify to support others some day, make a list of possible output types
 
             for c in data["connectors"]:
                 con = Connector(c)

--- a/timApp/modules/cs/static/dfa/animatedDFA.html
+++ b/timApp/modules/cs/static/dfa/animatedDFA.html
@@ -176,7 +176,7 @@
               let color = "";
               let error = "";
               let activeColor = "yellow";
-              if (node.error && (dfaState.active || node.dublicate)) {
+              if (node.error && (dfaState.active || node.duplicate)) {
                   color = ", fillcolor=red, style=filled"
                   error = node.error;
                   activeColor = "orange";

--- a/timApp/modules/cs/static/dfa/combinations.js
+++ b/timApp/modules/cs/static/dfa/combinations.js
@@ -6,11 +6,11 @@ class Combinations {
     /*!
      * Initilaize combinations
      * \fn constructor(chars, n, full)
-     * \params string or array chars of elements to combinate
+     * \params string or array chars of elements to combine
      * \params int n number of max items
      * \params boolean full if true make all lengths from 1 to
-     *                      if false make jus all combinations
-     *                      of n lenght array of chars
+     *                      if false make just all combinations
+     *                      of n length array of chars
      */
     constructor(chars, n, full) {
         this.chars = chars;

--- a/timApp/modules/cs/static/dfa/dfa.js
+++ b/timApp/modules/cs/static/dfa/dfa.js
@@ -86,8 +86,8 @@ class DFA {
             if (value === -1) return;
             const node = dfa.nodes[from];
             if (node.arcs[value]) {
-                node.error += "Node " + node.name + ": dublicate transition " + value + "\n";
-                node.dublicate = true;
+                node.error += "Node " + node.name + ": duplicate transition " + value + "\n";
+                node.duplicate = true;
             }
             node.arcs[value] = arc;
         }
@@ -201,7 +201,7 @@ class DFA {
     /*!
      * Check if input s is accepted by this dfa
      * \param s input to check
-     * \return boolean true if accpeted
+     * \return boolean true if accepted
      */
     accepts(s) {
         this.cnt = 0;

--- a/timApp/modules/cs/static/dfa/lexcalc.js
+++ b/timApp/modules/cs/static/dfa/lexcalc.js
@@ -2,7 +2,7 @@
 
 // For Lexer see: https://github.com/aaditmshah/lexer
 class Lexer {
-// Create lexer, add rexexp rules where to match
+// Create lexer, add regexp rules where to match
 // call lexer.setInput(input) to give input
 // call lexer.lex() to get on token at time until undefined
 // longest match is used if not /g in rule.
@@ -147,7 +147,7 @@ class Lexer {
 
             if (rule.global) index = j; // do not sort prior this
 
-            // move to place agording by its length, longest firts
+            // move to place according to its length, longest first
             while (--j > index) {
                 let k = j - 1;
 
@@ -265,7 +265,7 @@ class CalculatorOp {
     }
 
     type() {   }           // if parser should order, return on of above
-    reg() { return / /;  }  // regexp to match those opertation
+    reg() { return / /;  }  // regexp to match those operation
 
     pop() {                // pop value from calc stack
         if (this.calculator.stack.length === 0)
@@ -278,12 +278,12 @@ class CalculatorOp {
     lexname() { return this.name(); } // name to be used in allowed or illegals list
     output(extraBefore) { return ` ${this.name()} `;  } // text to output
     extraSpaceAfter() { return ""; } // need space before some operation?
-    doCalc() {  }              // helpper method for doing calc
-    calc() { this.doCalc(); }  // what to do when runned
+    doCalc() {  }              // helper method for doing calc
+    calc() { this.doCalc(); }  // what to do when run
     r(v) { return roundToNearest(v, this.calculator.params.decimals);  }
     lexfunc(lexme, lexer) { return this;  }  // what to be returned for lexer if match
     allowSignRight() { return true; } // does allow sign operation on right side
-    checkSign(lastToken) { return this; } // deny 2-3 as a sign and change to bin opertator -
+    checkSign(lastToken) { return this; } // deny 2-3 as a sign and change to bin operator -
 
     getnum(s) { // convert s as numeric using p, mem or parse
         if (s === undefined) return this.calculator.lastResult;
@@ -354,8 +354,8 @@ class SignOperation extends FuncRROperation{
     newCalcOperation() { return new BinOperation(this.calculator); }
 }
 
-// Thse two are outside of operations list, because
-// they are refered inside the list (SignMinus and SignPlus)
+// These two are outside of operations list, because
+// they are referred inside the list (SignMinus and SignPlus)
 class Plus extends BinOperation {
     reg() { return / *\+ /; }
     name() { return "+"; }

--- a/timApp/modules/cs/static/dfa/rpn.js
+++ b/timApp/modules/cs/static/dfa/rpn.js
@@ -1,5 +1,5 @@
 /*!
-* Class for Reverce Polish Notation
+* Class for Reverse Polish Notation
 */
 
 
@@ -419,7 +419,7 @@ class RPN {
                     cmds = cls.isMy(line);
                     if (cmds) break;
                 }
-                if (!cmds) {  // this should not happend if there is UnknownCommand last
+                if (!cmds) {  // this should not happen if there is UnknownCommand last
                     this.addError(`${this.linenumber}: ${line} - ` + this.params.unknownCommandError);
                     continue; // did not match any know types
                 }
@@ -488,7 +488,7 @@ class RPN {
 
 
     runUntil(n) {
-        // Runs the command list from begining until in step n
+        // Runs the command list from beginning until in step n
         // If n not defined, run all commands
         this.init();
         this.maxStack = Math.max(this.stack.length, this.maxStack);

--- a/timApp/modules/cs/static/dfa/vars.js
+++ b/timApp/modules/cs/static/dfa/vars.js
@@ -6,7 +6,7 @@ function removePairs(s, start, end) {
     s = s.replace(/\\0/g, "␀").replace(/\0/g, "␀");
     let i = start.indexOf(s[0]);
     if (end === undefined) end = start;
-    if (i >= 0) { // eat parenthes away
+    if (i >= 0) { // eat parentheses away
         // s[0] = ' ';
         let first = 1;
         let paren = end[i];
@@ -112,7 +112,7 @@ function normalizeJson(str){
 
 
 function varsStringToJson(s) {
-    // tries fix missing quotes and parenthes
+    // tries fix missing quotes and parentheses
     // does not work if object inside object
     // {x 4, y 2} => {"x": 4, "y": 2}
     // x: 4, y: 2 => {"x": 4, "y": 2}
@@ -204,7 +204,7 @@ class PrgObject {
  *
  * cmd has isMy static method that checks if string to parse belongs
  * to this cmd.
- * Check is mosty done by regexp and there should be
+ * Check is mostly done by regexp and there should be
  * a regex101 link for every cmd to see examples.
  *
  * If string is for this cmd, new command is created and
@@ -213,7 +213,7 @@ class PrgObject {
  * representing that string.  Mostly the list has only one command,
  * but there might be syntaxes like
  *    Ref list -> List $1 R 4
- * when isMy returns three commnds representing strings
+ * when isMy returns three commands representing strings
  *    Ref list
  *    List $1 R 4
  *    list -> $1
@@ -278,7 +278,7 @@ class Command extends PrgObject {
      * Mostly variables is needed to find other variables
      * and for checking options like step or static mode.
      * variables might change during running commands, so
-     * the value in comands creation moment can not be used.
+     * the value in commands creation moment can not be used.
      * Returns error message
      */
     run(variables) {
@@ -303,7 +303,7 @@ class TextObject extends PrgObject {
 class CreateVariable extends Command {
     /*!
      * Initialize variable creation
-     * \param create is function to create the variable, mostly lanbda
+     * \param create is function to create the variable, mostly lambda
      */
     constructor(create, name) {
         super();
@@ -341,7 +341,7 @@ class CreateVariable extends Command {
 
 
 /*!
- * base Class for one varible
+ * base Class for one variable
  * Even in normal C# or Java variable can not be reference
  * and value same time, but to allow user errors here it
  * is possible.  But then it hase error if used for both
@@ -386,7 +386,7 @@ class Variable extends PrgObject {
 
     addRef(objTo, variables, force) {
         // adds ref to any variable, but it is error
-        // if more than one ref or if not ref varible.
+        // if more than one ref or if not ref variable.
         // In static mode it is not allowed to change the
         // ref but new ref is added.  In step mode ref is changed.
         // index2 is for syntax: $2 = $1[3]
@@ -528,7 +528,7 @@ class Variable extends PrgObject {
     }
 
     checkCount(variables) {
-        return ""; // error allready given when set
+        return ""; // error already given when set
     }
 
     isString() {
@@ -541,7 +541,7 @@ class Variable extends PrgObject {
 }
 
 class NullVariable extends Variable {
-    // Null varible for un assigned refs or null ref
+    // Null variable for un assigned refs or null ref
     constructor(vals) {
         super("null", undefined, undefined);
         this.label = "null";
@@ -627,7 +627,7 @@ class CreateValueVariable extends CreateVariable {
 }
 
 
-class RefecenceVariable extends ValueVariable {
+class ReferenceVariable extends ValueVariable {
     // Creates a reference variable
     constructor(name, value, ref, rank) {
         super(name, value, ref, rank);
@@ -638,7 +638,7 @@ class RefecenceVariable extends ValueVariable {
     }
 }
 
-class SimpleRefecenceVariable extends RefecenceVariable {
+class SimpleReferenceVariable extends ReferenceVariable {
     // Creates a reference variable
     constructor(name, value, ref, rank) {
         super(name, value, ref, rank);
@@ -650,7 +650,7 @@ class SimpleRefecenceVariable extends RefecenceVariable {
 }
 
 
-class CreateRefecenceVariable extends CreateVariable {
+class CreateReferenceVariable extends CreateVariable {
     // Creates a reference variable
     // see: https://regex101.com/r/RSTA4z/latest
     // syntax: Ref luvut
@@ -659,7 +659,7 @@ class CreateRefecenceVariable extends CreateVariable {
         let r = re.exec(s);
         if (!r) return undefined;
         return [new CreateVariable(
-            () => new RefecenceVariable(r[1], undefined, nullRef, 0))];
+            () => new ReferenceVariable(r[1], undefined, nullRef, 0))];
     }
 }
 
@@ -709,7 +709,7 @@ class ArrayVariable extends ObjectVariable {
     // Creates array or list for refs or values
     // value ei not used in this case
     // kind is [ for Array and L for List (ArrayList in Java)
-    // type is R for referneces and V for values.
+    // type is R for references and V for values.
     constructor(name, value, kind, type, dir, len, rank) {
         super(name, value, undefined, rank);
         this.kind = kind;
@@ -723,7 +723,7 @@ class ArrayVariable extends ObjectVariable {
         let cls;
         switch (type) {
             case "R":
-                cls = RefecenceVariable;
+                cls = ReferenceVariable;
                 break;
             case "C":
                 cls = CharVariable;
@@ -809,7 +809,7 @@ class StructVariable extends ObjectVariable {
     // Creates array or list for refs or values
     // value ei not used in this case
     // kind is [ for Array and L for List (ArrayList in Java)
-    // type is R for referneces and V for values.
+    // type is R for references and V for values.
     constructor(name, value, kind, sclass, type, dir, len, rank) {
         super(name, value, undefined, rank);
         this.kind = kind;
@@ -828,11 +828,11 @@ class StructVariable extends ObjectVariable {
             init = undefined;
             switch (type.toUpperCase()) {
                 case "R":
-                    cls = RefecenceVariable;
+                    cls = ReferenceVariable;
                     nref = nullRef;
                     break;
                 case "SR":
-                    cls = SimpleRefecenceVariable;
+                    cls = SimpleReferenceVariable;
                     nref = nullRef;
                     break;
                 case "C":
@@ -898,7 +898,7 @@ class StructVariable extends ObjectVariable {
 
 
 class InitializedStructVariable extends StructVariable {
-    // Creates initilized array or list
+    // Creates initialized array or list
 
     constructor(name, value, kind, sclass, type, dir, vals, rank) {
         // let s = vals.replace(/  */g, " ").replace(/ *[,;] */g, ",");
@@ -951,7 +951,7 @@ class InitializedStructVariable extends StructVariable {
 
 
 class CreateInitializedStructVariable extends CreateVariable {
-    // Creates initilized struct
+    // Creates initialized struct
     // see: https://regex101.com/r/hN8WJy/latest   named class
     // see: https://regex101.com/r/Tbvab7/latest   ad hoc struct
     // syntax:
@@ -1002,7 +1002,7 @@ class CreateInitializedStructVariable extends CreateVariable {
 
 
 class InitializedArrayVariable extends ArrayVariable {
-    // Creates initilized array or list
+    // Creates initialized array or list
 
     constructor(name, value, kind, type, dir, len, vals, rank) {
         // let s = vals.replace(/  */g, " ").replace(/ *[,;] */g, ",");
@@ -1058,7 +1058,7 @@ class InitializedArrayVariable extends ArrayVariable {
 
 
 class CreateInitializedArrayVariable extends CreateVariable {
-    // Creates initilized array or list
+    // Creates initialized array or list
     // see: https://regex101.com/r/Hre5iQ/latest
     //      https://regex101.com/r/ZepJ1V/latest
     // syntax:
@@ -1115,7 +1115,7 @@ function addVarsCommandLines(cmds, cls, line) {
 
 
 class CreateInitialized2DArrayVariable extends CreateVariable {
-    // Creates initilized array or list
+    // Creates initialized array or list
     // see: https://regex101.com/r/u2asVs/1
     // syntax:
     //    A $1 V2x3 {3,4,5}
@@ -1182,7 +1182,7 @@ class CreateInitialized2DArrayVariable extends CreateVariable {
 
 
 class ReferenceTo extends Command {
-    // Set ref variable to refecence object
+    // Set ref variable to reference object
     // see: https://regex101.com/r/KTT0RB/latest
     // syntax: lista -> $1
     static isMy(s) {
@@ -1257,8 +1257,8 @@ const combinedRefCommands = [
     CreateObjectVariable,
 ];
 
-class CreateReferenceAndObject extends CreateRefecenceVariable {
-    // Set Crete object and set ref variable to refecence object
+class CreateReferenceAndObject extends CreateReferenceVariable {
+    // Set Crete object and set ref variable to reference object
     // see: https://regex101.com/r/CmSGH9/latest
     // syntax: ref aku -> new $1 Aku
     // syntax: ref aku -> a $1 v 3
@@ -1276,7 +1276,7 @@ class CreateReferenceAndObject extends CreateRefecenceVariable {
         }
         if (!cmds) return undefined;
         let refCmd = new CreateVariable(
-            () => new RefecenceVariable(name, undefined, nullRef, 0));
+            () => new ReferenceVariable(name, undefined, nullRef, 0));
         refCmd.line = "Ref " + name;
 
         let cmd = cmds[0];
@@ -1366,11 +1366,11 @@ class SetStyle extends Command {
         let errors = "";
         // let varTo = this.findVarForAssign(variables,this.to, false)[1];
         let tos = this.to.split(",");
-        for (const nto of tos) {
-            // let varTo = variables.findVar(nto);
-            if (!nto) continue;
-            let [,varTo] = this.findVarForAssign(variables,nto, true)
-            if (!varTo) errors += `Muuttujaa ${nto} ei löydy! `
+        for (const name of tos) {
+            // let varTo = variables.findVar(name);
+            if (!name) continue;
+            let [,varTo] = this.findVarForAssign(variables,name, true)
+            if (!varTo) errors += `Muuttujaa ${name} ei löydy! `
             else varTo.style = this.style;
         }
         return errors;
@@ -1585,7 +1585,7 @@ class AddSVG extends Command {
 
 
 class SetGraphAttributes extends Command {
-    // Add Garåh command to control positions etc
+    // Add graph command to control positions etc
     // see: https://regex101.com/r/q6YJDq/latest
     // syntax:
     //  Graph {x: 10, y:20}
@@ -1756,7 +1756,7 @@ class CodeCommand extends Command {
 }
 
 class UnknownCommand extends Command {
-    // This commad takes all commands that are not known
+    // This command takes all commands that are not known
     static isMy(s) {
         return [new UnknownCommand(s)];
     }
@@ -1797,7 +1797,7 @@ const knownCommands = [
     ReferenceTo,
     CreateValueVariable,
     CreateNullVariable,
-    CreateRefecenceVariable,
+    CreateReferenceVariable,
     CreateInitializedStructVariable,
     SetCount,
     AssignTo,
@@ -1821,9 +1821,9 @@ const knownCommands = [
 
 
 /*!
- * A phase is a list of variables and releted texts.
+ * A phase is a list of variables and related texts.
  * It may have phaseNumber, but in most cases there
- * is only one phese without phaseNumber.
+ * is only one phase without phaseNumber.
  * The whole drawing (variableRelations) may include
  * one or more phases.  Many option and other things
  * are in variableRelations, so reference to that parent
@@ -2176,7 +2176,7 @@ class VariableRelations {
      *     - phase 1
      *         - var 1
      *         - var 2
-     *     - pahse 2
+     *     - phase 2
      *         - var 1
      *         - var 2
      *         - var 3
@@ -2308,7 +2308,7 @@ class VariableRelations {
                     cmds = cls.isMy(line, this.currentPhase);
                     if (cmds) break;
                 }
-                if (!cmds) {  // this should not happend if there is UnknownCommand last
+                if (!cmds) {  // this should not happen if there is UnknownCommand last
                     this.addError(`${this.linenumber}: ${line} - ei tunneta tai ei hyväksytä`);
                     continue; // did not match any know types
                 }
@@ -2331,7 +2331,7 @@ class VariableRelations {
     }
 
     runUntil(n) {
-        // Runs the command list from begining until in step n
+        // Runs the command list from beginning until in step n
         // If n not defined, run all commands
         this.init();
         let nr = 0;
@@ -2349,7 +2349,7 @@ class VariableRelations {
         for (let phase of this.phaseList) {
             phase.solveLazy(true);
         }
-        if (nr >= this.commands.length) { // all runned, check counts
+        if (nr >= this.commands.length) { // all ran, check counts
             for (let phase of this.phaseList) {
                 for (let v of phase.vars) {
                     let error = v.checkCount(phase);
@@ -2439,7 +2439,7 @@ class VariableRelations {
 
 
 /*!
- * Compare two results and return dirrerences
+ * Compare two results and return differences
  */
 function compareValsAndRefs(code1, code2, params) {
     let vars1 =  new VariableRelations(code1, params);
@@ -2666,7 +2666,7 @@ const svgTextMixin = {
  */
 const svgVariableMixin = {
     showCount(dy) {
-        // show varibales count-attribute.  By red if in error state
+        // show variables count-attribute.  By red if in error state
         if (this.count !== undefined) {
             let p = this.left();
             p.x -= 5;
@@ -3014,7 +3014,7 @@ const svgSimpleReferenceVariableMixin = {
 const svgArrayVariableMixin = {
     toSVG(x, y, w, h, dx, dy) {
         // draw array as variables side by side
-        // and indesies over it. If there is over/under indexing
+        // and indices over it. If there is over/under indexing
         // draw those before and after array
         let nw = undefined;
         let dir = undefined;
@@ -3139,7 +3139,7 @@ const svgArrayVariableMixin = {
 
     refToSVG() {
         // draw all array's references and also
-        // over and under indexed refreneces
+        // over and under indexed references
         let svg = "";
         for (let ref of this.vars)
             svg += ref.refToSVG();
@@ -3180,7 +3180,7 @@ const svgArrayVariableMixin = {
 
 const svgStructVariableMixin = {
     toSVG(x, y, w, h, dx, dy) {
-        // draw struct as emty boxes side by side
+        // draw struct as empty boxes side by side
         let nh = 1;
         let nw = undefined;
         let dir = 0;
@@ -3327,7 +3327,7 @@ const svgStructVariableMixin = {
 
     refToSVG() {
         // draw all array's references and also
-        // over and under indexed refreneces
+        // over and under indexed references
         let svg = "";
         for (let ref of this.vars)
             svg += ref.refToSVG();
@@ -3363,11 +3363,11 @@ const svgStructVariableMixin = {
     },
 }
 
-// Add visual methods to variable and array varaible
+// Add visual methods to variable and array variable
 Object.assign(TextObject.prototype, svgTextMixin);
 Object.assign(Variable.prototype, svgVariableMixin);
 Object.assign(NullVariable.prototype, svgNullVariableMixin);
-Object.assign(SimpleRefecenceVariable.prototype, svgSimpleReferenceVariableMixin);
+Object.assign(SimpleReferenceVariable.prototype, svgSimpleReferenceVariableMixin);
 Object.assign(ArrayVariable.prototype, svgArrayVariableMixin);
 Object.assign(StructVariable.prototype, svgStructVariableMixin);
 
@@ -3760,7 +3760,7 @@ class VisualSVGVariableRelations {
                     if (gopts.dx !== undefined) xadd = gopts.dx;
                     if (gopts.dy !== undefined) yadd = gopts.dy;
 
-                    if (v.noMove) {  // mosty for null variable
+                    if (v.noMove) {  // mostly for null variable
                         xadd = 0;
                         yadd = 0;
                     }
@@ -3910,7 +3910,7 @@ class VisualSVGVariableRelations {
 
     startAnimate(moveOneStepToDirection, until) {
         // start animation and call moveOneStepToDirection
-        // in every intervall.  Stop if condtion until
+        // in every interval.  Stop if condition until
         // reached.
         let visual = this;
         this.stopAnimate();
@@ -4087,7 +4087,7 @@ function setData(data) {
     let variableRelations = new VariableRelations(data.code,
         params, knownCommands);
     let newCall = true;
-    let visual = elements.svgdiv.visual; // is it allreadu created?
+    let visual = elements.svgdiv.visual; // is it already created?
     if (!visual) {
         visual = new VisualSVGVariableRelations(variableRelations,
             data.args,

--- a/timApp/modules/cs/static/digraph/animatedDiGraph.html
+++ b/timApp/modules/cs/static/digraph/animatedDiGraph.html
@@ -176,7 +176,7 @@
               let color = "";
               let error = "";
               let activeColor = "yellow";
-              if (node.error && (digraphState.active || node.dublicate)) {
+              if (node.error && (digraphState.active || node.duplicate)) {
                   color = ", fillcolor=red, style=filled"
                   error = node.error;
                   activeColor = "orange";

--- a/timApp/modules/cs/static/digraph/combinations.js
+++ b/timApp/modules/cs/static/digraph/combinations.js
@@ -6,11 +6,11 @@ class Combinations {
     /*!
      * Initilaize combinations
      * \fn constructor(chars, n, full)
-     * \params string or array chars of elements to combinate
+     * \params string or array chars of elements to combine
      * \params int n number of max items
      * \params boolean full if true make all lengths from 1 to
-     *                      if false make jus all combinations
-     *                      of n lenght array of chars
+     *                      if false make just all combinations
+     *                      of n length array of chars
      */
     constructor(chars, n, full) {
         this.chars = chars;

--- a/timApp/modules/cs/static/digraph/digraph.js
+++ b/timApp/modules/cs/static/digraph/digraph.js
@@ -86,8 +86,8 @@ class DiGraph {
             if (value === -1) return;
             const node = digraph.nodes[from];
             if (node.arcs[value]) {
-                node.error += "Node " + node.name + ": dublicate transition " + value + "\n";
-                node.dublicate = true;
+                node.error += "Node " + node.name + ": duplicate transition " + value + "\n";
+                node.duplicate = true;
             }
             node.arcs[value] = arc;
         }
@@ -201,7 +201,7 @@ class DiGraph {
     /*!
      * Check if input s is accepted by this digraph
      * \param s input to check
-     * \return boolean true if accpeted
+     * \return boolean true if accepted
      */
     accepts(s) {
         this.cnt = 0;

--- a/timApp/modules/cs/static/html/animaatiot/jsvee.css
+++ b/timApp/modules/cs/static/html/animaatiot/jsvee.css
@@ -556,7 +556,7 @@ div table td.jsvee-code-line {
 
 .jsvee-block {
 	height: 0;
-	widht: 0;
+	width: 0;
 	display: none;
 }
 

--- a/timApp/modules/cs/static/html/hanoi/hanoi.html
+++ b/timApp/modules/cs/static/html/hanoi/hanoi.html
@@ -228,12 +228,12 @@ return game_is_over;
 //
 
 function Animation() {
-this.imageNum = new Array();  // Array of indicies document.images to be changed
+this.imageNum = new Array();  // Array of indices document.images to be changed
 this.imageSrc = new Array();  // Array of new srcs for imageNum array
 this.frameIndex = 0;          // the frame to play next
 this.alreadyPlaying = false;  // semaphore to ensure we play smoothly
 
-this.getFrameCount = getframecount;   // the total numebr of frame so far
+this.getFrameCount = getframecount;   // the total number of frame so far
 this.moreFrames = moreframes;         // tells us if there are more frames to play
 this.addFrame = addframe;             // add a frame to the animation
 this.drawNextFrame = drawnextframe;   // draws the next frame

--- a/timApp/modules/cs/tauno/taulukko.js
+++ b/timApp/modules/cs/tauno/taulukko.js
@@ -380,12 +380,12 @@ Virtuaalikone.prototype.luoTaulukko = function (parametrit) {
     return new Taulukko(this); // XXX tää on niiiiin väärin...
 };
 
-Virtuaalikone.prototype.luoIndeksi = function (nimi,inro) {
-    var muuttuja = this.lisääMuuttuja(nimi, inro);
-    if (!inro) inro = muuttuja.diviArvo.arvo;
+Virtuaalikone.prototype.luoIndeksi = function (nimi,iNro) {
+    var muuttuja = this.lisääMuuttuja(nimi, iNro);
+    if (!iNro) iNro = muuttuja.diviArvo.arvo;
 
 
-    var solu = this.solu(inro);
+    var solu = this.solu(iNro);
     if (!solu) return;
 
     var io = new Indeksi(this, solu);
@@ -408,8 +408,8 @@ Virtuaalikone.prototype.luoMuuttujat = function (parametrit) {
             if ( isNaN(val) ) val = null;
             this.lisääMuuttuja(pn.substring(1), val ,null, true);
         } else if (pn[0]=='i') {
-            var inro = parseInt(parametrit[pn]);
-            this.luoIndeksi(pn.substring(1), inro);
+            var iNro = parseInt(parametrit[pn]);
+            this.luoIndeksi(pn.substring(1), iNro);
         }
     }
 
@@ -2062,13 +2062,13 @@ function alustaTauno(event) {
     if (prt.lang && prt.lang == "en" || prt.help ) {
        wordMuuttujat = "variables:";
        wordUusiMuuttuja = "new variable";
-       wordMuuttujatTitle = "list of variables, add varibale from button above";
+       wordMuuttujatTitle = "list of variables, add variable from button above";
        wordOhjelma = "program";
        wordApua = 'Parameters:\n' +
               '  help=help in english\n'+
               '  apua=apua suomeksi\n'+
               '  lang=en - user interface as english\n'+
-              '  s    - simple, no indeces\n'+
+              '  s    - simple, no indices\n'+
               '  mx=v - variable x by value v.\n'+
               '  ix=v - index variable x by value v.\n'+
               '  ts=n - set array size as n.\n'+

--- a/timApp/modules/cs/templates/3/accessDuration
+++ b/timApp/modules/cs/templates/3/accessDuration
@@ -4,4 +4,4 @@ User will have limited time to answer the task after unlocking the task
 accessDuration: 60
 # Message to be shown after task expires and is hidden.
 # Leave blank to disable hiding when using accessDuration
-accesssEndText:
+accessEndText:

--- a/timApp/modules/cs/templates/3/remove
+++ b/timApp/modules/cs/templates/3/remove
@@ -1,4 +1,4 @@
 removebegin/end
-Instert lines code that is removed from users eays
+Insert lines code that is removed from users eays
 // REMOVEBEGIN
 // REMOVEEND

--- a/timApp/modules/feedback/js/feedback.ts
+++ b/timApp/modules/feedback/js/feedback.ts
@@ -598,7 +598,7 @@ export class FeedbackPluginComponent
      * Saves the selected plugins content to the database.
      *
      * @param plugin The plugin to be saved.
-     * @returns{boolean} Whether the save was succesful.
+     * @returns{boolean} Whether the save was successful.
      */
     async savePlugin(plugin: ITimComponent) {
         this.saving = true;

--- a/timApp/modules/fields/field.py
+++ b/timApp/modules/fields/field.py
@@ -1,5 +1,5 @@
 """
-TIM plugin: a field to start other fileds
+TIM plugin: a field to start other fields
 """
 from flask import Response
 

--- a/timApp/modules/fields/js/cbcountfield-plugin.component.ts
+++ b/timApp/modules/fields/js/cbcountfield-plugin.component.ts
@@ -366,7 +366,7 @@ export class CbcountfieldPluginComponent
 
     /**
      * Autosaver used by ng-blur in cbcountfieldApp component.
-     * Needed to seperate from other save methods because of the if-structure.
+     * Needed to separate from other save methods because of the if-structure.
      * Unused method warning is suppressed, as the method is only called in template.
      */
     autoSave() {

--- a/timApp/modules/fields/js/cbfield-plugin.component.ts
+++ b/timApp/modules/fields/js/cbfield-plugin.component.ts
@@ -339,7 +339,7 @@ export class CbfieldPluginComponent
 
     /**
      * Autosaver used by ng-blur in cbfieldApp component.
-     * Needed to seperate from other save methods because of the if-structure.
+     * Needed to separate from other save methods because of the if-structure.
      * Unused method warning is suppressed, as the method is only called in template.
      */
     autoSave() {

--- a/timApp/modules/fields/js/numericfield-plugin.component.ts
+++ b/timApp/modules/fields/js/numericfield-plugin.component.ts
@@ -403,7 +403,7 @@ export class NumericfieldPluginComponent
 
     /**
      * Autosaver used by ng-blur in textfieldApp component.
-     * Needed to seperate from other save methods because of the if-structure.
+     * Needed to separate from other save methods because of the if-structure.
      * Unused method warning is suppressed, as the method is only called in template.
      */
     autoSave() {

--- a/timApp/modules/fields/js/rbfield-plugin.component.ts
+++ b/timApp/modules/fields/js/rbfield-plugin.component.ts
@@ -116,7 +116,7 @@ export class RbfieldPluginComponent
         saved: false,
         message: undefined,
     };
-    private preventedAutosave = false; // looks depracated???
+    private preventedAutosave = false; // looks deprecated???
     private rbName: string = "";
     saveFailed = false;
 
@@ -350,7 +350,7 @@ export class RbfieldPluginComponent
 
     /**
      * Autosaver used by ng-blur in rbfieldApp component.
-     * Needed to seperate from other save methods because of the if-structure.
+     * Needed to separate from other save methods because of the if-structure.
      * Unused method warning is suppressed, as the method is only called in template.
      */
     autoSave() {

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -503,7 +503,7 @@ export class TextfieldPluginComponent
 
     /**
      * Autosaver used by ng-blur in textfieldApp component.
-     * Needed to seperate from other save methods because of the if-structure.
+     * Needed to separate from other save methods because of the if-structure.
      * Unused method warning is suppressed, as the method is only called in template.
      */
     autoSave() {

--- a/timApp/modules/imagex/imagex.py
+++ b/timApp/modules/imagex/imagex.py
@@ -245,7 +245,7 @@ class ImagexServer(TimServer):
                                     gottenpointsobj = {}
 
         answer = {}
-        # Check if getting finalanswer from excercise is allowed and if client asked for it.
+        # Check if getting finalanswer from exercise is allowed and if client asked for it.
         finalanswer = get_param(query, "finalanswer", False)
         finalanswerquery = get_json_param(query.jso, "input", "finalanswerquery", False)
 

--- a/timApp/modules/imagex/templates/0/1
+++ b/timApp/modules/imagex/templates/0/1
@@ -58,7 +58,7 @@ objects:
       borderWidth: 2
       borderColor: "brown"
       textColor: "blue"
-      backgroud: yellow
+      background: yellow
       font: "30px times"
       size:
 targets: 

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -624,15 +624,15 @@ export class VideoComponent extends AngularPluginBase<
                 allow: iframeopts.allow,
             };
         } else {
-            let tbe = "";
+            let range = "";
             if (this.start) {
-                tbe += this.start; // loadedmetadata event doesn't work on iPad
+                range += this.start; // loadedmetadata event doesn't work on iPad
                 if (this.end) {
-                    tbe += "," + this.end;
+                    range += "," + this.end;
                 }
             }
-            if (tbe) {
-                srcUrl.hash = "#t=" + tbe;
+            if (range) {
+                srcUrl.hash = "#t=" + range;
             }
             this.videosettings = {
                 src: srcUrl.toString(),

--- a/timApp/modules/svn/svn3.py
+++ b/timApp/modules/svn/svn3.py
@@ -47,7 +47,7 @@ from tim_common.fileParams import (
     do_headers,
     post_params,
     multi_post_params,
-    get_chache_keys,
+    get_cache_keys,
     clear_cache,
     get_template,
     join_dict,
@@ -501,13 +501,13 @@ class TIMShowFileServer(http.server.BaseHTTPRequestHandler):
 
         print("do_POST MULTIHML ==========================================")
         t1 = time.perf_counter()
-        querys = multi_post_params(self)
-        # print(querys)
+        queries = multi_post_params(self)
+        # print(queries)
 
         do_headers(self, "application/json")
 
         htmls = []
-        for query in querys:
+        for query in queries:
             if multimd:
                 s = get_md(self, query)
             else:
@@ -517,7 +517,7 @@ class TIMShowFileServer(http.server.BaseHTTPRequestHandler):
         sresult = json.dumps(htmls)
         self.wout(sresult)
         t2 = time.perf_counter()
-        ts = "multihtml: %d - %7.4f" % (len(querys), (t2 - t1))
+        ts = "multihtml: %d - %7.4f" % (len(queries), (t2 - t1))
         print(ts)
 
     def do_PUT(self):
@@ -555,7 +555,7 @@ class TIMShowFileServer(http.server.BaseHTTPRequestHandler):
 
         if self.path.find("refresh") >= 0:
             print(f"Cleaning cache")
-            keys, mem_cache_len, disk_cache_len = get_chache_keys()
+            keys, mem_cache_len, disk_cache_len = get_cache_keys()
             clear_cache()
             print(keys)
             self.wout(

--- a/timApp/modules/svn/templates/video/1/Review summary
+++ b/timApp/modules/svn/templates/video/1/Review summary
@@ -80,7 +80,7 @@ anonNames: false  # To show or hide user (and full) names in report, true or fal
 reportButton: "Raportti"
 userListButtonText: "Käyttäjälista"
 showToolbar: true # toolbar for editing the table
-# hiddenColumns: [0,1] # which colums are hidden
+# hiddenColumns: [0,1] # which columns are hidden
 
 # forceUpdateButtonText: "Virkistä" # button for refreshing the table
 #dataView:        # uncomment this if table is big or want to use special properties

--- a/timApp/modules/svn/templates/video/1/Review summary by macros
+++ b/timApp/modules/svn/templates/video/1/Review summary by macros
@@ -47,7 +47,7 @@ anonNames: false  # To show or hide user (and full) names in report, true or fal
 reportButton: "Raportti"
 userListButtonText: "Käyttäjälista"
 showToolbar: true # toolbar for editing the table
-# hiddenColumns: [0,1] # which colums are hidden
+# hiddenColumns: [0,1] # which columns are hidden
 
 # forceUpdateButtonText: "Virkistä" # button for refreshing the table
 #dataView:        # uncomment this if table is big or want to use special properties

--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -367,7 +367,7 @@ anonNames: false  # Whether to show anonymised names, true or false
 reportButton: "Raportti"
 userListButtonText: "Käyttäjälista"
 showToolbar: true # toolbar for editing the table
-# hiddenColumns: [0,1] # which colums are hidden
+# hiddenColumns: [0,1] # which columns are hidden
 
 # forceUpdateButtonText: "Virkistä" # button for refreshing the table
 #dataView:        # uncomment this if table is big or want to use special properties

--- a/timApp/plugin/timtable/timTable.py
+++ b/timApp/plugin/timtable/timTable.py
@@ -938,7 +938,7 @@ def is_datablock(yaml: dict[str, Any]) -> bool:
     Checks if tableDataBlock exists
 
     :param yaml:
-    :return: Boolean indicating the existance of tabledatablock
+    :return: Boolean indicating the existence of tabledatablock
     """
     try:
         if yaml[TABLE][DATABLOCK]:

--- a/timApp/plugin/timtable/timTableLatex.py
+++ b/timApp/plugin/timtable/timTableLatex.py
@@ -148,7 +148,7 @@ class Cell:
     cell_width: str = default_width
     """Width of the cell."""
     cell_height: str = default_height
-    """Heigth of the cell."""
+    """Height of the cell."""
     line_space: int = 0
     """Unused attribute."""
     pbox: str = "10cm"
@@ -970,7 +970,7 @@ def get_size(
     Parse width or height into LaTeX-supported format.
 
     :param item: Cell data.
-    :param key: Width or heigth.
+    :param key: Width or height.
     :param default: Value to be used if key wasn't found.
     :return: Cell width or height.
     """

--- a/timApp/printing/documentprinter.py
+++ b/timApp/printing/documentprinter.py
@@ -922,7 +922,7 @@ def tim_convert_text(
     :param str outputfile: output will be written to outfilename or the converted content
             returned if None (Default value = None)
     :param list filters: pandoc filters e.g. filters=['pandoc-citeproc']
-    :param removethis: lines that contains this text are removed from genereted LaTeX file
+    :param removethis: lines that contains this text are removed from generated LaTeX file
     :param texfiles: what files need to copy
     :returns: converted string (unicode) or an empty string if an outputfile was given
     :param eol_type: EOL type to use. Allowed values are same as Pandoc (crlf, lf, native)
@@ -1077,7 +1077,7 @@ def _decode_result(s):
     try:
         s = s.decode("utf-8")
     except UnicodeDecodeError:
-        # this shouldn't happen: pandoc more or less garantees that the output is utf-8!
+        # this shouldn't happen: pandoc more or less guarantees that the output is utf-8!
         # raise RuntimeError('Pandoc output was not utf-8.')
         # noinspection PyBroadException
         try:

--- a/timApp/printing/print.py
+++ b/timApp/printing/print.py
@@ -268,7 +268,7 @@ def get_printed_document(
 
     print_type = PrintFormat(file_type)
     template_doc = None
-    orginal_print_type = print_type
+    original_print_type = print_type
     eol_type = "native"
     if print_type == PrintFormat.ICS:
         print_type = PrintFormat.PLAIN
@@ -370,7 +370,7 @@ def get_printed_document(
             + line
             + "#L"
             + line
-            + '" target="_blank">Erronous LaTeX file</a></p>'
+            + '" target="_blank">Erroneous LaTeX file</a></p>'
             + '<p><a href="'
             + latex_access_url
             + '" target="_blank">Created LaTeX file</a></p>'
@@ -388,10 +388,10 @@ def get_printed_document(
         add_csp_header(response)
         return response
 
-    mime = get_mimetype_for_format(orginal_print_type)
+    mime = get_mimetype_for_format(original_print_type)
 
     if not line:
-        if orginal_print_type == PrintFormat.HTML:
+        if original_print_type == PrintFormat.HTML:
             with open(cached, "r", encoding="utf-8") as f:
                 result = f.read()
             # TODO: This sanitizes the HTML, including PDF iframes.
@@ -452,7 +452,7 @@ def get_printed_document(
 def get_setting_and_counters_par(
     doc_info: DocInfo,
 ) -> tuple[DocParagraph | None, DocParagraph | None]:
-    # TODO: Make this more efective!
+    # TODO: Make this more effective!
     settings_par: DocParagraph | None = None
     counters_par: DocParagraph | None = None
     for par in doc_info.document:  # type: DocParagraph

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -174,7 +174,7 @@ export class AnswerBrowserComponent
     public review: boolean = false;
     imageReview: boolean = false;
     private imageReviewUrls: string[] = [];
-    imageReviewDatas: string[] = [];
+    imageReviewData: string[] = [];
     private imageReviewUrlIndex = 0;
     public oldreview: boolean = false;
     public shouldFocus: boolean = false;
@@ -635,11 +635,11 @@ export class AnswerBrowserComponent
                     const velpImages = await comp.getVelpImages();
                     if (velpImages) {
                         this.imageReview = true;
-                        this.imageReviewDatas = velpImages;
+                        this.imageReviewData = velpImages;
                     }
                 } else if (newReviewHtml.startsWith("data:image")) {
                     this.imageReview = true;
-                    this.imageReviewDatas = [newReviewHtml];
+                    this.imageReviewData = [newReviewHtml];
                 } else if (newReviewHtml.startsWith("imageurls:")) {
                     this.imageReview = true;
                     const fetchedImages: string[] = [];
@@ -661,7 +661,7 @@ export class AnswerBrowserComponent
                         );
                         fetchedImages.push(base64Data as string);
                     }
-                    this.imageReviewDatas = fetchedImages;
+                    this.imageReviewData = fetchedImages;
                 }
 
                 if (this.selectedAnswer) {

--- a/timApp/static/scripts/tim/answer/userlistController.ts
+++ b/timApp/static/scripts/tim/answer/userlistController.ts
@@ -307,7 +307,7 @@ export class UserListController implements IController {
                 },
                 {
                     // TODO: better desc
-                    title: "De-sync selected users in taks",
+                    title: "De-sync selected users in tasks",
                     action: ($event: IAngularEvent) => {
                         this.viewctrl.syncAnswerBrowsers = false;
                     },

--- a/timApp/static/scripts/tim/editor/BaseParEditor.ts
+++ b/timApp/static/scripts/tim/editor/BaseParEditor.ts
@@ -99,7 +99,7 @@ export abstract class BaseParEditor {
             return;
         }
         $timeout(() => {
-            // time to let new char happend
+            // time to let new char happen
             this.forceWrap(false);
         });
     }

--- a/timApp/static/scripts/tim/editor/pareditor.ts
+++ b/timApp/static/scripts/tim/editor/pareditor.ts
@@ -979,7 +979,7 @@ ${backTicks}
                         name: "Math SVG",
                     },
                     {
-                        title: "Insert new editor tempates",
+                        title: "Insert new editor templates",
                         func: () =>
                             this.editor!.insertTemplate(
                                 `editor_templates:
@@ -1646,7 +1646,7 @@ ${backTicks}
     /**
      * Checks whether the language combination is supported by the selected translator.
      * @param orig The source document's language code
-     * @param tr The curent document's language code
+     * @param tr The current document's language code
      * @returns Whether or not the language combination is supported
      */
     isTranslationPairSupported(orig: string, tr: string) {

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -16,12 +16,12 @@ import {documentglobals, genericglobals} from "tim/util/globals";
                             <div class="col-xs-6">
                                 <p>
                                     <ng-container *ngIf="!docGlobals.requires_login || !hide.links" i18n>TIM last updated: </ng-container>
-                                    <ng-container *ngIf="hide.links && !docGlobals.requires_login">{{config.gitLastestCommitTimestamp}}
+                                    <ng-container *ngIf="hide.links && !docGlobals.requires_login">{{config.gitLatestCommitTimestamp}}
                                         <br>    
                                         <ng-container i18n>Problems and questions about TIM</ng-container>: {{config.helpEmail}}
                                     </ng-container>
                                     <ng-container *ngIf="!hide.links">
-                                        <a href="/view/tim/muutoshistoria">{{config.gitLastestCommitTimestamp}}</a>
+                                        <a href="/view/tim/muutoshistoria">{{config.gitLatestCommitTimestamp}}</a>
                                         <br>
                                         <ng-container i18n>Problems and questions about TIM</ng-container>
                                         :

--- a/timApp/static/scripts/tim/gamification/gamification-map.component.ts
+++ b/timApp/static/scripts/tim/gamification/gamification-map.component.ts
@@ -388,7 +388,7 @@ export class GamificationMapComponent {
                 this.tileFrameSet.tilewidth * scale,
                 this.tileFrameSet.tileheight * scale
             );
-            // If clicked on a bulding with one floor, draw two frame tiles and a roof frame
+            // If clicked on a building with one floor, draw two frame tiles and a roof frame
         } else if (
             tile.tileset.properties != null &&
             tile.tileset.properties.buildingProperty === 1 && // && this.json.layers[tile.layerNo + 1] &&
@@ -474,7 +474,7 @@ export class GamificationMapComponent {
                 this.tileFrameSet.tilewidth * scale,
                 this.tileFrameSet.tileheight * scale
             );
-            // If clicked on a bulding with two floors, draw one frame tile and a roof frame
+            // If clicked on a building with two floors, draw one frame tile and a roof frame
         } else if (
             tile.tileset.properties != null &&
             tile.tileset.properties.buildingProperty === 1 && // this.json.layers[tile.layerNo + 1] &&

--- a/timApp/static/scripts/tim/item/tagged-document-list.component.ts
+++ b/timApp/static/scripts/tim/item/tagged-document-list.component.ts
@@ -117,7 +117,7 @@ export class TaggedDocumentListComponent {
 
     /*
      * Calls tag search function. Has option to searching for exactly matching
-     * tags or all that containg parts of the tag.
+     * tags or all that contain parts of the tag.
      */
     async searchClicked(tagName: string) {
         if (!this.enableSearch) {

--- a/timApp/static/scripts/tim/lecture/lectureController.ts
+++ b/timApp/static/scripts/tim/lecture/lectureController.ts
@@ -1,6 +1,6 @@
 /**
  * Created by hajoviin on 24.2.2015.
- * Contoller that handles lectures.
+ * Controller that handles lectures.
  * @author Matias Berg
  * @author Bek Eljurkaev
  * @author Minna Lehtomäki

--- a/timApp/static/scripts/tim/messaging/manage/message-list-admin.component.scss
+++ b/timApp/static/scripts/tim/messaging/manage/message-list-admin.component.scss
@@ -131,7 +131,7 @@ input[type="checkbox"], input[type="radio"] {
 }
 
 .indented-more {
-  // Some elemenents are sub-elements, those are indented a bit more.
+  // Some elements are sub-elements, those are indented a bit more.
   margin-left: 4em;
 }
 

--- a/timApp/static/scripts/tim/messaging/tim-message-send.component.ts
+++ b/timApp/static/scripts/tim/messaging/tim-message-send.component.ts
@@ -185,7 +185,7 @@ export class TimMessageSendComponent {
      *  TODO: This component has a minor bug. If the textfield of recipients is emptied by hand, the component closes
      *  and it can't be reopened unless the recipientList variable changes. A hypothetical fix would be to use a
      *  separate flag in the *ngIf, instead of just the recipientList variable. Then this flag would only be operated to
-     *  close when the component is closed from the x. It would propably requrie change detection for the recipientList
+     *  close when the component is closed from the x. It would probably require change detection for the recipientList
      *  variable, as its length grows beoynd 0 the the flag is set on?
      */
 

--- a/timApp/static/scripts/tim/plugin/calendar/calendar.component.scss
+++ b/timApp/static/scripts/tim/plugin/calendar/calendar.component.scss
@@ -100,7 +100,7 @@ input[type="checkbox"] {
   margin-right: 4px;
 }
 
-.cal-ui-swicth {
+.cal-ui-switch {
   display: flex;
   align-items: center;
   column-gap: 0.5em;

--- a/timApp/static/scripts/tim/plugin/calendar/calendar.component.ts
+++ b/timApp/static/scripts/tim/plugin/calendar/calendar.component.ts
@@ -281,7 +281,7 @@ export type TIMCalendarEvent = CalendarEvent<TIMEventMeta>;
                 </div>
             </div>
         </ng-template>
-        <div class="cal-ui-swicth">
+        <div class="cal-ui-switch">
             <label><input type="checkbox" [(ngModel)]="advancedUI" /><ng-container i18n>Advanced</ng-container></label>
             <tim-calendar-minimal-header 
                     [locale]="locale" 

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -313,7 +313,7 @@ export class TableFormComponent
         lockedCells: [],
         lockedColumns: [],
         table: {countRow: 0, countCol: 0, columns: []},
-        // TODO: give rows (and maybe colums) in data.table
+        // TODO: give rows (and maybe columns) in data.table
         task: true,
         userdata: {type: "Relative", cells: {}},
         nonUserSpecific: true,
@@ -788,7 +788,7 @@ export class TableFormComponent
             for (const aliasfield of ownFields) {
                 const field = aliasfield.split("=")[0].trim();
                 const docField = this.viewctrl.docId + "." + field;
-                // TODO: Double .includes call - maybe it's better to search for fieldsToUpdate from somethign
+                // TODO: Double .includes call - maybe it's better to search for fieldsToUpdate from something
                 //  that already has the docID
                 if (fields.includes(field) || fields.includes(docField)) {
                     fieldsToUpdate.push(aliasfield);
@@ -1015,7 +1015,7 @@ export class TableFormComponent
 
     /**
      * String to determinate how usernames are filtered in report.
-     * Choises are username, username and full name and anonymous. Username as default.
+     * Choices are username, username and full name and anonymous. Username as default.
      */
     sortBy() {
         return this.markup.sortBy ?? "username";

--- a/timApp/static/scripts/tim/plugin/tape/tape-plugin.component.ts
+++ b/timApp/static/scripts/tim/plugin/tape/tape-plugin.component.ts
@@ -334,7 +334,7 @@ function scrollElementVisibleInParent(
     extraY: number
 ) {
     // Scroll par window so that el comes visible if it is not visible
-    // it is ensured that at least extraY times el hight is over or under el
+    // it is ensured that at least extraY times el height is over or under el
     const rect = el.getBoundingClientRect();
     const prect = par.getBoundingClientRect();
 
@@ -581,7 +581,7 @@ export class TapePluginContent implements PluginJson {
 
     /**
      * Inserts a command into the program.
-     * Returns true if succesful, otherwise false.
+     * Returns true if successful, otherwise false.
      * @param commandToAdd The command.
      * @param parameterString The parameter of the command given as a string.
      * @param index (Optional) The place where the command is inserted in the program, if not to the end.

--- a/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
+++ b/timApp/static/scripts/tim/plugin/timTable/tim-table.component.ts
@@ -265,7 +265,7 @@ export interface TimTable {
     saveCallBack?: (cellsTosave: CellToSave[]) => void;
     saveStyleCallBack?: (cellsTosave: CellAttrToSave[]) => void;
     cbCallBack?: (cbs: boolean[], n: number, index: number) => void;
-    maxWidth?: string; // Possibly obsolete if cell/column layout can be given in data.table.colums
+    maxWidth?: string; // Possibly obsolete if cell/column layout can be given in data.table.columns
     minWidth?: string;
     singleLine?: boolean;
     filterRow?: boolean;
@@ -358,8 +358,8 @@ export interface ICellIndex {
 }
 
 export interface ISelectedCells {
-    cells: ICellIndex[]; // List of original cell indecies inside selected area
-    srows: boolean[]; // table for screen indecies selected
+    cells: ICellIndex[]; // List of original cell indices inside selected area
+    srows: boolean[]; // table for screen indices selected
     scol1: number; // screen index for first selected column
     scol2: number; // screen index for last selected column
     srow1: number; // screen index for first selected row
@@ -688,7 +688,7 @@ export enum ClearSort {
                           style="position: absolute; width: max-content"
                           [hidden]="hide.editorButtons">
                     <span [hidden]="hide.editorPosition" [innerHtml]="editorPosition"
-                          (click)="handleClickEditorPostion()" style="background: yellow;"></span>
+                          (click)="handleClickEditorPosition()" style="background: yellow;"></span>
                     <button
                             #buttonOpenBigEditor class="timButton buttonOpenBigEditor"
                             (click)="handleClickOpenBigEditor()"><span class="glyphicon glyphicon-pencil"></span>
@@ -736,7 +736,7 @@ export class TimTableComponent
 {
     error: string = "";
     public viewctrl?: ViewCtrl;
-    public cellDataMatrix: ICell[][] = []; // this has all table data as original indecies (sort does not affect)
+    public cellDataMatrix: ICell[][] = []; // this has all table data as original indices (sort does not affect)
     private prevCellDataMatrix: ICell[][] = [];
     public columns: IColumn[] = [];
     @Input() public data!: TimTable;
@@ -1289,7 +1289,7 @@ export class TimTableComponent
     /**
      * Make smaller matrix by cutting only needed columns
      * @param rows list of rows to use
-     * @param cols col indecies to take
+     * @param cols col indices to take
      */
     public static makeSmallerMatrix(rows: string[][], cols: number[]) {
         const result = [];
@@ -2312,7 +2312,7 @@ export class TimTableComponent
         // hideToolbar(this);
     }
 
-    handleClickEditorPostion() {
+    handleClickEditorPosition() {
         copyToClipboard(this.editorPosition);
     }
 
@@ -2391,7 +2391,7 @@ export class TimTableComponent
         ev: KeyboardEvent
     ): Promise<ChangeDetectionHint> {
         if (isKeyCode(ev, KEY_F2)) {
-            // TODO: change all other keys like this to avoid depreceted warings
+            // TODO: change all other keys like this to avoid deprecated warnings
             if (this.hide.edit) {
                 return ChangeDetectionHint.DoNotTrigger;
             }
@@ -3420,7 +3420,7 @@ export class TimTableComponent
      * @param styles The dictionary that will contain the final object styles
      * @param object The object that contains the user-given style attributes
      * @param validAttrs A set that contains the accepted style attributes
-     * @return posible class
+     * @return possible class
      */
     private applyStyle(
         styles: Record<string, string | number>,
@@ -4067,7 +4067,7 @@ export class TimTableComponent
                                         !newCls.includes(s1) &&
                                         areaClearOrSet != 2
                                     ) {
-                                        // is not allredy in classes
+                                        // is not already in classes
                                         newCls = newCls + " " + s1;
                                         clearOrSet = 1;
                                     } else if (!toggle && areaClearOrSet != 2) {

--- a/timApp/static/scripts/tim/plugin/util.ts
+++ b/timApp/static/scripts/tim/plugin/util.ts
@@ -181,7 +181,7 @@ export abstract class PluginBaseCommon {
      * Sets plugin's answer content via external call
      * @param content answer to be parsed
      * @returns ISetAnswerResult: {ok: boolean, message: (string | undefined)}
-     * ok: true if content was succesfully parsed
+     * ok: true if content was successfully parsed
      * message: for replying with possible errors
      */
     setAnswer(content: Record<string, unknown>): ISetAnswerResult {

--- a/timApp/static/scripts/tim/user/user-action-verify.component.ts
+++ b/timApp/static/scripts/tim/user/user-action-verify.component.ts
@@ -121,7 +121,7 @@ const INFO_MAP: Record<VerificationType, Type<unknown> | undefined> = {
     [VerificationType.SET_PRIMARY_CONTACT]: SetPrimaryContactInfoComponent,
 };
 
-const VERIFY_RETRUN_URLS: Record<VerificationType, string | undefined> = {
+const VERIFY_RETURN_URLS: Record<VerificationType, string | undefined> = {
     [VerificationType.LIST_JOIN]: undefined,
     [VerificationType.CONTACT_OWNERSHIP]: $localize`Return to TIM settings.`,
     [VerificationType.SET_PRIMARY_CONTACT]: $localize`Return to TIM settings.`,
@@ -165,7 +165,7 @@ export class UserActionVerifyComponent implements AfterViewInit {
     infoContainer!: ViewContainerRef;
     processing: boolean = false;
     verifyComplete: boolean = false;
-    verifyReturnUrls = VERIFY_RETRUN_URLS;
+    verifyReturnUrls = VERIFY_RETURN_URLS;
     verificationResult?: {
         severity: AlertSeverity;
         message: string;

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -54,7 +54,7 @@ interface IHostConfig {
 interface IConfig {
     minPasswordLength: number;
     simpleLoginUseStudyInfoMessage: boolean;
-    gitLastestCommitTimestamp: string;
+    gitLatestCommitTimestamp: string;
     helpEmail: string;
     gitBranch: string;
     hakaEnabled: boolean;

--- a/timApp/static/scripts/tim/velp/velp-summary.component.scss
+++ b/timApp/static/scripts/tim/velp/velp-summary.component.scss
@@ -30,7 +30,7 @@
     border-left: 0;
 }
 
-.summThiColumn {
+.summThirdColumn {
     text-align: center;
 }
 

--- a/timApp/static/scripts/tim/velp/velp-summary.component.ts
+++ b/timApp/static/scripts/tim/velp/velp-summary.component.ts
@@ -22,30 +22,30 @@ import type {Annotation} from "tim/velp/velptypes";
                 <table>
                     <tr>
                         <th class="summSecColumn">Annotation</th>
-                        <th class="summThiColumn">Points</th>
+                        <th class="summThirdColumn">Points</th>
                     </tr>
                     <tr *ngFor="let a of taskAnns">
                         <td class="summSecColumn"><a
                                 (click)="annotationselected.emit(a)">{{ a.content }}</a>
                         </td>
-                        <td class="summThiColumn"><span>{{ a.points }}</span></td>
+                        <td class="summThirdColumn"><span>{{ a.points }}</span></td>
                     </tr>
                     <tr>
                         <th class="summSecColumn">Points total in all answers</th>
-                        <th class="summThiColumn"><span>{{ getTotalPoints(taskAnns) }}</span></th>
+                        <th class="summThirdColumn"><span>{{ getTotalPoints(taskAnns) }}</span></th>
                     </tr>
                 </table>
                 <h5>Other document annotations</h5>
                 <table>
                     <tr>
                         <th class="summSecColumn">Annotation</th>
-                        <th class="summThiColumn">Points</th>
+                        <th class="summThirdColumn">Points</th>
                     </tr>
                     <tr *ngFor="let b of docAnns">
                         <td class="summSecColumn"><a
                                 (click)="annotationselected.emit(b)">{{ b.content }}</a>
                         </td>
-                        <td class="summThiColumn"><span>{{ b.points }}</span></td>
+                        <td class="summThirdColumn"><span>{{ b.points }}</span></td>
                     </tr>
                 </table>
             </div>

--- a/timApp/static/scripts/tim/velp/velpSelection.ts
+++ b/timApp/static/scripts/tim/velp/velpSelection.ts
@@ -492,7 +492,7 @@ export class VelpSelectionController implements IController {
     /**
      * Initially resets this.velpToEdit variable to the original (empty) state.
      * NOTE! this function is replaced in 'setVelpToEdit'. When replaced
-     * this mehtod resets the velp that is being edited to its original state.
+     * this method resets the velp that is being edited to its original state.
      */
     resetEditVelp() {
         this.velpToEdit = {

--- a/timApp/static/stylesheets/cssPrint.scss
+++ b/timApp/static/stylesheets/cssPrint.scss
@@ -36,8 +36,8 @@
 
 @media print and (color) {
 
-  //This forces h1 elemet to ignore page-break (Remove this. This shouldn't be here.)
-  //[id='3lUURaXWmQvB'] .parContent h1{ //Replace 3lUURaXWmQvB with apporiate id.
+  //This forces h1 element to ignore page-break (Remove this. This shouldn't be here.)
+  //[id='3lUURaXWmQvB'] .parContent h1{ //Replace 3lUURaXWmQvB with appropriate id.
   //page-break-before: initial !important;
   //background-color: green !important;
   //}

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -196,7 +196,7 @@
                 <div *ngIf="imageReview">
                     <draw-canvas
                             [options]="{enabled: false, color: 'red', drawType: 2, opacity: 1.0, fill: false, w: 2}"
-                            [toolBar]="viewctrl.velpMode" [bgSources]="imageReviewDatas"
+                            [toolBar]="viewctrl.velpMode" [bgSources]="imageReviewData"
                             [imgLoadCallback]="setImageReview"></draw-canvas>
                 </div>
                 <div *ngIf="!imageReview" class="review" [innerHtml]="reviewHtml">

--- a/timApp/templates/base.jinja2
+++ b/timApp/templates/base.jinja2
@@ -78,7 +78,7 @@
             layout.col_m_xs = {{col_m_xs|tojson}};
 
             var config = {};
-            config.gitLastestCommitTimestamp = {{config.GIT_LATEST_COMMIT_TIMESTAMP|tojson}};
+            config.gitLatestCommitTimestamp = {{config.GIT_LATEST_COMMIT_TIMESTAMP|tojson}};
             config.helpEmail = {{config.HELP_EMAIL|tojson}};
             config.gitBranch = {{config.GIT_BRANCH|tojson}};
             config.hakaEnabled = {{config.HAKA_ENABLED|tojson}};

--- a/timApp/templates/messagelist/archive_export.jinja2
+++ b/timApp/templates/messagelist/archive_export.jinja2
@@ -73,7 +73,7 @@
 </head>
 <body>
     <nav>
-        <strong>TIM messsage list archive</strong> – <span>{{ message_list.name }}</span>
+        <strong>TIM message list archive</strong> – <span>{{ message_list.name }}</span>
     </nav>
     <aside>
         <ul>

--- a/timApp/tests/browser/test_csplugin.py
+++ b/timApp/tests/browser/test_csplugin.py
@@ -218,7 +218,7 @@ postprogram: |!!
         self.assertEqual("1/1", count.text)
         self.assertEqual("-6 + -3 = -9; -9 on OK", self.find_element(".console").text)
 
-        # make a new anwser, that is not saved (see later)
+        # make a new answer, that is not saved (see later)
         input_and_send("3")
         self.assertEqual("1/1", count.text)
         self.assertEqual(
@@ -418,7 +418,7 @@ stackversion: 0
         self.assertEqual("1/1", count.text)
         self.assertEqual("OK!", feedback_text())
 
-        # make a new anwser, that is not saved (see later)
+        # make a new answer, that is not saved (see later)
         input_and_send("16")
         self.assertEqual("1/1", count.text)
         self.assertEqual("4553:15+2", stem_text())

--- a/timApp/tests/server/test_messagelist.py
+++ b/timApp/tests/server/test_messagelist.py
@@ -209,7 +209,7 @@ class MessageListTest(TimMessageListTest):
         admin_doc = get_doc_or_abort(manage_doc["id"])
         # Verify returned admin doc is the same message list's admin doc in db.
         self.assertEqual(message_list.manage_doc_id, admin_doc.id)
-        # Verify name and archive type are as intented in the db.
+        # Verify name and archive type are as intended in the db.
         self.assertEqual(message_list.name, list_name)
         self.assertEqual(message_list.archive, archive)
         self.assertIsNotNone(Folder.find_by_path(f"archives/{message_list.name}"))

--- a/timApp/tests/server/test_wuff.py
+++ b/timApp/tests/server/test_wuff.py
@@ -14,7 +14,7 @@ class TestWuff(TimRouteTest):
         sent_mails_in_testing.clear()
         self.login_test1()
 
-    def tigger_error(self, count: int, expect_mail_count: int):
+    def trigger_error(self, count: int, expect_mail_count: int):
         for i in range(count):
             self.get("/exception", expect_status=500)
         self.assertEqual(expect_mail_count, len(sent_mails_in_testing))
@@ -26,7 +26,7 @@ class TestWuff(TimRouteTest):
                 "PROPAGATE_EXCEPTIONS": False,
             }
         ):
-            self.tigger_error(count=1, expect_mail_count=1)
+            self.trigger_error(count=1, expect_mail_count=1)
             m = sent_mails_in_testing[0]
             self.assertEqual(m["rcpt"], app.config["ERROR_EMAIL"])
             self.assertEqual(m["mail_from"], app.config["WUFF_EMAIL"])
@@ -44,7 +44,7 @@ class TestWuff(TimRouteTest):
             for i in range(2):
                 # Sleeping beyond the WUFF_MAX_SAME_INTERVAL should not prevent the next mail
                 sleep(1)
-                self.tigger_error(count=1, expect_mail_count=i + 1)
+                self.trigger_error(count=1, expect_mail_count=i + 1)
 
     def test_wuff_send_mute_cooldown(self):
         with self.temp_config(
@@ -56,11 +56,11 @@ class TestWuff(TimRouteTest):
                 "WUFF_MAX_SAME_MUTE_DURATION": 1,
             }
         ):
-            self.tigger_error(count=2, expect_mail_count=2)
+            self.trigger_error(count=2, expect_mail_count=2)
 
             # This should not trigger a mail
-            self.tigger_error(count=1, expect_mail_count=2)
+            self.trigger_error(count=1, expect_mail_count=2)
 
             # Waiting for WUFF_MAX_SAME_MUTE_DURATION should reset the mute cooldown
             sleep(1)
-            self.tigger_error(count=2, expect_mail_count=4)
+            self.trigger_error(count=2, expect_mail_count=4)

--- a/timApp/tests/unit/test_translator_parser.py
+++ b/timApp/tests/unit/test_translator_parser.py
@@ -980,7 +980,7 @@ P.getData = function(){
         md = """**fet**
 
 
-*kursiv stil*
+*cursive style*
 
 
 <u>Understrykning</u>
@@ -1008,7 +1008,7 @@ kodblock
         NT = NoTranslate
         self.assertEqual(
             [
-                TR("\n<b>fet</b>\n\n<i>kursiv stil</i>\n\n"),
+                TR("\n<b>fet</b>\n\n<i>cursive style</i>\n\n"),
                 NT("<u>"),
                 TR("Understrykning"),
                 NT("</u>"),

--- a/timApp/util/pdftools.py
+++ b/timApp/util/pdftools.py
@@ -367,7 +367,7 @@ def parse_error(message: str) -> str:
         return "Error: Unable to merge a password protected file; please remove the password requirement (including empty password)"
     elif (
         "Error: Unable to find file" in message
-        or "java.io.FileNotFoundEception" in message
+        or "java.io.FileNotFoundException" in message
     ):
         return "Error: file not found; merging tool couldn't find the attachment, try reuploading it"
     elif "java.lang.ClassCastException" in message:

--- a/timApp/util/rndutils.py
+++ b/timApp/util/rndutils.py
@@ -142,7 +142,7 @@ def get_int_list(myrandom: Random, jso: str) -> list[int]:
 
 def get_uniform_list(myrandom: Random, jso: str) -> list[float]:
     """
-    Returns list of uniformely distributed random floats from given interval.
+    Returns list of uniformly distributed random floats from given interval.
 
     :param myrandom: random number generator
     :param jso: string to find the values

--- a/timApp/util/utils.py
+++ b/timApp/util/utils.py
@@ -349,7 +349,7 @@ TASK_NAME_PROG = re.compile(
 
 def widen_fields(fields: list[str] | str) -> list[str]:
     """
-    if there is syntax d(1,3) in fileds, it is made d1,d2
+    if there is syntax d(1,3) in fields, it is made d1,d2
     from d(1,3)=t  would come d1=t1, d2=t2
 
     :param fields: list of fields

--- a/tim_common/fileParams.py
+++ b/tim_common/fileParams.py
@@ -267,7 +267,7 @@ def clear_cache():
         os.remove(CACHE_DIR + f)
 
 
-def get_chache_keys():
+def get_cache_keys():
     global cache
     s = ""
     memory_cache_size = len(cache)
@@ -287,7 +287,7 @@ def get_chache_keys():
 # noinspection PyBroadException
 def get_url_lines(url: str):
     global cache
-    # print("========= CACHE KEYS ==========\n", get_chache_keys())
+    # print("========= CACHE KEYS ==========\n", get_cache_keys())
     if url in cache:
         # print("from cache: ", url)
         return cache[url]
@@ -358,9 +358,9 @@ def get_url_lines_as_string(url: str, headers: dict[str, str] | None = None):
     global cache
     cachename = "lines_" + url + secure_hash_dict(headers)
     diskcache = CACHE_DIR + cachename.replace("/", "_").replace(":", "_")
-    # print("========= CACHE KEYS ==========\n", get_chache_keys())
+    # print("========= CACHE KEYS ==========\n", get_cache_keys())
     # print(cachename + "\n")
-    # print(cache) # chache does not work in forkingMix
+    # print(cache) # cache does not work in forkingMix
     if cachename in cache:
         # print("from cache: ", cachename)
         return cache[cachename]
@@ -978,8 +978,8 @@ def get_templates(dirname: str) -> object:
 
 def get_all_templates(dirname: str) -> dict:
     """Find list of all templates from dirname.  Dir should include file tabs.txt where there is one line for every tab
-    needed for TIM editor. Then there should be directories 0, 1, ... for each corresponding tab-line.  So if tehre is
-    two lines in tabs.txt tehre is directories 0 and 1 for first and second tab.
+    needed for TIM editor. Then there should be directories 0, 1, ... for each corresponding tab-line.  So if there is
+    two lines in tabs.txt there is directories 0 and 1 for first and second tab.
 
     :param dirname: the directory name where to find template list file and sub directories for templates
     :return: dict with list of lif to template items (templates) and texts (text)
@@ -1096,7 +1096,7 @@ def make_lazy(
 def replace_template_params(
     query: QueryClass, template: str, cond_itemname: str, itemnames=None
 ) -> str:
-    """Replaces all occurances of itemnames and cond_item_name in template by their value in query if  cond_itemname
+    """Replaces all occurrences of itemnames and cond_item_name in template by their value in query if  cond_itemname
     exists in query.
 
     :param query: query params where items can be read
@@ -1128,7 +1128,7 @@ def replace_template_params(
 def replace_template_param(
     query: QueryClass, template: str, cond_itemname: str, default=""
 ) -> str:
-    """Replaces all occurances of itemnames and cond_item_name in template by their value in query if  cond_itemname
+    """Replaces all occurrences of itemnames and cond_item_name in template by their value in query if  cond_itemname
     exists in query.
 
     :param query: query params where items can be read

--- a/tim_common/pluginserver_flask.py
+++ b/tim_common/pluginserver_flask.py
@@ -226,7 +226,7 @@ class GenericHtmlModel(GenericRouteModel[PluginInput, PluginMarkup, PluginState]
         """
         If component is not show in view mode return False.
         This method is for to be overridden in child classes if they should not be shown on View-mode
-        :return: is component shown in view as deafault
+        :return: is component shown in view as default
         """
         return True
 

--- a/tim_common/tim_server.py
+++ b/tim_common/tim_server.py
@@ -74,15 +74,15 @@ class TimServer(http.server.BaseHTTPRequestHandler):
             return self.do_all(post_params(self))
 
         print("do_POST MULTIHTML ==========================================")
-        querys = multi_post_params(self)
+        queries = multi_post_params(self)
         do_headers(self, "application/json")
         htmls = []
-        self.user_id = get_param(querys[0], "user_id", "--")
+        self.user_id = get_param(queries[0], "user_id", "--")
         print("UserId:", self.user_id)
         log(self)
-        # print(querys)
+        # print(queries)
 
-        for query in querys:
+        for query in queries:
             # print(query.jso)
             # print(str(query))
             s = self.get_html(query)
@@ -114,7 +114,7 @@ class TimServer(http.server.BaseHTTPRequestHandler):
         self.wfile.write(s.encode("UTF-8"))
 
     def send_text_file(self, name: str, ftype: str, content_type: str):
-        """Sends a file to server from directory ftype with contect_type.
+        """Sends a file to server from directory ftype with content_type.
 
         :param name: files name part, possible extra directories
         :param ftype: files type (js, html, css), specifies also the directory where to get the file

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,85 @@
+[files]
+extend-exclude = [
+    "typos.toml",
+    "*.c",
+    "*.cc",
+    "*.h",
+    "*.cpp",
+    "*.xlf",
+    "*.patch",
+    "*.min.js",
+    "*-min.js",
+    "timApp/static/scripts/vendor/",
+    "timApp/static/ohj1/",
+    "timApp/modules/cs/static/ohj2/",
+    "timApp/modules/cs/static/WeScheme/",
+    "test_signup.py",
+    "full.render.js",
+    "lite.render.js",
+    "embedded_sagecell.js",
+    "processing.js",
+    "codeHighlight.scss",
+]
+
+[default.extend-identifiers]
+# False positives/otherwise not worth fixing:
+ba = "ba"
+datas = "datas"
+global_datas = "global_datas"
+SMTPHeloError = "SMTPHeloError"
+ba_group = "ba_group"
+ue = "ue"
+nd = "nd"
+nd_path = "nd_path"
+209fc28604ba = "209fc28604ba"
+70a159e42ba6 = "70a159e42ba6"
+82c3b050ba5d = "82c3b050ba5d"
+209fc28604ba_ = "209fc28604ba_"
+70a159e42ba6_ = "70a159e42ba6_"
+82c3b050ba5d_add_index_to_readparagraphs = "82c3b050ba5d_add_index_to_readparagraphs"
+Anonymoys = "Anonymoys"
+ba_change = "ba_change"
+ba_confirm = "ba_confirm"
+GHYGje2NiYlQM66xyggsnzQht1OHSgtv_9baHbFIklU = "GHYGje2NiYlQM66xyggsnzQht1OHSgtv_9baHbFIklU"
+Otho = "Otho"
+makro = "makro"
+euclidianView = "euclidianView"
+alue = "alue"
+uudenMuuttujanAlue = "uudenMuuttujanAlue"
+muuttujaButtonAlue = "muuttujaButtonAlue"
+alle = "alle"
+funktion = "funktion"
+t_lnBA = "t_lnBA"
+rekursion = "rekursion"
+als = "als"
+ist = "ist"
+sade = "sade"
+addToDatas = "addToDatas"
+sectionning = "sectionning"
+eJwVy0EOhCAMQNG7dG0yahGFy5BaS2ZigEnFlfHu4vL95F8Q_qKJsuQKvuopHVDmb1HwAB0wJQlRS2r8vD40hlp2yS2YwTGamceerWXkaR0nIiTroiFaNtsPy = "eJwVy0EOhCAMQNG7dG0yahGFy5BaS2ZigEnFlfHu4vL95F8Q_qKJsuQKvuopHVDmb1HwAB0wJQlRS2r8vD40hlp2yS2YwTGamceerWXkaR0nIiTroiFaNtsPy"
+Versio = "Versio"
+MATA280 = "MATA280"
+
+[default.extend-words]
+# Custom corrections:
+'garåh' = "graph"
+agording = "according"
+allreadu = "already"
+charracter = "character"
+depreceted = "deprecated"
+dirrerences = "differences"
+helpper = "helper"
+indesies = "indices"
+lanbda = "lambda"
+opertation = "operation"
+opertator = "operator"
+pahse = "phase"
+parenthes = "parentheses"
+phese = "phase"
+refecence = "reference"
+refreneces = "references"
+releted = "related"
+requrie = "require"
+rexexp = "regexp"
+sthe = "the"
+whinch = "which"


### PR DESCRIPTION
Uudenvuoden kunniaksi tärkeä typokorjaus-pr!

Samalla typos-työkalu käyttöön CI:hin. Se siis ylläpitää [listaa](https://raw.githubusercontent.com/crate-ci/typos/master/crates/typos-dict/assets/words.csv) yleisistä typoista, jolloin false positiveja ei tule kovin paljon. Ja Rustilla tehty, niin on myös nopea.
