### PR TITLE
TIM login: refactor simple login to work like sign up

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -181,7 +181,10 @@ BOOKMARKS_ENABLED = True
 # If False, only admins can create folders and documents.
 ALLOW_CREATE_DOCUMENTS = True
 
+# When enabled, display sign up/account registration option in login dialog.
 EMAIL_REGISTRATION_ENABLED = True
+
+# When enabled, display Haka identity provider/federation service as a login option.
 HAKA_ENABLED = True
 
 # If False, resetting password is not allowed.

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -2734,44 +2734,12 @@
           <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3386853674104368310" datatype="html">
-        <source>Haka login</source>
-        <target state="translated">Haka-kirjautuminen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5946121121970393200" datatype="html">
         <source>Select your home organization...</source>
         <target state="translated">Valitse kotiorganisaatiosi...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
           <context context-type="linenumber">77</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2715185765061607307" datatype="html">
-        <source>
-                Log in
-            </source>
-        <target state="translated">
-                Kirjaudu sisään
-            </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">85</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4814606488888120626" datatype="html">
-        <source>
-                Members from universities and other Haka organizations, please use Haka to log in.
-            </source>
-        <target state="translated">
-                Yliopistojen ja muiden Haka-organisaatioiden jäsenet, kirjautukaa Hakalla.
-            </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7169763988476671054" datatype="html">
@@ -7840,6 +7808,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">240</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3657392489783075042" datatype="html">
+        <source>Haka login (Haka organizations and universities)</source>
+        <target state="translated">Haka login (Haka organisaatiot and yliopistot)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6576888153560947254" datatype="html">
+        <source> Log in with Haka </source>
+        <target state="translated"> Kirjaudu sisään Haka-tunnistautumisella </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2470527158706928323" datatype="html">

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -2774,18 +2774,6 @@
           <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2341982959296346504" datatype="html">
-        <source>
-                Others, please log in with your TIM account.
-            </source>
-        <target state="translated">
-                Muut, kirjautukaa TIM-tilillä.
-            </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">82</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="7169763988476671054" datatype="html">
         <source>Email or username</source>
         <target state="translated">Sähköpostiosoite tai käyttäjätunnus</target>
@@ -2852,14 +2840,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">137</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3023906871690155199" datatype="html">
-        <source> Not a <x id="INTERPOLATION" equiv-text="{{getHomeOrgDisplayName()}}"/> student or staff member and don't have a TIM account? </source>
-        <target state="translated"> Etkö ole <x id="INTERPOLATION" equiv-text="{{getHomeOrgDisplayName()}}"/>-opiskelija tai henkilökuntaa eikä sinulla ole TIM-tiliä? </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">147,149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7203320122205058413" datatype="html">
@@ -2952,18 +2932,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">214</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6962699013778688473" datatype="html">
-        <source>Continue</source>
-        <target state="translated">Jatka</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">132</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">220</context>
         </context-group>
       </trans-unit>
       <trans-unit id="834072654360023442" datatype="html">
@@ -7852,6 +7820,26 @@
         <context-group purpose="location">
           <context context-type="sourcefile">modules/cs/js/util/file-select.ts</context>
           <context context-type="linenumber">113,116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5894581303239667306" datatype="html">
+        <source> Email login </source>
+        <target state="translated"> Kirjaudu sisään sähköpostilla </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8743900787768000333" datatype="html">
+        <source>Continue </source>
+        <target state="translated">Jatka</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
+          <context context-type="linenumber">152</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
+          <context context-type="linenumber">240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2470527158706928323" datatype="html">

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -2726,14 +2726,6 @@
           <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8747125763308501031" datatype="html">
-        <source>Federation logo</source>
-        <target state="translated">Federaation logo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">66</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5946121121970393200" datatype="html">
         <source>Select your home organization...</source>
         <target state="translated">Valitse kotiorganisaatiosi...</target>
@@ -7800,7 +7792,7 @@
       </trans-unit>
       <trans-unit id="8743900787768000333" datatype="html">
         <source>Continue </source>
-        <target state="translated">Jatka</target>
+        <target state="translated">Jatka </target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">152</context>
@@ -7816,14 +7808,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
           <context context-type="linenumber">72</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6576888153560947254" datatype="html">
-        <source> Log in with Haka </source>
-        <target state="translated"> Kirjaudu sisään Haka-tunnistautumisella </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2470527158706928323" datatype="html">
@@ -7880,6 +7864,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/calendar/export-ical.component.ts</context>
           <context context-type="linenumber">19,20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5003932537689068654" datatype="html">
+        <source>Haka logo</source>
+        <target state="translated">Hakan logo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">67,68</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="498717790849733177" datatype="html">
+        <source>Log in via</source>
+        <target state="translated">Kirjaudu kohteella:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -4318,14 +4318,6 @@
           <context context-type="linenumber">74,76</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="2341982959296346504" datatype="html">
-        <source> Others, please log in with your TIM account. </source>
-        <target state="translated"> Övriga, vänligen logga in med ditt TIM-konto. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">81,83</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="7169763988476671054" datatype="html">
         <source>Email or username</source>
         <target state="translated">E-postadress eller användarnamn</target>
@@ -4386,18 +4378,6 @@
           <context context-type="linenumber">126</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6962699013778688473" datatype="html">
-        <source>Continue</source>
-        <target state="translated">Fortsätt</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">132</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">220</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="2336550011721758066" datatype="html">
         <source>Log in</source>
         <target state="translated">Logga in</target>
@@ -4412,14 +4392,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-menu.component.ts</context>
           <context context-type="linenumber">18</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3023906871690155199" datatype="html">
-        <source> Not a <x id="INTERPOLATION" equiv-text="{{getHomeOrgDisplayName()}}"/> student or staff member and don't have a TIM account? </source>
-        <target state="translated"> Inte ett student eller anställd av <x id="INTERPOLATION" equiv-text="{{getHomeOrgDisplayName()}}"/> och utan TIM konto? </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">147,149</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7203320122205058413" datatype="html">
@@ -7742,6 +7714,26 @@
         <context-group purpose="location">
           <context context-type="sourcefile">modules/cs/js/util/file-select.ts</context>
           <context context-type="linenumber">113,116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5894581303239667306" datatype="html">
+        <source> Email login </source>
+        <target state="translated"> Inloggning via e-post</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
+          <context context-type="linenumber">81</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8743900787768000333" datatype="html">
+        <source>Continue </source>
+        <target state="translated">Fortsätt </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
+          <context context-type="linenumber">152</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
+          <context context-type="linenumber">240</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2470527158706928323" datatype="html">

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -4262,14 +4262,6 @@
           <context context-type="linenumber">41,43</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8747125763308501031" datatype="html">
-        <source>Federation logo</source>
-        <target state="translated">Federation logo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">66</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5946121121970393200" datatype="html">
         <source>Select your home organization...</source>
         <target state="translated">Välj din hemorgansation...</target>
@@ -7694,7 +7686,7 @@
       </trans-unit>
       <trans-unit id="5894581303239667306" datatype="html">
         <source> Email login </source>
-        <target state="translated"> Inloggning via e-post</target>
+        <target state="translated"> Inloggning via e-post </target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">81</context>
@@ -7718,14 +7710,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
           <context context-type="linenumber">72</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6576888153560947254" datatype="html">
-        <source> Log in with Haka </source>
-        <target state="translated"> Logga in med Haka</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2470527158706928323" datatype="html">
@@ -7782,6 +7766,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/calendar/export-ical.component.ts</context>
           <context context-type="linenumber">19,20</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5003932537689068654" datatype="html">
+        <source>Haka logo</source>
+        <target state="translated">Hakas logo</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">67,68</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="498717790849733177" datatype="html">
+        <source>Log in via</source>
+        <target state="translated">Logga in via</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -4270,28 +4270,12 @@
           <context context-type="linenumber">66</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3386853674104368310" datatype="html">
-        <source>Haka login</source>
-        <target state="translated">Haka inloggning</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5946121121970393200" datatype="html">
         <source>Select your home organization...</source>
         <target state="translated">Välj din hemorgansation...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
           <context context-type="linenumber">77</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2715185765061607307" datatype="html">
-        <source> Log in </source>
-        <target state="translated"> Logga in </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
-          <context context-type="linenumber">84,86</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2826581353496868063" datatype="html">
@@ -4308,14 +4292,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/language-selector.component.ts</context>
           <context context-type="linenumber">15</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4814606488888120626" datatype="html">
-        <source> Members from universities and other Haka organizations, please use Haka to log in. </source>
-        <target state="translated"> Medlemmar från universitet och andra Haka-prganisationer, använd Haka för att logga in. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">74,76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7169763988476671054" datatype="html">
@@ -7734,6 +7710,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">240</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3657392489783075042" datatype="html">
+        <source>Haka login (Haka organizations and universities)</source>
+        <target state="translated">Haka login (organisationer och universitet)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6576888153560947254" datatype="html">
+        <source> Log in with Haka </source>
+        <target state="translated"> Logga in med Haka</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/haka-login.component.ts</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2470527158706928323" datatype="html">

--- a/timApp/static/scripts/tim/frontpage/front-page.component.ts
+++ b/timApp/static/scripts/tim/frontpage/front-page.component.ts
@@ -9,6 +9,8 @@ import {Users} from "tim/user/userService";
 import {genericglobals} from "tim/util/globals";
 import {$http} from "tim/util/ngimport";
 import {to, to2} from "tim/util/utils";
+import type {IVisibilityVars} from "tim/timRoot";
+import {getVisibilityVars} from "tim/timRoot";
 
 @Component({
     selector: "tim-start",
@@ -42,7 +44,7 @@ import {to, to2} from "tim/util/utils";
                 <button *ngIf="!isLoggedIn()" (click)="openLoginDialog(false)" type="button"
                         class="timButton margin-4" i18n>Log in
                 </button>
-                <button *ngIf="!isLoggedIn()" (click)="openLoginDialog(true)" type="button"
+                <button *ngIf="!isLoggedIn() && !hideVars.signup" (click)="openLoginDialog(true)" type="button"
                         class="timButton margin-4"
                         title="Create a TIM account"
                         i18n-title
@@ -112,6 +114,7 @@ export class FrontPageComponent implements IController {
     private docListOpen: boolean;
     bookmarks?: IBookmarkGroup[]; // For My courses.
     settings = genericglobals().userPrefs;
+    hideVars: IVisibilityVars = getVisibilityVars();
 
     constructor() {
         this.creatingNew = false;

--- a/timApp/static/scripts/tim/user/haka-login.component.scss
+++ b/timApp/static/scripts/tim/user/haka-login.component.scss
@@ -11,6 +11,11 @@
   }
 }
 
+.idp-selector {
+  margin-top: 10px;
+  row-gap: 0.5em;
+}
+
 .wrap-normal {
   white-space: normal;
   display: flex;

--- a/timApp/static/scripts/tim/user/haka-login.component.scss
+++ b/timApp/static/scripts/tim/user/haka-login.component.scss
@@ -18,4 +18,8 @@
   justify-content: center;
   max-width: 25em;
   margin: auto;
+
+  button {
+    white-space: normal;
+  }
 }

--- a/timApp/static/scripts/tim/user/haka-login.component.scss
+++ b/timApp/static/scripts/tim/user/haka-login.component.scss
@@ -1,0 +1,21 @@
+.haka-login-box {
+  background: #FFF;
+  border-radius: 4px;
+  border-color: #848484;
+  border-width: 1px;
+  padding: 10px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.32), 0 1px 3px 0 rgba(0, 0, 0, 0.37);
+
+  .haka-logo {
+    height: 1.8em;
+  }
+}
+
+.wrap-normal {
+  white-space: normal;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 25em;
+  margin: auto;
+}

--- a/timApp/static/scripts/tim/user/haka-login.component.ts
+++ b/timApp/static/scripts/tim/user/haka-login.component.ts
@@ -69,7 +69,7 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
             </a>
             <div class="form-group">
                 <label for="haka-select">
-                    <ng-container i18n>Haka login</ng-container>
+                    <ng-container i18n>Haka login (Haka organisations and universities)</ng-container>
                 </label>
                 <select class="form-control"
                         id="haka-select"
@@ -84,7 +84,7 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
                         type="button"
                         (click)="login()"
                         class="timButton" i18n>
-                    Log in
+                    Log in with Haka
                 </button>
             </div>
         </div>

--- a/timApp/static/scripts/tim/user/haka-login.component.ts
+++ b/timApp/static/scripts/tim/user/haka-login.component.ts
@@ -61,11 +61,11 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
 @Component({
     selector: "tim-haka-login",
     template: `
-        <div style="background:#F0F0F0;border-style: solid;border-color: #848484;border-width: 1px;padding: 10px;">
+        <div class="haka-login-box">
             <a href="https://wiki.eduuni.fi/display/CSCHAKA" target="_blank" class="pull-right">
                 <img src="https://haka.funet.fi/shibboleth/images/Haka_nega_tiivis_pieni.svg"
                      alt="Federation logo"
-                     i18n-alt>
+                     i18n-alt class="haka-logo">
             </a>
             <div class="form-group">
                 <label for="haka-select">
@@ -79,14 +79,17 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
                     <option *ngFor="let idp of idps" [ngValue]="idp">{{getName(idp)}}</option>
                 </select>
             </div>
-            <button [disabled]="!selectedIdp"
-                    type="button"
-                    (click)="login()"
-                    class="timButton" i18n>
-                Log in
-            </button>
+            <div class="wrap-normal">
+                <button [disabled]="!selectedIdp"
+                        type="button"
+                        (click)="login()"
+                        class="timButton" i18n>
+                    Log in
+                </button>
+            </div>
         </div>
     `,
+    styleUrls: ["./haka-login.component.scss"],
 })
 export class HakaLoginComponent implements OnChanges {
     selectedIdp?: IDiscoveryFeedEntry;

--- a/timApp/static/scripts/tim/user/haka-login.component.ts
+++ b/timApp/static/scripts/tim/user/haka-login.component.ts
@@ -69,7 +69,7 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
             </a>
             <div class="form-group">
                 <label for="haka-select">
-                    <ng-container i18n>Haka login (Haka organisations and universities)</ng-container>
+                    <ng-container i18n>Haka login (Haka organizations and universities)</ng-container>
                 </label>
                 <select class="form-control"
                         id="haka-select"

--- a/timApp/static/scripts/tim/user/haka-login.component.ts
+++ b/timApp/static/scripts/tim/user/haka-login.component.ts
@@ -64,7 +64,7 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
         <div class="haka-login-box">
             <a href="https://wiki.eduuni.fi/display/CSCHAKA" target="_blank" class="pull-right">
                 <img src="https://haka.funet.fi/shibboleth/images/Haka_nega_tiivis_pieni.svg"
-                     alt="Federation logo"
+                     alt="Haka logo"
                      i18n-alt class="haka-logo">
             </a>
             <div class="form-group">
@@ -74,6 +74,7 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
                 <select class="form-control"
                         id="haka-select"
                         style="margin-top: 6px"
+                        [disabled]="!idps || !idps.length"
                         [(ngModel)]="selectedIdp">
                     <option [ngValue]="undefined" disabled i18n>Select your home organization...</option>
                     <option *ngFor="let idp of idps" [ngValue]="idp">{{getName(idp)}}</option>
@@ -83,8 +84,8 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
                 <button [disabled]="!selectedIdp"
                         type="button"
                         (click)="login()"
-                        class="timButton" i18n>
-                    Log in with Haka
+                        class="timButton">
+                    <ng-container i18n>Log in via</ng-container> {{ selectedIdp ? getName(selectedIdp) : "Haka" }}
                 </button>
             </div>
         </div>

--- a/timApp/static/scripts/tim/user/haka-login.component.ts
+++ b/timApp/static/scripts/tim/user/haka-login.component.ts
@@ -71,21 +71,24 @@ function getDisplayNameForCurrLang(idp: IDiscoveryFeedEntry) {
                 <label for="haka-select">
                     <ng-container i18n>Haka login (Haka organizations and universities)</ng-container>
                 </label>
-                <select class="form-control"
-                        id="haka-select"
-                        style="margin-top: 6px"
-                        [disabled]="!idps || !idps.length"
-                        [(ngModel)]="selectedIdp">
-                    <option [ngValue]="undefined" disabled i18n>Select your home organization...</option>
-                    <option *ngFor="let idp of idps" [ngValue]="idp">{{getName(idp)}}</option>
-                </select>
+                <div class="flex cl align-center idp-selector">
+                    <select class="form-control"
+                            id="haka-select"
+                            [disabled]="!idps || !idps.length"
+                            [(ngModel)]="selectedIdp">
+                        <option [ngValue]="undefined" disabled i18n>Select your home organization...</option>
+                        <option *ngFor="let idp of idps" [ngValue]="idp">{{getName(idp)}}</option>
+                    </select>
+                    <tim-loading *ngIf="!idps || !idps.length"></tim-loading>
+                </div>
             </div>
             <div class="wrap-normal">
                 <button [disabled]="!selectedIdp"
                         type="button"
                         (click)="login()"
                         class="timButton">
-                    <ng-container i18n>Log in via</ng-container> {{ selectedIdp ? getName(selectedIdp) : "Haka" }}
+                    <ng-container i18n>Log in via</ng-container>
+                    {{ selectedIdp ? getName(selectedIdp) : "Haka" }}
                 </button>
             </div>
         </div>

--- a/timApp/static/scripts/tim/user/login-dialog.component.scss
+++ b/timApp/static/scripts/tim/user/login-dialog.component.scss
@@ -1,5 +1,5 @@
 .instructions {
-  font-size: 1.3em;
+  font-size: 1.1em;
 }
 
 .margin-left-1 {

--- a/timApp/static/scripts/tim/user/login-dialog.component.scss
+++ b/timApp/static/scripts/tim/user/login-dialog.component.scss
@@ -5,3 +5,18 @@
 .margin-left-1 {
   margin-left: 1em;
 }
+
+.login-flex-col {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 25em;
+  margin: auto;
+  row-gap: 0.5em;
+
+  .center-block {
+    white-space: normal;
+    margin-right: unset;
+    margin-left: unset;
+  }
+}

--- a/timApp/static/scripts/tim/user/login-dialog.component.scss
+++ b/timApp/static/scripts/tim/user/login-dialog.component.scss
@@ -5,7 +5,15 @@
 .margin-left-1 {
   margin-left: 1em;
 }
-
+.margin-right-1 {
+  margin-right: 1em;
+}
+.margin-top-1 {
+  margin-top: 1em;
+}
+.margin-bottom-1 {
+  margin-bottom: 1em;
+}
 
 .login-flex-col {
   display: flex;

--- a/timApp/static/scripts/tim/user/login-dialog.component.scss
+++ b/timApp/static/scripts/tim/user/login-dialog.component.scss
@@ -1,3 +1,7 @@
 .instructions {
   font-size: 1.3em;
 }
+
+.margin-left-1 {
+  margin-left: 1em;
+}

--- a/timApp/static/scripts/tim/user/login-dialog.component.scss
+++ b/timApp/static/scripts/tim/user/login-dialog.component.scss
@@ -6,6 +6,7 @@
   margin-left: 1em;
 }
 
+
 .login-flex-col {
   display: flex;
   flex-direction: column;
@@ -18,5 +19,9 @@
     white-space: normal;
     margin-right: unset;
     margin-left: unset;
+  }
+
+  button {
+    white-space: normal;
   }
 }

--- a/timApp/static/scripts/tim/user/login-dialog.component.scss
+++ b/timApp/static/scripts/tim/user/login-dialog.component.scss
@@ -1,0 +1,3 @@
+.instructions {
+  font-size: 1.3em;
+}

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -91,7 +91,7 @@ interface ISimpleRegistrationResponse {
                         </ng-container>
                         
 <!--                    Simple email login form-->
-                        <ng-container *ngIf="(showSimpleLogin || (hideVars.hakaLogin && hideVars.signup))">
+                        <ng-container *ngIf="showSimpleLogin">
                             <div class="form-group">
                                 <label for="email" class="control-label" i18n>Email or username</label>
                                 <input class="form-control"
@@ -150,13 +150,13 @@ interface ISimpleRegistrationResponse {
                                 <tim-loading *ngIf="signUpRequestInProgress"></tim-loading>
                             </div>
 
-                            <div class="flex"
+                            <div class="flex align-center"
                                  *ngIf="simpleLoginEmailGiven || !simpleEmailLogin">
                                 <button [disabled]="loggingIn || resetPassword" class="btn btn-primary" (click)="loginWithEmail()"
                                         i18n>Log in
                                 </button>
                                 <button *ngIf="showSimpleLogin" class="btn btn-default margin-left-1" [disabled]="resetPassword" (click)="cancelSimpleLogin()" i18n>Cancel</button>
-                                <tim-loading *ngIf="loggingIn"></tim-loading>
+                                <tim-loading class="margin-left-1" *ngIf="loggingIn"></tim-loading>
                             </div>
                             <tim-alert severity="danger" *ngIf="loginError">
                                 <tim-error-description [error]="loginError"></tim-error-description>
@@ -383,6 +383,8 @@ export class LoginDialogComponent extends AngularDialogComponent<
         (async () => {
             this.idps = await loadIdPs();
         })();
+
+        this.resetView();
     }
 
     ngAfterViewInit() {
@@ -544,6 +546,7 @@ export class LoginDialogComponent extends AngularDialogComponent<
 
     public forgotPassword() {
         this.resetPassword = true;
+        this.showSimpleLogin = false;
         this.beginSignup();
     }
 
@@ -552,6 +555,10 @@ export class LoginDialogComponent extends AngularDialogComponent<
      */
     public cancelSignup() {
         this.showSignup = false;
+        // If we were in "I forgot my password" in minimal view, just reset back to login
+        if (this.resetPassword && this.showMinimalLoginView) {
+            this.resetView();
+        }
         this.resetPassword = false;
     }
 
@@ -566,8 +573,24 @@ export class LoginDialogComponent extends AngularDialogComponent<
         }
     }
 
+    private get showMinimalLoginView() {
+        // Minimal view is used when all methods except email are disabled.
+        return this.hideVars.hakaLogin && this.hideVars.signup;
+    }
+
+    private resetView() {
+        this.showSignup = false;
+        this.resetPassword = false;
+        this.loginForm.email = "";
+        this.loginForm.password = "";
+        this.simpleLoginEmailGiven = false;
+        this.loginError = undefined;
+        this.showSimpleLogin = this.showMinimalLoginView;
+    }
+
     public cancelSimpleLogin() {
         this.showSimpleLogin = false;
+        this.resetView();
     }
 
     public beginSimpleLogin() {

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -152,10 +152,10 @@ interface ISimpleRegistrationResponse {
 
                             <div class="flex"
                                  *ngIf="simpleLoginEmailGiven || !simpleEmailLogin">
-                                <button [disabled]="loggingIn" class="btn btn-primary" (click)="loginWithEmail()"
+                                <button [disabled]="loggingIn || resetPassword" class="btn btn-primary" (click)="loginWithEmail()"
                                         i18n>Log in
                                 </button>
-                                <button class="btn btn-default margin-left-1" (click)="cancelSimpleLogin()" i18n>Cancel</button>
+                                <button class="btn btn-default margin-left-1" [disabled]="resetPassword" (click)="cancelSimpleLogin()" i18n>Cancel</button>
                                 <tim-loading *ngIf="loggingIn"></tim-loading>
                             </div>
                             <tim-alert severity="danger" *ngIf="loginError">

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -73,7 +73,7 @@ interface ISimpleRegistrationResponse {
                             <div class="login-flex-col">
                                 <ng-container *ngIf="!hideVars.emailLogin">
                                     
-                                    <button *ngIf="!showSimpleLogin" class="center-block timButton" type="button"
+                                    <button *ngIf="(!showSimpleLogin && (!hideVars.hakaLogin || !hideVars.signup))" class="center-block timButton" type="button"
                                             (click)="beginSimpleLogin()" i18n>
                                         Email login
                                     </button>
@@ -91,7 +91,7 @@ interface ISimpleRegistrationResponse {
                         </ng-container>
                         
 <!--                    Simple email login form-->
-                        <ng-container *ngIf="showSimpleLogin">
+                        <ng-container *ngIf="(showSimpleLogin || (hideVars.hakaLogin && hideVars.signup))">
                             <div class="form-group">
                                 <label for="email" class="control-label" i18n>Email or username</label>
                                 <input class="form-control"
@@ -155,7 +155,7 @@ interface ISimpleRegistrationResponse {
                                 <button [disabled]="loggingIn || resetPassword" class="btn btn-primary" (click)="loginWithEmail()"
                                         i18n>Log in
                                 </button>
-                                <button class="btn btn-default margin-left-1" [disabled]="resetPassword" (click)="cancelSimpleLogin()" i18n>Cancel</button>
+                                <button *ngIf="showSimpleLogin" class="btn btn-default margin-left-1" [disabled]="resetPassword" (click)="cancelSimpleLogin()" i18n>Cancel</button>
                                 <tim-loading *ngIf="loggingIn"></tim-loading>
                             </div>
                             <tim-alert severity="danger" *ngIf="loginError">

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -55,251 +55,275 @@ interface ISimpleRegistrationResponse {
 @Component({
     selector: "tim-login-dialog",
     template: `
-<tim-dialog-frame>
-    <ng-container header>
-        {{ getTitle() }}
-    </ng-container>
-    <ng-container body>
-<div class="row">
-    <div class="col-sm-12">
-    <ng-container *ngIf="!showSignup">
-        <ng-container *ngIf="!hideVars.hakaLogin">
-            <p class="text-center" i18n>
-                Members from universities and other Haka organizations, please use Haka to log in.
-            </p>
-            <tim-haka-login [idps]="idps"
-                    [homeOrg]="homeOrg"
-                    [addingUser]="addingToSession"></tim-haka-login>
-            <hr>
-            <p class="text-center" i18n>
-                Others, please log in with your TIM account.
-            </p>
-        </ng-container>
-
-        <ng-container *ngIf="!hideVars.emailLogin">
-        <div class="form-group">
-            <label for="email" class="control-label" i18n>Email or username</label>
-            <input class="form-control"
-                   id="email"
-                   [disabled]="simpleLoginEmailGiven"
-                   #loginEmail
-                   [(ngModel)]="loginForm.email"
-                   (keydown.enter)="handleEmailGiven()"
-                   autocomplete="username"
-                   type="text">
-        </div>
-
-            <ng-container *ngIf="simpleLoginEmailGiven">
-                <p>
-                    <ng-container *ngIf="useStudyInfoMessage; else normalHelpMsg" i18n>
-                        If you have not logged in before,
-                        and your email corresponds to the one in Studyinfo.fi,
-                        TIM sent a password to your email now.
-                        Please read the email in a separate browser tab,
-                        and please wait for the email at least 5 minutes
-                        if you don't get the email right away.
-                        Check your spam folder too.
-                    </ng-container>
-                    <ng-template #normalHelpMsg i18n>
-                        If you have not logged in to TIM before, TIM sent a password to your email now.
-                    </ng-template>
-                </p>
-                <p i18n>If you have logged in before, use your current password.</p>
+        <tim-dialog-frame>
+            <ng-container header>
+                {{ getTitle() }}
             </ng-container>
+            <ng-container body>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <ng-container *ngIf="!showSignup && !showSimpleLogin">
+                            <ng-container *ngIf="!hideVars.hakaLogin">
+                                <p class="text-center instructions" i18n>
+                                    Members from universities and other Haka organizations, please use Haka to log in.
+                                </p>
+                                <tim-haka-login [idps]="idps"
+                                                [homeOrg]="homeOrg"
+                                                [addingUser]="addingToSession"></tim-haka-login>
+                                <hr>
+                            </ng-container>
 
-        <div class="form-group" [hidden]="simpleEmailLogin && !simpleLoginEmailGiven">
-            <label for="password" class="control-label" i18n>Password</label>
-            <input class="form-control"
-                   id="password"
-                   #pw
-                   [(ngModel)]="loginForm.password"
-                   (keydown.enter)="loginWithEmail()"
-                   focusMe
-                   [enable]="focusPassword"
-                   autocomplete="current-password"
-                   type="password">
-            <p *ngIf="!hideVars.passwordRecovery" class="text-smaller"><a href="#" (click)="forgotPassword()" i18n>I forgot my password</a></p>
-        </div>
+                            <div class="flex">
+                                <ng-container *ngIf="!hideVars.emailLogin">
+                                    
+                                    <button *ngIf="!showSimpleLogin" class="center-block timButton" type="button"
+                                            (click)="beginSimpleLogin()" i18n>
+                                        Email login
+                                    </button>
+                                    
+                                </ng-container>
 
-            <div class="flex cl align-center" *ngIf="simpleEmailLogin && !simpleLoginEmailGiven">
-                <button [disabled]="!loginForm.email || signUpRequestInProgress"
-                        class="timButton"
-                        (click)="handleEmailGiven()" i18n>Continue</button>
-                <tim-loading *ngIf="signUpRequestInProgress"></tim-loading>
-            </div>
+                                <ng-container *ngIf="!hideVars.signup">
+                                    <button *ngIf="!showSignup" class="center-block timButton" type="button"
+                                            (click)="beginSignup()" i18n>
+                                        Sign up
+                                    </button>
+                                </ng-container>
+                            </div>
+                            
+                        </ng-container>
+                        
+<!--                    Simple email login form-->
+                        <ng-container *ngIf="showSimpleLogin">
+                            <div class="form-group">
+                                <label for="email" class="control-label" i18n>Email or username</label>
+                                <input class="form-control"
+                                       id="email"
+                                       [disabled]="simpleLoginEmailGiven"
+                                       #loginEmail
+                                       [(ngModel)]="loginForm.email"
+                                       (keydown.enter)="handleEmailGiven()"
+                                       autocomplete="username"
+                                       type="text">
+                            </div>
 
-        <div class="flex cl align-center" *ngIf="simpleLoginEmailGiven || !simpleEmailLogin">
-            <button [disabled]="loggingIn" class="timButton" (click)="loginWithEmail()" i18n>Log in</button>
-            <tim-loading *ngIf="loggingIn"></tim-loading>
-        </div>
-        <tim-alert severity="danger" *ngIf="loginError">
-            <tim-error-description [error]="loginError"></tim-error-description>
-        </tim-alert>
-        </ng-container>
+                            <ng-container *ngIf="simpleLoginEmailGiven">
+                                <p>
+                                    <ng-container *ngIf="useStudyInfoMessage; else normalHelpMsg" i18n>
+                                        If you have not logged in before,
+                                        and your email corresponds to the one in Studyinfo.fi,
+                                        TIM sent a password to your email now.
+                                        Please read the email in a separate browser tab,
+                                        and please wait for the email at least 5 minutes
+                                        if you don't get the email right away.
+                                        Check your spam folder too.
+                                    </ng-container>
+                                    <ng-template #normalHelpMsg i18n>
+                                        If you have not logged in to TIM before, TIM sent a password to your
+                                        email
+                                        now.
+                                    </ng-template>
+                                </p>
+                                <p i18n>If you have logged in before, use your current password.</p>
+                            </ng-container>
 
-        <ng-container *ngIf="!hideVars.signup">
-            <hr>
-            <p class="text-center" *ngIf="!showSignup" i18n>
-                Not a {{getHomeOrgDisplayName()}} student or staff member and don't have a TIM account?
-            </p>
-            <button *ngIf="!showSignup" class="center-block timButton" type="button"
-                (click)="beginSignup()" i18n>
-                Sign up
-            </button>
-        </ng-container>
-    </ng-container>
+                            <div class="form-group" [hidden]="simpleEmailLogin && !simpleLoginEmailGiven">
+                                <label for="password" class="control-label" i18n>Password</label>
+                                <input class="form-control"
+                                       id="password"
+                                       #pw
+                                       [(ngModel)]="loginForm.password"
+                                       (keydown.enter)="loginWithEmail()"
+                                       focusMe
+                                       [enable]="focusPassword"
+                                       autocomplete="current-password"
+                                       type="password">
+                                <p *ngIf="!hideVars.passwordRecovery" class="text-smaller"><a href="#"
+                                                                                              (click)="forgotPassword()"
+                                                                                              i18n>I forgot
+                                    my password</a></p>
+                            </div>
 
-    <form class="form" *ngIf="showSignup">
-        <div class="text-center" *ngIf="!resetPassword">
-            <p i18n>If you don't have an existing TIM or {{getHomeOrgDisplayName()}} account, you can create a TIM account here.</p>
-            <p i18n>Please input your email address to receive a temporary password.</p>
-        </div>
-        <p class="text-center" *ngIf="resetPassword && !emailSent" i18n>
-            To reset password, enter your email or username first.
-        </p>
-        <div class="form-group">
-            <label for="email-signup" class="control-label" i18n>Email or username</label>
-            <input class="form-control"
-                   id="email-signup"
-                   focusMe
-                   [(ngModel)]="email"
-                   [disabled]="emailSent"
-                   (keydown.enter)="provideEmail()"
-                   name="email"
-                   required
-                   i18n-placeholder
-                   autocomplete="username"
-                   placeholder="Email or username"
-                   type="text"/>
-            <label [ngStyle]="urlStyle" for="url" class="control-label" i18n>Do not type anything here</label>
-            <input class="form-control"
-                   [ngStyle]="urlStyle"
-                   tabindex="-1"
-                   id="url"
-                   [(ngModel)]="url"
-                   [disabled]="emailSent"
-                   name="url"
-                   i18n-placeholder
-                   placeholder="Do not type anything here"
-                   type="text"/>
-        </div>
-        <button (click)="provideEmail()"
-                [disabled]="!email"
-                *ngIf="!emailSent"
-                class="timButton" i18n>
-            Continue
-        </button>
-        <button (click)="cancelSignup()"
-                *ngIf="!emailSent"
-                class="btn btn-default" i18n>
-            Cancel
-        </button>
-        <div *ngIf="emailSent">
-            <div class="form-group" *ngIf="!tempPasswordProvided">
-                <label for="one-time-code-signup" class="control-label" i18n>
-                    TIM sent you a temporary password. Please check your email and type the password below to continue.
-                </label>
-                <input class="form-control"
-                       id="one-time-code-signup"
-                       focusMe
-                       [(ngModel)]="tempPassword"
-                       (keydown.enter)="provideTempPassword()"
-                       name="oneTimeCode"
-                       required
-                       i18n-placeholder
-                       placeholder="Password you received"
-                       autocomplete="one-time-code"
-                       type="password"/>
-            </div>
-            <button (click)="provideTempPassword()"
-                    [disabled]="!tempPassword"
-                    *ngIf="!tempPasswordProvided"
-                    class="center-block timButton" i18n>Continue</button>
-            <div *ngIf="tempPasswordProvided">
-                <div class="form-group">
-                    <label for="name-signup" class="control-label" i18n>
-                        Enter your name (Lastname Firstname)
-                    </label>
-                    <input class="form-control"
-                           id="name-signup"
-                           focusMe
-                           [(ngModel)]="name"
-                           [disabled]="nameProvided || !canChangeName"
-                           (keydown.enter)="newpw.focus()"
-                           name="name"
-                           required
-                           i18n-placeholder
-                           autocomplete="name"
-                           placeholder="Your name"
-                           type="text"/>
-                </div>
-                <div class="form-group">
-                    <label for="newpassword-signup" class="control-label" i18n>
-                        Create a new password (at least {{ minPasswordLength }} characters)
-                    </label>
-                    <input class="form-control"
-                           id="newpassword-signup"
-                           #newpw
-                           [(ngModel)]="newPassword"
-                           [disabled]="nameProvided"
-                           (keydown.enter)="repw.focus()"
-                           name="newPassword"
-                           required
-                           i18n-placeholder
-                           placeholder="Password"
-                           autocomplete="new-password"
-                           type="password"/>
-                </div>
-                <div class="form-group">
-                    <label for="repassword-signup" class="control-label" i18n>
-                        Retype the above password
-                    </label>
-                    <input class="form-control"
-                           id="repassword-signup"
-                           #repw
-                           [(ngModel)]="rePassword"
-                           [disabled]="nameProvided"
-                           (keydown.enter)="provideName()"
-                           name="rePassword"
-                           required
-                           i18n-placeholder
-                           autocomplete="new-password"
-                           placeholder="Retype password"
-                           type="password"/>
-                </div>
-                <button (click)="provideName()"
-                        [disabled]="!name"
-                        *ngIf="!nameProvided"
-                        class="center-block timButton" i18n>Finish
-                </button>
-            </div>
-            <span *ngIf="finishStatus === 'registered'" i18n>
+                            <div class="flex cl align-center"
+                                 *ngIf="simpleEmailLogin && !simpleLoginEmailGiven">
+                                <button [disabled]="!loginForm.email || signUpRequestInProgress"
+                                        class="timButton"
+                                        (click)="handleEmailGiven()" i18n>Continue
+                                </button>
+                                <tim-loading *ngIf="signUpRequestInProgress"></tim-loading>
+                            </div>
+
+                            <div class="flex"
+                                 *ngIf="simpleLoginEmailGiven || !simpleEmailLogin">
+                                <button [disabled]="loggingIn" class="timButton" (click)="loginWithEmail()"
+                                        i18n>Log in
+                                </button>
+                                <button class="timButton margin-left-1" (click)="cancelSimpleLogin()" i18n>Cancel</button>
+                                <tim-loading *ngIf="loggingIn"></tim-loading>
+                            </div>
+                            <tim-alert severity="danger" *ngIf="loginError">
+                                <tim-error-description [error]="loginError"></tim-error-description>
+                            </tim-alert>
+
+                        </ng-container>
+                        
+<!--                    Sign up form-->
+                        <form class="form" *ngIf="showSignup">
+                            <div class="text-center" *ngIf="!resetPassword">
+                                <p i18n>If you don't have an existing TIM or {{getHomeOrgDisplayName()}} account, you
+                                    can create a TIM account here.</p>
+                                <p i18n>Please input your email address to receive a temporary password.</p>
+                            </div>
+                            <p class="text-center" *ngIf="resetPassword && !emailSent" i18n>
+                                To reset password, enter your email or username first.
+                            </p>
+                            <div class="form-group">
+                                <label for="email-signup" class="control-label" i18n>Email or username</label>
+                                <input class="form-control"
+                                       id="email-signup"
+                                       focusMe
+                                       [(ngModel)]="email"
+                                       [disabled]="emailSent"
+                                       (keydown.enter)="provideEmail()"
+                                       name="email"
+                                       required
+                                       i18n-placeholder
+                                       autocomplete="username"
+                                       placeholder="Email or username"
+                                       type="text"/>
+                                <label [ngStyle]="urlStyle" for="url" class="control-label" i18n>Do not type anything
+                                    here</label>
+                                <input class="form-control"
+                                       [ngStyle]="urlStyle"
+                                       tabindex="-1"
+                                       id="url"
+                                       [(ngModel)]="url"
+                                       [disabled]="emailSent"
+                                       name="url"
+                                       i18n-placeholder
+                                       placeholder="Do not type anything here"
+                                       type="text"/>
+                            </div>
+                            <button (click)="provideEmail()"
+                                    [disabled]="!email"
+                                    *ngIf="!emailSent"
+                                    class="timButton" i18n>
+                                Continue
+                            </button>
+                            <button (click)="cancelSignup()"
+                                    *ngIf="!emailSent"
+                                    class="btn btn-default margin-left-1" i18n>
+                                Cancel
+                            </button>
+                            <div *ngIf="emailSent">
+                                <div class="form-group" *ngIf="!tempPasswordProvided">
+                                    <label for="one-time-code-signup" class="control-label" i18n>
+                                        TIM sent you a temporary password. Please check your email and type the password
+                                        below to continue.
+                                    </label>
+                                    <input class="form-control"
+                                           id="one-time-code-signup"
+                                           focusMe
+                                           [(ngModel)]="tempPassword"
+                                           (keydown.enter)="provideTempPassword()"
+                                           name="oneTimeCode"
+                                           required
+                                           i18n-placeholder
+                                           placeholder="Password you received"
+                                           autocomplete="one-time-code"
+                                           type="password"/>
+                                </div>
+                                <button (click)="provideTempPassword()"
+                                        [disabled]="!tempPassword"
+                                        *ngIf="!tempPasswordProvided"
+                                        class="center-block timButton" i18n>Continue
+                                </button>
+                                <div *ngIf="tempPasswordProvided">
+                                    <div class="form-group">
+                                        <label for="name-signup" class="control-label" i18n>
+                                            Enter your name (Lastname Firstname)
+                                        </label>
+                                        <input class="form-control"
+                                               id="name-signup"
+                                               focusMe
+                                               [(ngModel)]="name"
+                                               [disabled]="nameProvided || !canChangeName"
+                                               (keydown.enter)="newpw.focus()"
+                                               name="name"
+                                               required
+                                               i18n-placeholder
+                                               autocomplete="name"
+                                               placeholder="Your name"
+                                               type="text"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="newpassword-signup" class="control-label" i18n>
+                                            Create a new password (at least {{ minPasswordLength }} characters)
+                                        </label>
+                                        <input class="form-control"
+                                               id="newpassword-signup"
+                                               #newpw
+                                               [(ngModel)]="newPassword"
+                                               [disabled]="nameProvided"
+                                               (keydown.enter)="repw.focus()"
+                                               name="newPassword"
+                                               required
+                                               i18n-placeholder
+                                               placeholder="Password"
+                                               autocomplete="new-password"
+                                               type="password"/>
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="repassword-signup" class="control-label" i18n>
+                                            Retype the above password
+                                        </label>
+                                        <input class="form-control"
+                                               id="repassword-signup"
+                                               #repw
+                                               [(ngModel)]="rePassword"
+                                               [disabled]="nameProvided"
+                                               (keydown.enter)="provideName()"
+                                               name="rePassword"
+                                               required
+                                               i18n-placeholder
+                                               autocomplete="new-password"
+                                               placeholder="Retype password"
+                                               type="password"/>
+                                    </div>
+                                    <button (click)="provideName()"
+                                            [disabled]="!name"
+                                            *ngIf="!nameProvided"
+                                            class="center-block timButton" i18n>Finish
+                                    </button>
+                                </div>
+                                <span *ngIf="finishStatus === 'registered'" i18n>
                 Thank you!
             </span>
-            <span *ngIf="finishStatus === 'updated'" i18n>
+                                <span *ngIf="finishStatus === 'updated'" i18n>
                 Your information was updated successfully.
             </span>
-            <span *ngIf="finishStatus" i18n>
+                                <span *ngIf="finishStatus" i18n>
                 Now you can
                 <a href="" focusMe>refresh</a>
                 the page to log in.
             </span>
-        </div>
-        <div class="flex justify-center">
-            <tim-loading *ngIf="signUpRequestInProgress"></tim-loading>
-        </div>
-        <tim-alert severity="danger" *ngIf="signUpError">
-            <tim-error-description [error]="signUpError"></tim-error-description>
-        </tim-alert>
-    </form>
-    </div>
-</div>
-    </ng-container>
-    <ng-container footer>
-        <button class="timButton" (click)="dismiss()" i18n>Close</button>
-    </ng-container>
-</tim-dialog-frame>
+                            </div>
+                            <div class="flex justify-center">
+                                <tim-loading *ngIf="signUpRequestInProgress"></tim-loading>
+                            </div>
+                            <tim-alert severity="danger" *ngIf="signUpError">
+                                <tim-error-description [error]="signUpError"></tim-error-description>
+                            </tim-alert>
+                        </form>
+                    </div>
+                </div>
+            </ng-container>
+            <ng-container footer>
+                <button class="timButton" (click)="dismiss()" i18n>Close</button>
+            </ng-container>
+        </tim-dialog-frame>
     `,
+    styleUrls: ["./login-dialog.component.scss"],
 })
 export class LoginDialogComponent extends AngularDialogComponent<
     ILoginParams,
@@ -307,6 +331,7 @@ export class LoginDialogComponent extends AngularDialogComponent<
 > {
     hideVars: IVisibilityVars = getVisibilityVars();
     showSignup?: boolean; // Show sign up form instead of log in.
+    showSimpleLogin?: boolean; // Show simple email log in
     loginForm = {email: "", password: ""};
     addingToSession = false;
 
@@ -546,6 +571,14 @@ export class LoginDialogComponent extends AngularDialogComponent<
         if (this.loginForm.email) {
             this.email = this.loginForm.email;
         }
+    }
+
+    public cancelSimpleLogin() {
+        this.showSimpleLogin = false;
+    }
+
+    public beginSimpleLogin() {
+        this.showSimpleLogin = true;
     }
 
     private async sendRequest<T>(url: string, data: JsonValue): ToReturn<T> {

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -363,7 +363,6 @@ export class LoginDialogComponent extends AngularDialogComponent<
     protected extraVerticalSize = 0;
     loggingIn = false;
 
-    // @ViewChild("loginEmail") private loginField!: ElementRef<HTMLInputElement>;
     @ViewChild("pw") private passwordField!: ElementRef<HTMLInputElement>;
     simpleEmailLogin = this.config.simpleEmailLogin;
     simpleLoginEmailGiven = false;
@@ -391,9 +390,6 @@ export class LoginDialogComponent extends AngularDialogComponent<
 
     ngAfterViewInit() {
         super.ngAfterViewInit();
-        // if (this.hideVars.hakaLogin) {
-        //     this.loginField.nativeElement.focus();
-        // }
     }
 
     getHomeOrgDisplayName() {

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -73,7 +73,7 @@ interface ISimpleRegistrationResponse {
                                 <hr>
                             </ng-container>
 
-                            <div class="flex">
+                            <div class="login-flex-col">
                                 <ng-container *ngIf="!hideVars.emailLogin">
                                     
                                     <button *ngIf="!showSimpleLogin" class="center-block timButton" type="button"

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -316,7 +316,7 @@ interface ISimpleRegistrationResponse {
                 </div>
             </ng-container>
             <ng-container footer>
-                <button class="timButton" (click)="dismiss()" i18n>Close</button>
+                <button class="btn btn-default" (click)="dismiss()" i18n>Close</button>
             </ng-container>
         </tim-dialog-frame>
     `,

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -165,7 +165,7 @@ interface ISimpleRegistrationResponse {
                         </ng-container>
                         
 <!--                    Sign up form-->
-                        <form class="form" *ngIf="showSignup">
+                        <form class="form margin-top-1" *ngIf="showSignup">
                             <div class="text-center" *ngIf="!resetPassword">
                                 <p i18n>If you don't have an existing TIM or {{getHomeOrgDisplayName()}} account, you
                                     can create a TIM account here.</p>
@@ -305,7 +305,7 @@ interface ISimpleRegistrationResponse {
                 the page to log in.
             </span>
                             </div>
-                            <div class="flex justify-center">
+                            <div class="flex justify-center margin-bottom-1">
                                 <tim-loading *ngIf="signUpRequestInProgress"></tim-loading>
                             </div>
                             <tim-alert severity="danger" *ngIf="signUpError">

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -363,7 +363,7 @@ export class LoginDialogComponent extends AngularDialogComponent<
     protected extraVerticalSize = 0;
     loggingIn = false;
 
-    @ViewChild("loginEmail") private loginField!: ElementRef<HTMLInputElement>;
+    // @ViewChild("loginEmail") private loginField!: ElementRef<HTMLInputElement>;
     @ViewChild("pw") private passwordField!: ElementRef<HTMLInputElement>;
     simpleEmailLogin = this.config.simpleEmailLogin;
     simpleLoginEmailGiven = false;
@@ -391,9 +391,9 @@ export class LoginDialogComponent extends AngularDialogComponent<
 
     ngAfterViewInit() {
         super.ngAfterViewInit();
-        if (this.hideVars.hakaLogin) {
-            this.loginField.nativeElement.focus();
-        }
+        // if (this.hideVars.hakaLogin) {
+        //     this.loginField.nativeElement.focus();
+        // }
     }
 
     getHomeOrgDisplayName() {

--- a/timApp/static/scripts/tim/user/login-dialog.component.ts
+++ b/timApp/static/scripts/tim/user/login-dialog.component.ts
@@ -64,9 +64,6 @@ interface ISimpleRegistrationResponse {
                     <div class="col-sm-12">
                         <ng-container *ngIf="!showSignup && !showSimpleLogin">
                             <ng-container *ngIf="!hideVars.hakaLogin">
-                                <p class="text-center instructions" i18n>
-                                    Members from universities and other Haka organizations, please use Haka to log in.
-                                </p>
                                 <tim-haka-login [idps]="idps"
                                                 [homeOrg]="homeOrg"
                                                 [addingUser]="addingToSession"></tim-haka-login>
@@ -155,10 +152,10 @@ interface ISimpleRegistrationResponse {
 
                             <div class="flex"
                                  *ngIf="simpleLoginEmailGiven || !simpleEmailLogin">
-                                <button [disabled]="loggingIn" class="timButton" (click)="loginWithEmail()"
+                                <button [disabled]="loggingIn" class="btn btn-primary" (click)="loginWithEmail()"
                                         i18n>Log in
                                 </button>
-                                <button class="timButton margin-left-1" (click)="cancelSimpleLogin()" i18n>Cancel</button>
+                                <button class="btn btn-default margin-left-1" (click)="cancelSimpleLogin()" i18n>Cancel</button>
                                 <tim-loading *ngIf="loggingIn"></tim-loading>
                             </div>
                             <tim-alert severity="danger" *ngIf="loginError">

--- a/timApp/tests/browser/browsertest.py
+++ b/timApp/tests/browser/browsertest.py
@@ -88,7 +88,7 @@ class BrowserTest(TimLiveServer, TimRouteTest):
         elem.find_element(By.XPATH, "//input[@type='text']").send_keys(email)
         elem.find_element(By.XPATH, "//input[@type='password']").send_keys(password)
         login = elem.find_element(
-            By.CSS_SELECTOR, ".flex > .timButton:first-child"
+            By.CSS_SELECTOR, ".flex > button:first-child"
         )  # Log in button
         login.click()
         self.wait.until(

--- a/timApp/tests/browser/browsertest.py
+++ b/timApp/tests/browser/browsertest.py
@@ -81,10 +81,14 @@ class BrowserTest(TimLiveServer, TimRouteTest):
         elem = self.drv.find_element(By.XPATH, "//tim-login-menu/button")
         elem.click()
         elem = self.find_element("tim-login-dialog")
+        email_login_btn = elem.find_element(
+            By.CSS_SELECTOR, ".login-flex-col button:first-child"
+        )
+        email_login_btn.click()
         elem.find_element(By.XPATH, "//input[@type='text']").send_keys(email)
         elem.find_element(By.XPATH, "//input[@type='password']").send_keys(password)
         login = elem.find_element(
-            By.CSS_SELECTOR, ".flex.cl.align-center > .timButton"
+            By.CSS_SELECTOR, ".flex > .timButton:first-child"
         )  # Log in button
         login.click()
         self.wait.until(


### PR DESCRIPTION
Closes #3266 

Refactors the UI of TIM login so that the simple username/email login is hidden by default, and works exactly like the 'sign up' procedure.

Todo:
- [x] Fix/update tests
- [x] Update translations