### PR TITLE
jsrunner: Add tools.request

### DIFF
--- a/timApp/modules/jsrunner/server/package-lock.json
+++ b/timApp/modules/jsrunner/server/package-lock.json
@@ -330,10 +330,33 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz",
-      "integrity": "sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
+    },
+    "@types/node-fetch": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -597,6 +620,11 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
       "integrity": "sha1-sqRdpf36ILBJb8N2jMJ8EvqRan0="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -778,6 +806,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
@@ -914,6 +950,11 @@
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -1540,6 +1581,16 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1946,9 +1997,9 @@
       "dev": true
     },
     "isolated-vm": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.4.1.tgz",
-      "integrity": "sha512-5aDwxQGm78vHS+qJeUli2ILroG7OS/k3D/Mc0kcT9vyujiL4bV7PYYix1mAvuBm3v44nz2qcfAOqgAbhuACc/w=="
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.4.2.tgz",
+      "integrity": "sha512-4ObzqZWZTS3bQtavzgoCMsOxpQt3hMeenkPavx2Razig3wX3fAkXZ3XpmqXKoJu6KMl4egBI1MfSg0BnxZ/rfg=="
     },
     "jade": {
       "version": "1.11.0",
@@ -2203,6 +2254,14 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -2761,6 +2820,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "transformers": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
@@ -2971,6 +3035,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/timApp/modules/jsrunner/server/package.json
+++ b/timApp/modules/jsrunner/server/package.json
@@ -18,9 +18,11 @@
     "fp-ts": "^2.12.3",
     "http-errors": "^2.0.0",
     "io-ts": "^2.2.18",
-    "isolated-vm": "^4.4.1",
+    "isolated-vm": "^4.4.2",
     "jade": "~1.11.0",
-    "morgan": "~1.10.0"
+    "morgan": "~1.10.0",
+    "node-fetch": "^2.6.9",
+    "form-data": "^4.0.0"
   },
   "devDependencies": {
     "@types/acorn": "^6.0.0",
@@ -28,6 +30,8 @@
     "@types/debug": "^4.1.7",
     "@types/http-errors": "^1.8.2",
     "@types/morgan": "^1.9.3",
+    "@types/node": "^18.13.0",
+    "@types/node-fetch": "^2.6.2",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
     "eslint": "^8.24.0",

--- a/timApp/modules/jsrunner/server/routes/answer.ts
+++ b/timApp/modules/jsrunner/server/routes/answer.ts
@@ -20,6 +20,7 @@ import type {
     VelpDataT,
 } from "../servertypes";
 import {JsrunnerAnswer} from "../servertypes";
+import {ivmRequest} from "../util/request";
 import type {IToolsResult, NewUserData, ToolsBase} from "./tools";
 import {GTools, numberLines, Tools} from "./tools";
 
@@ -301,6 +302,10 @@ router.put("/", async (req, res, next) => {
         peerreviews: value.input.peerreviews,
     };
     await ctx.global.set("g", JSON.stringify(runnerData));
+    await ctx.global.set(
+        "_ivm_request",
+        new ivm.Callback(ivmRequest, {sync: true})
+    );
     let r: AnswerReturn;
     try {
         const result: ReturnType<typeof runner> = JSON.parse(

--- a/timApp/modules/jsrunner/server/tsconfig.json
+++ b/timApp/modules/jsrunner/server/tsconfig.json
@@ -13,6 +13,7 @@
     "paths": {
       "tim/plugin/*": ["../../../static/scripts/tim/plugin/*"],
       "io-ts": ["node_modules/io-ts"],
+      "io-ts/lib/Reporter": ["node_modules/io-ts/lib/Reporter"],
       "fp-ts/lib/Either": ["node_modules/fp-ts/lib/Either"],
       "tim/util/*": ["../../../static/scripts/tim/util/*"]
     },

--- a/timApp/modules/jsrunner/server/tsconfig.json
+++ b/timApp/modules/jsrunner/server/tsconfig.json
@@ -13,6 +13,7 @@
     "paths": {
       "tim/plugin/*": ["../../../static/scripts/tim/plugin/*"],
       "io-ts": ["node_modules/io-ts"],
+      "fp-ts/lib/Either": ["node_modules/fp-ts/lib/Either"],
       "tim/util/*": ["../../../static/scripts/tim/util/*"]
     },
     "lib": [

--- a/timApp/modules/jsrunner/server/util/request.ts
+++ b/timApp/modules/jsrunner/server/util/request.ts
@@ -1,0 +1,170 @@
+import * as t from "io-ts";
+import {isLeft} from "fp-ts/Either";
+import {withDefault} from "tim/plugin/attributes";
+import type {BodyInit} from "node-fetch";
+import fetch from "node-fetch";
+import FormData from "form-data";
+import ivm from "isolated-vm";
+import {getErrors} from "tim/plugin/errors";
+
+const RequestFormData = t.type({
+    type: t.literal("form-data"),
+    data: t.record(t.string, t.string),
+});
+
+const RequestSearchParams = t.type({
+    type: t.literal("form-urlencoded"),
+    params: t.record(t.string, t.string),
+});
+
+const RequestJsonBody = t.type({
+    type: t.literal("json"),
+    data: t.UnknownRecord,
+});
+
+const RequestBody = t.union([
+    t.string,
+    t.undefined,
+    RequestFormData,
+    RequestSearchParams,
+    RequestJsonBody,
+]);
+
+const RequestOptions = withDefault(
+    t.type({
+        method: withDefault(
+            t.union([
+                t.literal("GET"),
+                t.literal("POST"),
+                t.literal("PUT"),
+                t.literal("DELETE"),
+                t.literal("PATCH"),
+            ]),
+            "GET"
+        ),
+        query: t.union([t.record(t.string, t.string), t.undefined]),
+        headers: withDefault(t.record(t.string, t.string), {}),
+        body: RequestBody,
+        responseType: withDefault(
+            t.union([
+                t.literal("json"),
+                t.literal("text"),
+                t.literal("status"),
+            ]),
+            "text"
+        ),
+        timeout: withDefault(t.number, 10000),
+    }),
+    {
+        method: "GET",
+        query: undefined,
+        body: undefined,
+        responseType: "text",
+        headers: {},
+        timeout: 10000,
+    }
+);
+
+export async function request(url: unknown, opt: unknown) {
+    if (!t.string.is(url)) {
+        throw new Error("url must be a string");
+    }
+    const decodedOpt = RequestOptions.decode(opt);
+    if (isLeft(decodedOpt)) {
+        const errString = getErrors(decodedOpt, "*", false)
+            .map(({name, type}) => `- ${name}: ${type}`)
+            .join(`\n`);
+        throw new Error(
+            `Invalid request options for the following values:\n${errString}`
+        );
+    }
+    const options = decodedOpt.right;
+    let body: BodyInit | undefined;
+    const headers: Record<string, string> = {
+        ...options.headers,
+        "User-Agent": "tim_jsrunner",
+    };
+
+    if (options.body === undefined || typeof options.body === "string") {
+        body = options.body;
+    } else {
+        if (options.body.type === "form-data") {
+            const formData = new FormData();
+            Object.entries(options.body.data).forEach(([key, value]) => {
+                formData.append(key, value);
+            });
+            body = formData;
+        } else if (options.body.type === "form-urlencoded") {
+            const searchParams = new URLSearchParams();
+            Object.entries(options.body.params).forEach(([key, value]) => {
+                searchParams.append(key, value);
+            });
+            body = searchParams;
+        } else if (options.body.type === "json") {
+            body = JSON.stringify(options.body.data);
+            headers["Content-Type"] = "application/json;charset=UTF-8";
+        }
+    }
+
+    let reqUrl = url;
+    if (options.query) {
+        const urlObj = new URL(url);
+        Object.entries(options.query).forEach(([key, value]) => {
+            urlObj.searchParams.append(key, value);
+        });
+        reqUrl = urlObj.toString();
+    }
+
+    const response = await fetch(reqUrl, {
+        method: options.method,
+        headers,
+        body,
+    });
+
+    if (options.responseType === "status") {
+        return response.status;
+    }
+    if (options.responseType === "json") {
+        return await response.json();
+    }
+    return await response.text();
+}
+
+// isolated-vm does not handle passing Promises well between the isolated environments.
+// Therefore, we use the following trick:
+// 1. Create a reference object of format {status: boolean; result?: unknown; error?: string}
+// 2. Call the request function and bind to then/catch/finally that set the status when the request is done.
+// 3. Return the reference object
+//
+// When the isolated environment calls the function, it will get the reference object and waits for status check in a loop.
+// This allows to block the script while it waits for the request to finish.
+export function ivmRequest(url: unknown, opts: unknown) {
+    const ref = new ivm.Reference<{
+        done: boolean;
+        result?: unknown;
+        error?: string;
+    }>({
+        done: false,
+        result: undefined,
+        error: undefined,
+    });
+    request(url, opts)
+        .then((res) => {
+            ref.setSync("result", res, {externalCopy: true});
+        })
+        .catch((err) => {
+            let errorMessage = "Unknown error";
+            if (!err) {
+                errorMessage = "No error available";
+            } else if (err instanceof Error) {
+                errorMessage = `(${err.name}): ${err.message}`;
+            } else {
+                errorMessage = String(err);
+            }
+            ref.setSync("error", errorMessage);
+        })
+        .finally(() => {
+            ref.setSync("done", true);
+        });
+    return ref;
+}

--- a/timApp/modules/jsrunner/server/util/request.ts
+++ b/timApp/modules/jsrunner/server/util/request.ts
@@ -5,7 +5,7 @@ import type {BodyInit} from "node-fetch";
 import fetch from "node-fetch";
 import FormData from "form-data";
 import ivm from "isolated-vm";
-import {getErrors} from "tim/plugin/errors";
+import {BasicReporter} from "tim/plugin/errors";
 
 const RequestFormData = t.type({
     type: t.literal("form-data"),
@@ -71,9 +71,9 @@ export async function request(url: unknown, opt: unknown) {
     }
     const decodedOpt = RequestOptions.decode(opt);
     if (isLeft(decodedOpt)) {
-        const errString = getErrors(decodedOpt, "*", false)
-            .map(({name, type}) => `- ${name}: ${type}`)
-            .join(`\n`);
+        const errString = BasicReporter.report(decodedOpt)
+            .map((e) => ` - ${e}`)
+            .join("\n");
         throw new Error(
             `Invalid request options for the following values:\n${errString}`
         );

--- a/timApp/static/scripts/tim/plugin/errors.ts
+++ b/timApp/static/scripts/tim/plugin/errors.ts
@@ -26,7 +26,11 @@ function indexOfFirstName(context: Context) {
     return context.findIndex((c) => c.key.match(/^[a-z]/) != null);
 }
 
-export function getErrors(v: Left<t.Errors>): MarkupError {
+export function getErrors(
+    v: Left<t.Errors>,
+    filterKey: string = "markup",
+    showKeyLessErrors: boolean = true
+): MarkupError {
     const ps: Array<[string[], string]> = v.left
         .filter((e) => {
             const ind = indexOfFirstName(e.context);
@@ -34,7 +38,7 @@ export function getErrors(v: Left<t.Errors>): MarkupError {
                 return (
                     e.context.length >= 3 &&
                     e.context[0].key === "" &&
-                    e.context[ind].key === "markup"
+                    (e.context[ind].key === filterKey || filterKey === "*")
                 );
             }
         })
@@ -49,6 +53,10 @@ export function getErrors(v: Left<t.Errors>): MarkupError {
         const key = keys.join(".");
         // don't report parent fields because it's not useful
         if (isPrefixOfSome(key, knownKeys)) {
+            continue;
+        }
+        // Avoid showing the errors that don't have a key
+        if (!key && !showKeyLessErrors) {
             continue;
         }
         // avoid too verbose messages


### PR DESCRIPTION
Lisää `tools.request`-funktion, jonka avulla JSRunner-skripteistä voi tehdä HTTP-kutsuja.
Tämän avulla onnistuu esim. vuorovaikutus GitLabin kanssa TIMista (esim. opiskelijoiden lisääminen ryhmään, yms). Toinen esimerkki on JetBrains-lisenssien antaminen käyttäjille.

Funktion dokumentaatio:
```ts
    /**
     * Performs an HTTP request.
     *
     * @param url URL to request
     * @param opts Options for the request. The available options are:
     *              - method: HTTP method to use (default: "GET")
     *              - query: URL query parameters to add to the URL as a record [string, string] (default: undefined)
     *              - headers: HTTP headers to send (default: {})
     *              - timeout: Request timeout in milliseconds (default: 10000)
     *              - body: Data to send with the request. This can be a string or an object that has the following properties:
     *                     - type: Type of data to send. Available values are "form-data" (send data as multipart/form-data), "form-urlencoded" (send data as URL-encoded string) and "json" (send data as JSON).
     *                     - params: The data to send. This must be a record of type [string, string] for "form-data" and "url-params" and a record of type [string, unknown] for "json".
     *              - responseType: What data to return. Available values are
     *                     - "text": Return the response as a string (default)
     *                     - "json": Return the response as a parsed JSON object
     *                     - "status": Return the response status code
     */
    request(url: string, opts: unknown);
```

Esimerkki: <https://timdevs01-2.it.jyu.fi/teacher/users/dz-dz/test-jsrunner-request> (kirjaudu jollain testusers-käyttäjällä)

Huomioita ja rajoitteita:

* `tools.request` on blokkaava skriptissä. Tämä niin, koska `isolated-vm` ei toimi kunnolla Promisen kanssa, joten `async` ei toimi kunnolla. Sen sijaan toteutin "rautalankaratkaisun", jossa kutsun tilaa pollataan ja näin blokataan kutsu.
* Kaikissa kutstuissa User-Agent on `tim_jsrunner`
* Pohjana käytetään `node-fetch`-kirjastoa. Asetuksien määrä on kuitenkin rajoitettu, jotta peruskäyttäjä ei voi tehdä jotain tosi pahaa (esim. ylimääräistä spammausta)