### PR TITLE
Textfield md

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -459,6 +459,16 @@ def get_answers_for_tasks(tasks: list[str], user_id: int) -> Response:
             get_useranswers_for_task(user, tids, answer_map)
         if gtids:
             get_globals_for_tasks(gtids, answer_map)
+        loaded_contents = [json.loads(c.get("content")) for c in answer_map.values()]
+        for ans in answer_map.values():
+            try:
+                loaded_content = json.loads(ans.get("content"))
+            except JSONDecodeError:
+                loaded_content = ""
+            loaded_contents.append(loaded_content)
+        loaded_contents = call_dumbo(loaded_contents, path="/mdkeys")
+        for idx, ans in enumerate(answer_map.values()):
+            ans["content"] = json.dumps(loaded_contents[idx])
         return json_response({"answers": answer_map, "userId": user_id})
     except Exception as e:
         raise RouteException(str(e))

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -467,10 +467,10 @@ def get_answers_for_tasks(tasks: list[str], user_id: int) -> Response:
 @answers.get("/answerMD")
 def get_answer_md(task_id: str, user_id: int) -> Response:
     """
-    Route for getting the latest valid answer for given task for given user.
+    Route for getting the contents of the latest valid answer for given task for given user.
     Any answer content beginning with "md:" will be markdown-converted
 
-    :return: {"answer": {answer contents}, "userId": user_id}
+    :return: {"content": {answer content}, "userId": user_id}
     """
     user = User.get_by_id(user_id)
     if user is None:
@@ -503,14 +503,14 @@ def get_answer_md(task_id: str, user_id: int) -> Response:
         get_useranswers_for_task(user, [tid], answer_map)
     ans = list(answer_map.values())
     if not ans:
-        return json_response({"answers": {}, "userId": user_id})
+        return json_response({"content": {}, "userId": user_id})
     answer = ans[0]
     try:
         loaded_content = json.loads(answer.get("content"))
     except json.decoder.JSONDecodeError:
         loaded_content = ""
     loaded_content = call_dumbo(loaded_content, path="/mdkeys", options=dumbo_opts)
-    return json_response({"answer": loaded_content, "user_id": user_id})
+    return json_response({"content": loaded_content, "user_id": user_id})
 
 
 @dataclass

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -463,7 +463,7 @@ def get_answers_for_tasks(tasks: list[str], user_id: int) -> Response:
         for ans in answer_map.values():
             try:
                 loaded_content = json.loads(ans.get("content"))
-            except JSONDecodeError:
+            except json.decoder.JSONDecodeError:
                 loaded_content = ""
             loaded_contents.append(loaded_content)
         loaded_contents = call_dumbo(loaded_contents, path="/mdkeys")

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -429,6 +429,7 @@ def get_globals_for_tasks(task_ids: list[TaskId], answer_map: dict[str, dict]) -
 def get_answers_for_tasks(tasks: list[str], user_id: int) -> Response:
     """
     Route for getting latest valid answers for given user and list of tasks
+
     :return: {"answers": {taskID: Answer}, "userId": user_id}
     """
     user = User.get_by_id(user_id)
@@ -465,6 +466,12 @@ def get_answers_for_tasks(tasks: list[str], user_id: int) -> Response:
 
 @answers.get("/answerMD")
 def get_answer_md(task_id: str, user_id: int) -> Response:
+    """
+    Route for getting the latest valid answer for given task for given user.
+    Any answer content beginning with "md:" will be markdown-converted
+
+    :return: {"answer": {answer contents}, "userId": user_id}
+    """
     user = User.get_by_id(user_id)
     if user is None:
         raise RouteException("Non-existent user")

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7890,6 +7890,22 @@
           <context context-type="linenumber">306,307</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6393364220046549775" datatype="html">
+        <source>Error rendering text, please try again</source>
+        <target state="translated">Virhe tekstin muuntamisessa, ole hyvä ja yritä uuudestaan</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/fields/js/textfield-plugin.component.ts</context>
+          <context context-type="linenumber">390</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1752954653766571047" datatype="html">
+        <source>Text rendering timed out, please try again</source>
+        <target state="translated">Tekstin muuntaminen aikakatkaistiin, ole hyvä ja yritä uudestaan</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/fields/js/textfield-plugin.component.ts</context>
+          <context context-type="linenumber">392</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7792,6 +7792,22 @@
           <context context-type="linenumber">306,307</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6393364220046549775" datatype="html">
+        <source>Error rendering text, please try again</source>
+        <target state="translated">Tolkning misslyckades, var god försök igen </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/fields/js/textfield-plugin.component.ts</context>
+          <context context-type="linenumber">390</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1752954653766571047" datatype="html">
+        <source>Text rendering timed out, please try again</source>
+        <target state="translated">Timeout för tolkningen togs, var god försök igen</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/fields/js/textfield-plugin.component.ts</context>
+          <context context-type="linenumber">392</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -376,14 +376,14 @@ export class TextfieldPluginComponent
         }
         const uid = ab.user.id;
         const r = await this.httpGet<{
-            answer: Record<string, string>;
+            content: Record<string, string>;
             user_id: number;
         }>(`/answerMD`, {
             task_id: tid,
             user_id: uid.toString(),
         });
         if (r.ok && r.result.user_id == uid) {
-            this.userword = r.result.answer.c ?? "";
+            this.userword = r.result.content.c ?? "";
         }
         if (this.plainTextSpan) {
             ParCompiler.processAllMathDelayed(

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -328,7 +328,7 @@ export class TextfieldPluginComponent
     // TODO: get rid of any (styles can arrive as object)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setAnswer(content: Record<string, any>): ISetAnswerResult {
-        const ret = this.zone.run(() => {
+        return this.zone.run(() => {
             this.errormessage = undefined;
             let message;
             let ok = true;
@@ -353,17 +353,16 @@ export class TextfieldPluginComponent
             this.changes = false;
             this.saveFailed = false;
             this.updateListeners(ChangeType.Saved);
+            if (
+                this.markup.form != false &&
+                this.userword &&
+                this.isPlainText() &&
+                this.plainTextSpan
+            ) {
+                this.updateMdToHtml();
+            }
             return {ok: ok, message: message};
         });
-        if (
-            this.markup.form != false &&
-            this.userword &&
-            this.isPlainText() &&
-            this.plainTextSpan
-        ) {
-            this.updateMdToHtml();
-        }
-        return ret;
     }
 
     async updateMdToHtml() {

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -135,7 +135,8 @@ export type TFieldContent = t.TypeOf<typeof FieldContent>;
                </button>
          </span>
          <span #plainTextSpan *ngIf="isPlainText() && !isDownloadButton" [innerHtml]="userword | purify"
-               class="plaintext" [style.width.em]="cols" style="max-width: 100%" [ngStyle]="styles"></span>
+               class="plaintext" [style.width.em]="cols" style="max-width: 100%" [ngStyle]="styles"
+               [tooltip]="errormessage" [isOpen]="errormessage !== undefined && !hasButton()"></span>
          <a *ngIf="isDownloadButton" class="timButton" [href]="userWordBlobUrl" [download]="downloadButtonFile">{{downloadButton}}</a>
          </span></label>
     </form>
@@ -384,6 +385,11 @@ export class TextfieldPluginComponent
         });
         if (r.ok && r.result.user_id == uid) {
             this.userword = r.result.content.c ?? "";
+        }
+        if (!r.ok) {
+            this.errormessage = $localize`Error rendering text, please try again`;
+        } else if (this.userword.includes("<pre>Latex timeouted\n</pre>")) {
+            this.errormessage = $localize`Text rendering timed out, please try again`;
         }
         if (this.plainTextSpan) {
             ParCompiler.processAllMathDelayed(

--- a/timApp/modules/fields/textfield.py
+++ b/timApp/modules/fields/textfield.py
@@ -69,7 +69,7 @@ class TextfieldHtmlModel(
             return ""
         if isinstance(self.state.c, str) and not self.state.c.strip():
             return ""
-        return f"**{self.state.c}**"
+        return f"{self.state.c}"
 
 
 @dataclass


### PR DESCRIPTION
Muuntaa userAnswersForTasks-reitissä kaikki md:-alkuiset vastaukset markdowniksi.

Pallottelin jonkin verran onko tuota järkevää tehdä itse tuossa reitissä (eli hidastaako se lomakkeiden käyttäjävaihtoa), ja testailin toisessa haarassa tilannetta jossa tuo md-kutsu tehdään tarvittaessa eri pyynnöllä. 

Devsissä on tuo testihaara ja tilanne jossa on 50 pitkää vastausta sisältävää tekstfieldiä
https://timdevs01-3.it.jyu.fi/teacher/50fields_form (muunnokset eri pyynnöllä, userAnswersForTasks ~150ms)
https://timdevs01-3.it.jyu.fi/teacher/50fields-noform-nomd (muunnokset samassa pyynnössä, muttei mitään muutettavaa userAnswersForTasks ~200ms)
https://timdevs01-3.it.jyu.fi/teacher/50fields-noform-nomd (muunnokset samassa ja 50x pitkää muutettavaa md-tekstivastausta, userAnswersForTasks ~750ms)

Päädyin siihen että nuo muunnokset on parempi tehdä toistaiseksi tuossa samassa pyynnössä, koska silloin se palvelimelta tuleva vastaus on yhtenäinen sivun avaamistilanteen kanssa eli md:-alkavat vastaukset on muutettu markdowniksi. Silloin se on pluginista riippumatta aina samanmuotoinen, eikä pluginiin tarvitse toteuttaa tuota erillistä pyyntöä