### PR TITLE
Group urlparam

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -232,8 +232,8 @@ class AnswerPrintOptions(Enum):
 
 @dataclass
 class AllAnswersOptions(AnswerPeriodOptions):
-    group: list[str] = field(default_factory=list)
-    groups: list[str] = field(default_factory=list)
+    group: list[str] | None = field(default=None, metadata={"list_type": "delimited"})
+    groups: list[str] | None = field(default=None, metadata={"list_type": "delimited"})
     age: AgeOptions = field(default=AgeOptions.MAX, metadata={"by_value": True})
     valid: ValidityOptions = field(
         default=ValidityOptions.VALID, metadata={"by_value": True}
@@ -256,9 +256,8 @@ class AllAnswersOptions(AnswerPeriodOptions):
     )
 
     def __post_init__(self) -> None:
-        self.groups = [
-            word for arg in self.groups + self.group for word in arg.split(",")
-        ]
+        if self.group:
+            self.groups = self.groups + self.group if self.groups else self.group
 
 
 def get_all_answers(

--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -232,7 +232,8 @@ class AnswerPrintOptions(Enum):
 
 @dataclass
 class AllAnswersOptions(AnswerPeriodOptions):
-    group: str | None = None
+    group: list[str] = field(default_factory=list)
+    groups: list[str] = field(default_factory=list)
     age: AgeOptions = field(default=AgeOptions.MAX, metadata={"by_value": True})
     valid: ValidityOptions = field(
         default=ValidityOptions.VALID, metadata={"by_value": True}
@@ -253,6 +254,10 @@ class AllAnswersOptions(AnswerPeriodOptions):
     include_inactive_memberships: bool = field(
         default=False, metadata={"data_key": "includeInactiveMemberships"}
     )
+
+    def __post_init__(self):
+        if self.group:
+            self.groups += self.group
 
 
 def get_all_answers(
@@ -280,7 +285,7 @@ def get_all_answers(
         options.period_to,
         task_ids,
         options.valid,
-        options.group,
+        options.groups,
         options.include_inactive_memberships,
     )
 
@@ -460,7 +465,7 @@ def get_all_answer_initial_query(
     period_to: datetime,
     task_ids: list[TaskId],
     valid: ValidityOptions,
-    group: str | None = None,
+    groups: str | None = None,
     include_expired_members: bool = False,
 ) -> Query:
     q = Answer.query.filter(
@@ -474,10 +479,10 @@ def get_all_answer_initial_query(
         case ValidityOptions.VALID:
             q = q.filter_by(valid=True)
     q = q.join(User, Answer.users)
-    if group:
+    if groups:
         q = q.join(
             UserGroup, User.groups_dyn if include_expired_members else User.groups
-        ).filter(UserGroup.name == group)
+        ).filter(UserGroup.name.in_(groups))
     return q
 
 

--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -255,7 +255,7 @@ class AllAnswersOptions(AnswerPeriodOptions):
         default=False, metadata={"data_key": "includeInactiveMemberships"}
     )
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.groups = [
             word for arg in self.groups + self.group for word in arg.split(",")
         ]
@@ -466,7 +466,7 @@ def get_all_answer_initial_query(
     period_to: datetime,
     task_ids: list[TaskId],
     valid: ValidityOptions,
-    groups: str | None = None,
+    groups: list[str] | None = None,
     include_expired_members: bool = False,
 ) -> Query:
     q = Answer.query.filter(

--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -256,8 +256,9 @@ class AllAnswersOptions(AnswerPeriodOptions):
     )
 
     def __post_init__(self):
-        if self.group:
-            self.groups += self.group
+        self.groups = [
+            word for arg in self.groups + self.group for word in arg.split(",")
+        ]
 
 
 def get_all_answers(

--- a/timApp/document/docviewparams.py
+++ b/timApp/document/docviewparams.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from marshmallow import ValidationError
 
@@ -12,7 +12,8 @@ class DocViewParams:
     b: int | str | None = None
     e: int | str | None = None
     edit: str | None = None
-    group: str | None = None
+    group: list[str] | None = field(default=None, metadata={"list_type": "delimited"})
+    groups: list[str] | None = field(default=None, metadata={"list_type": "delimited"})
     hide_names: bool | None = None
     lazy: bool | None = None
     noanswers: bool = False

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -701,7 +701,11 @@ def render_doc_view(
         total_tasks = len(task_ids)
     if points_sum_rule and points_sum_rule.scoreboard_error:
         flash(f"Error in point_sum_rule scoreboard: {points_sum_rule.scoreboard_error}")
-    usergroups = [m.group] if m.group is not None else None
+    usergroups = m.group if m.group is not None else None
+    if m.groups is not None:
+        usergroups = usergroups + m.groups if usergroups is not None else m.groups
+    if usergroups == [""]:
+        usergroups = []
     peer_review_start = doc_settings.peer_review_start()
     peer_review_stop = doc_settings.peer_review_stop()
     show_valid_only = (

--- a/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
+++ b/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
@@ -362,6 +362,9 @@ export class AllAnswersDialogComponent extends AngularDialogComponent<
             periodFrom: this.options.periodFrom,
             periodTo: this.options.periodTo,
         };
+        if (this.options.groups) {
+            toSerialize.groups = [this.options.groups.join()];
+        }
         this.storage.set(this.options);
         // Don't include the salt in the serialized data if it's not used
         if (toSerialize.name !== "pseudonym") {

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -789,6 +789,17 @@ user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re
 \[false, false\]
         """.strip(),
         )
+        group_result = self.get(
+            f"/allDocumentAnswersPlain/{doc.path}",
+            query_string={"group": "testuser1,"},
+        )
+        self.assertEqual(2, group_result.count("testuser1"))
+        self.assertEqual(0, group_result.count("testuser2"))
+        group_result = self.get(
+            f"/allAnswersPlain/{task_id}", query_string={"groups": ",testuser2"}
+        )
+        self.assertEqual(0, group_result.count("testuser1"))
+        self.assertEqual(1, group_result.count("testuser2"))
 
     def test_save_points(self):
         cannot_give_custom = {

--- a/timApp/util/utils.py
+++ b/timApp/util/utils.py
@@ -467,7 +467,7 @@ def append_to_bytearray(b: bytearray, v: Any) -> None:
         b.extend(v.to_bytes(4, "little", signed=True))
     elif isinstance(v, float):
         b.extend(struct.pack("f", v))
-    elif isinstance(v, tuple):
+    elif isinstance(v, tuple) or isinstance(v, list):
         for m in v:
             append_to_bytearray(b, m)
     elif isinstance(v, Enum):


### PR DESCRIPTION
Korjaa ryhmäpäivityksessä hajonneet all answers / answers as plain text -painikkeet.

Lisäksi urlmacro group toimii useammalla pilkulla erotellulla ryhmällä. Groups toimii synonyyminä. Lisäksi jos antaa tyhjän &group= makron niin toimitaan kuin dokussa ei olisi ryhmäasetusta ollenkaan

https://timdevs01-3.it.jyu.fi/teacher/1csplug
Testiryhminä voi käyttää tu1pub, tu5pub jne