### PR TITLE
Add groups docsetting, handle group as element of groups

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -1032,8 +1032,8 @@ def flatten_points_result(
     return result_list
 
 
-def add_missing_users_from_group(result: list, usergroup: UserGroup) -> list:
-    users = set(usergroup.users)
+def add_missing_users_from_groups(result: list, usergroups: list[UserGroup]) -> list:
+    users = set(u for ug in usergroups for u in ug.users)
     existing_users = set()
     for d in result:
         existing_users.add(d["user"])

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2082,7 +2082,7 @@ def get_task_users(task_id: str) -> Response:
             raise AccessDenied()
         users = list(r.reviewable for r in reviews if r.task_name == tid.task_name)
     else:
-        usergroup = request.args.get("group")
+        usergroups = request.args.getlist("groups")
         q = (
             User.query.options(lazyload(User.groups))
             .join(Answer, User.answers)
@@ -2090,8 +2090,8 @@ def get_task_users(task_id: str) -> Response:
             .order_by(User.real_name.asc())
             .distinct()
         )
-        if usergroup is not None:
-            q = q.join(UserGroup, User.groups).filter(UserGroup.name.in_([usergroup]))
+        if usergroups:
+            q = q.join(UserGroup, User.groups).filter(UserGroup.name.in_(usergroups))
         users = q.all()
     if hide_names_in_teacher(d):
         model_u = User.get_model_answer_user()

--- a/timApp/document/course/validate.py
+++ b/timApp/document/course/validate.py
@@ -23,32 +23,43 @@ def verify_valid_course(path: str) -> UserGroup:
     if is_course(d):
         if not s.course_allow_manual_enroll():
             raise CourseException("Course does not allow manual enrollment.")
-        doc_group = s.group()
-        if isinstance(doc_group, str):
-            ug = UserGroup.get_by_name(doc_group)
-            if not ug:
+        doc_groups = s.groups()
+        if doc_groups:
+            if not isinstance(doc_groups, list):
+                raise CourseException(f"Invalid groups setting: ({doc_groups}).")
+            if len(doc_groups) != 1:
                 raise CourseException(
-                    f'The specified course group "{doc_group}" does not exist.'
+                    f"Multiple course groups found ({doc_groups}). Please specify only one course group"
                 )
-            group_tags = [
-                t.get_group_name() for t in d.block.tags if t.get_group_name()
-            ]
-            if doc_group not in group_tags:
-                raise CourseException("Document group setting not found in tags.")
-            owners = d.owners
-            if not owners:
-                raise CourseException("Document does not have owners.")
-            if not all(
-                verify_group_edit_access(ug, u, require=False)
-                for owner in owners
-                for u in owner.users
-            ):
-                raise CourseException(
-                    f'Some of the document owners does not have edit access to the course group "{doc_group}".'
-                )
-            return ug
-        elif doc_group:
-            raise CourseException(f"Invalid group setting: {doc_group}")
+            else:
+                doc_group = doc_groups[0]
+                if isinstance(doc_group, str):
+                    ug = UserGroup.get_by_name(doc_group)
+                    if not ug:
+                        raise CourseException(
+                            f'The specified course group "{doc_group}" does not exist.'
+                        )
+                    group_tags = [
+                        t.get_group_name() for t in d.block.tags if t.get_group_name()
+                    ]
+                    if doc_group not in group_tags:
+                        raise CourseException(
+                            "Document group setting not found in tags."
+                        )
+                    owners = d.owners
+                    if not owners:
+                        raise CourseException("Document does not have owners.")
+                    if not all(
+                        verify_group_edit_access(ug, u, require=False)
+                        for owner in owners
+                        for u in owner.users
+                    ):
+                        raise CourseException(
+                            f'Some of the document owners does not have edit access to the course group "{doc_group}".'
+                        )
+                    return ug
+                else:
+                    raise CourseException(f"Invalid group setting: {doc_group}")
         else:
             raise CourseException("Document does not have associated course group")
     else:

--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -150,6 +150,7 @@ class DocSettings:
     course_allow_manual_enroll_key = "course_allow_manual_enroll"
     show_velps_key = "show_velps"
     group_key = "group"
+    groups_key = "groups"
     allow_self_confirm_from_key = "allow_self_confirm_from"
     auto_confirm_key = "auto_confirm"
     expire_next_doc_message_key = "expire_next_doc_message"
@@ -287,11 +288,18 @@ class DocSettings:
         res = self.__dict.get(self.show_velps_key, True)
         return res
 
-    def group(self) -> str | None:
-        res = self.__dict.get(self.group_key, None)
-        if res is not None and not isinstance(res, str):
-            raise ValueError(f"group must be str, not {type(res)}")
-        return res
+    def groups(self) -> list[str] | None:
+        g = self.__dict.get(self.group_key, None)
+        if g is not None and not isinstance(g, str):
+            raise ValueError(f"The setting 'group' must be a string, not {type(g)}")
+        res = self.__dict.get(self.groups_key, None)
+        if res is None:
+            return [g] if g else None
+        if not (isinstance(res, list) and all(isinstance(e, str) for e in res)):
+            raise ValueError(f"The setting 'groups' must be a list of strings")
+        elif g:
+            return list(set([g] + res))
+        return list(set(res))
 
     def auto_number_start(self) -> dict[int, int]:
         result = {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0}

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -6448,14 +6448,6 @@
           <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8301861427771997270" datatype="html">
-        <source>Document group (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</source>
-        <target state="translated">Dokumenttiryhmä (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">66</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="1097032444998081907" datatype="html">
         <source>Refresh page</source>
         <target state="translated">Virkistä sivu</target>
@@ -7884,6 +7876,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">modules/cs/js/util/file-select.ts</context>
           <context context-type="linenumber">113,116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2470527158706928323" datatype="html">
+        <source>Document groups (<x id="INTERPOLATION" equiv-text="{{ activeGroups }}"/>)</source>
+        <target state="translated">Dokumentin ryhmät (<x id="INTERPOLATION" equiv-text="{{ activeGroups }}"/>)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">66,67</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -6338,14 +6338,6 @@
           <context context-type="linenumber">62</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8301861427771997270" datatype="html">
-        <source>Document group (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</source>
-        <target state="translated">Dokumentgrupp (<x id="INTERPOLATION" equiv-text="{{ activeGroup }}"/>)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">66</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="1097032444998081907" datatype="html">
         <source>Refresh page</source>
         <target state="translated">Uppdatera sidan</target>
@@ -7774,6 +7766,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">modules/cs/js/util/file-select.ts</context>
           <context context-type="linenumber">113,116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2470527158706928323" datatype="html">
+        <source>Document groups (<x id="INTERPOLATION" equiv-text="{{ activeGroups }}"/>)</source>
+        <target state="translated">Dokumentgrupper (<x id="INTERPOLATION" equiv-text="{{ activeGroups }}"/>)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">66,67</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/peerreview/util/groups.py
+++ b/timApp/peerreview/util/groups.py
@@ -25,14 +25,14 @@ def generate_review_groups(doc: DocInfo, tasks: list[Plugin]) -> None:
         if task.task_id:
             task_ids.append(task.task_id)
 
-    user_group = settings.group()
+    user_groups = settings.groups()
     user_ids = None
-    if user_group:
+    if user_groups:
         user_ids = [
             uid
             for uid, in (
                 UserGroupMember.query.join(UserGroup, UserGroupMember.group)
-                .filter(membership_current & (UserGroup.name == user_group))
+                .filter(membership_current & (UserGroup.name.in_(user_groups)))
                 .with_entities(UserGroupMember.user_id)
                 .all()
             )

--- a/timApp/sisu/sisu.py
+++ b/timApp/sisu/sisu.py
@@ -728,14 +728,14 @@ def get_sisu_assessments(
     doc_settings = doc.document.get_settings()
     if groups is None:
         try:
-            groupsetting = doc_settings.group()
+            groups_setting = doc_settings.groups()
         except ValueError as e:
             raise IncorrectSettings(str(e)) from e
-        if not groupsetting:
+        if not groups_setting:
             raise IncorrectSettings(
                 'The document must have "group" setting that indicates the student group name.'
             )
-        usergroups = [groupsetting]
+        usergroups = groups_setting
     else:
         usergroups = groups
     ugs = UserGroup.query.filter(UserGroup.name.in_(usergroups)).all()

--- a/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
+++ b/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
@@ -29,7 +29,7 @@ const AnswersDialogOptions = t.intersection([
         consent: t.string,
         format: t.keyof({text: null, json: null}),
         salt: maybeUndefined(t.string),
-        group: maybeUndefined(t.string),
+        groups: maybeUndefined(t.array(t.string)),
     }),
     CommonDialogOptions,
 ]);
@@ -52,18 +52,18 @@ export interface IAllAnswersParams {
             </ng-container>
             <ng-container body>
                 <form class="form-horizontal">
-                    <div class="form-group" *ngIf="activeGroup">
+                    <div class="form-group" *ngIf="activeGroups">
                         <div class="col-sm-3">
                             <label class="radio-inline" i18n>Answer group</label>
                         </div>
                         <div class="col-sm-9">
                             <label class="radio-inline">
-                                <input type="radio" [(ngModel)]="options.group" name="answer-group" [value]="undefined">
+                                <input type="radio" [(ngModel)]="options.groups" name="answer-group" [value]="undefined">
                                 <ng-container i18n>All answerers</ng-container>
                             </label>
                             <label class="radio-inline">
-                                <input type="radio" [(ngModel)]="options.group" name="answer-group" [value]="activeGroup">
-                                <ng-container i18n>Document group ({{ activeGroup }})</ng-container>
+                                <input type="radio" [(ngModel)]="options.groups" name="answer-group" [value]="activeGroups">
+                                <ng-container i18n>Document groups ({{ activeGroups }})</ng-container>
                             </label>
                         </div>
                     </div>
@@ -295,7 +295,7 @@ export class AllAnswersDialogComponent extends AngularDialogComponent<
     options!: IOptions;
     private storage = new TimStorage("allAnswersOptions", AnswersDialogOptions);
     lastFetch?: ReadonlyMoment;
-    activeGroup?: string;
+    activeGroups?: [string]; // TODO: if multiple groups, template ui needs selector for all groups vs specific groups
 
     constructor(private http: HttpClient) {
         super();
@@ -317,7 +317,7 @@ export class AllAnswersDialogComponent extends AngularDialogComponent<
     ngOnInit() {
         const options = this.data;
         this.showSort = options.allTasks;
-        this.activeGroup = documentglobals().group;
+        this.activeGroups = documentglobals().groups;
 
         const defs = {
             age: "max",
@@ -331,12 +331,12 @@ export class AllAnswersDialogComponent extends AngularDialogComponent<
             print: "all",
             format: "text",
             salt: undefined,
-            group: undefined,
+            groups: undefined,
         } as const;
 
         this.options = this.storage.get() ?? defs;
-        if (this.options.group && this.activeGroup) {
-            this.options.group = this.activeGroup;
+        if (this.options.groups && this.activeGroups) {
+            this.options.groups = this.activeGroups;
         }
 
         (async () => {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -969,7 +969,7 @@ export class AnswerBrowserComponent
         const r = await to(
             $http.get<IUser[]>(
                 `/getTaskUsers/${this.taskId.docTask().toString()}`,
-                {params: {group: this.viewctrl.group}}
+                {params: {groups: this.viewctrl.groups}}
             )
         );
         this.loading--;

--- a/timApp/static/scripts/tim/answer/import-answers-dialog.component.ts
+++ b/timApp/static/scripts/tim/answer/import-answers-dialog.component.ts
@@ -99,7 +99,10 @@ export class ImportAnswersDialogComponent extends AngularDialogComponent<
     }
 
     ngOnInit() {
-        this.importGroup = documentglobals().group;
+        const userGroups = documentglobals().groups;
+        if (userGroups?.length == 1) {
+            this.importGroup = userGroups[0]; // TODO: Support multiple groups
+        }
     }
 
     async importAnswers() {

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -224,7 +224,7 @@ export class ViewCtrl implements IController {
     public item: IDocument;
     public docId: number;
 
-    public group?: string;
+    public groups?: [string];
     public scope: IScope;
     public noBrowser: boolean;
     public docVersion: [number, number];
@@ -312,7 +312,7 @@ export class ViewCtrl implements IController {
         this.item = dg.curr_item;
         this.startIndex = dg.startIndex;
         this.users = dg.users;
-        this.group = dg.group;
+        this.groups = dg.groups;
         this.teacherMode = dg.teacherMode;
         this.velpMode = dg.velpMode;
         this.scope = sc;

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -118,7 +118,7 @@ export interface IDocumentGlobals extends IItemGlobals {
     curr_item: IDocument;
     noBrowser: boolean;
     allowMove: boolean; // TODO this doesn't come from server and should be removed from globals
-    group?: string;
+    groups?: [string];
     docSettings: IDocSettings;
     memoMinutesSettings?: IMeetingMemoSettings;
     editMode: EditMode | null;

--- a/timApp/templates/partials/doc_head.jinja2
+++ b/timApp/templates/partials/doc_head.jinja2
@@ -38,7 +38,7 @@
     var startIndex = {{start_index|tojson}};
     var teacherMode = {{teacher_mode|tojson}};
     var velpMode = {{velp_mode|tojson}};
-    var group = {{group|tojson}};
+    var groups = {{groups|tojson}};
     var lectureMode = {{lecture_mode|tojson}};
     {% if teacher_mode %}
         var users = {{plugin_users|tojson}};

--- a/timApp/tests/server/test_groups.py
+++ b/timApp/tests/server/test_groups.py
@@ -318,7 +318,7 @@ class GroupTest(TimRouteTest):
     def test_invalid_group_setting(self):
         d = self.create_doc(settings={"group": ["a", "b"]})
         html = self.get(d.get_url_for_view("teacher"))
-        self.assertIn("The setting &#39;group&#39; must be a string.", html)
+        self.assertIn("The setting &#39;group&#39; must be a string", html)
 
     def test_doc_group_setting_access(self):
         self.login_test1()

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -426,7 +426,7 @@ class PluginTest(TimRouteTest):
         )
         self.get(
             f"/getTaskUsers/{task_id}",
-            query_string={"group": "testuser1"},
+            query_string={"groups": "testuser1"},
             expect_content=[
                 {
                     "email": "test1@example.com",

--- a/timApp/tests/server/test_teacher.py
+++ b/timApp/tests/server/test_teacher.py
@@ -1,12 +1,17 @@
 """Server tests for xxx."""
 import json
-from datetime import timedelta
+
+import re
 
 from timApp.answer.answer import Answer
-from timApp.tests.db.timdbtest import TEST_USER_2_ID
+from timApp.answer.answers import save_answer
+from timApp.auth.accesstype import AccessType
+from timApp.plugin.taskid import TaskId
+from timApp.tests.db.timdbtest import TEST_USER_2_ID, TEST_USER_1_ID
 from timApp.tests.server.timroutetest import TimRouteTest
 from timApp.tim_app import get_home_organization_group
 from timApp.timdb.sqa import db
+from timApp.user.usergroup import UserGroup
 from timApp.util.utils import get_current_time
 
 
@@ -28,7 +33,7 @@ class TeacherTest(TimRouteTest):
         self.login_test1()
         d = self.create_doc()
         r = self.get(f"/teacher/{d.path}", query_string={"group": "nonexistent"})
-        self.assertIn("User group nonexistent not found", r)
+        self.assertIn("Following groups were not found: {&#39;nonexistent&#39;}", r)
 
     def test_teacher_single_user_in_group(self):
         self.login_test1()
@@ -50,7 +55,9 @@ class TeacherTest(TimRouteTest):
                 answered_on=now,
             )
         )
+        self.test_user_2.grant_access(d, AccessType.teacher)
         db.session.commit()
+        self.login_test2()
         r = self.get(
             f"/teacher/{d.path}",
             query_string={"group": "testuser2"},
@@ -75,4 +82,84 @@ class TeacherTest(TimRouteTest):
                     "velped_task_count": 0,
                 }
             ],
+        )
+
+    def create_group(self, name: str, users: list) -> UserGroup:
+        ug = UserGroup.create(name)
+        for u in users:
+            ug.users.append(u)
+        return ug
+
+    def test_mix_accesses(self):
+        self.login_test1()
+        ug = self.create_group("tu2_mix", [self.test_user_2])
+        ug.admin_doc = self.create_doc().block
+        self.create_group("tu3_mix", [self.test_user_3])
+        self.create_group("empty_mix", [])
+        db.session.commit()
+        d = self.create_doc(initial_par="#- {plugin=textfield #t}")
+        d.document.set_settings(
+            {"groups": ["tu2_mix", "tu3_mix"], "group": "empty_mix"}
+        )
+        save_answer(
+            [self.test_user_1], TaskId.parse(f"{d.id}.t"), json.dumps({"c": "tu1"}), 0
+        )
+        save_answer(
+            [self.test_user_2], TaskId.parse(f"{d.id}.t"), json.dumps({"c": "tu2"}), 0
+        )
+        r = self.get(
+            f"/teacher/{d.path}",
+            as_tree=True,
+        )
+        # tu1 and tu2 answered, groups want tu2, tu3 (not personal groups) and empty
+        # => only tu2 is listed, missing group access warnings present
+        alerts = r.cssselect(".alert.alert-info")
+        self.assertEqual(len(alerts), 2)
+        self.assertSetEqual(
+            {a.text_content().strip() for a in alerts},
+            {
+                "You don't have access to group 'tu3_mix'.",
+                "You don't have access to group 'empty_mix'.",
+            },
+        )
+        users = self.get_js_variable(r, "users")
+        self.assertEqual(len(users), 1)
+        self.assertEqual(users[0]["user"]["id"], TEST_USER_2_ID)
+
+    def test_missing_groups(self):
+        self.login_test1()
+        ug = self.create_group("tu2_mg", [self.test_user_2])
+        ug.admin_doc = self.create_doc().block
+        db.session.commit()
+        d = self.create_doc(initial_par="#- {plugin=textfield #t}")
+        d.document.set_settings(
+            {"groups": ["tu2_mg", "tu2_mg", "kissa", "tu2_mg"], "group": "koira"}
+        )
+        r = self.get(
+            f"/teacher/{d.path}",
+            as_tree=True,
+        )
+        alert = r.cssselect(".alert.alert-info")[0].text_content().strip()
+        self.assertIn("Following groups were not found:", alert)
+        self.assertSetEqual(
+            {m for m in re.findall("'(.*?)'", alert)}, {"kissa", "koira"}
+        )
+
+    def test_overlapping_users_in_groups(self):
+        self.login_test1()
+        ug = self.create_group("tu2_ol", [self.test_user_2])
+        ug.admin_doc = self.create_doc().block
+        ug = self.create_group("tu12_ol", [self.test_user_1, self.test_user_2])
+        ug.admin_doc = self.create_doc().block
+        d = self.create_doc(initial_par="#- {plugin=textfield #t}")
+        d.document.set_settings({"groups": ["tu2_ol", "tu12_ol"]})
+        r = self.get(
+            f"/teacher/{d.path}",
+            as_tree=True,
+        )
+        # tu2 is not listed twice
+        users = self.get_js_variable(r, "users")
+        self.assertEqual(len(users), 2)
+        self.assertSetEqual(
+            {u["user"]["id"] for u in users}, {TEST_USER_1_ID, TEST_USER_2_ID}
         )


### PR DESCRIPTION
Lisää `groups`-dokumenttiasetuksen, johon voi listata dokumentin ryhmät taulukkona, ja muuttaa dokumenttien asetuslogiikkaa niin että ryhmät käsitellään aina listana ryhmiä. Vanha `group`-dokumenttiasetus käsitellään yhtenä groups-listan alkiona

Testi timdevs02:ssa, esim
https://timdevs02.it.jyu.fi/teacher/users/sijualle/csplug

Ryhmiä joilla voi leikkiä
https://timdevs02.it.jyu.fi/view/groups/timohjeet/mallikurssinryhma1
https://timdevs02.it.jyu.fi/view/groups/pahikset1
https://timdevs02.it.jyu.fi/view/groups/tim/hiiret1
https://timdevs02.it.jyu.fi/view/groups/testiryhmat/vainankat1
https://timdevs02.it.jyu.fi/view/groups/ankat1
https://timdevs02.it.jyu.fi/view/groups/ankanpojat1