### PR TITLE
Add extra ACE comment shortcut, ignore invalid answers when counting answerLimit

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -489,7 +489,7 @@ def get_all_answer_initial_query(
 def get_existing_answers_info(
     users: list[User], task_id: TaskId
 ) -> ExistingAnswersInfo:
-    q = get_latest_answers_query(task_id, users)
+    q = get_latest_valid_answers_query(task_id, users)
     latest = q.first()
     count = q.count()
     return ExistingAnswersInfo(latest_answer=latest, count=count)

--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -48,13 +48,13 @@ class ExistingAnswersInfo:
     count: int
 
 
-def get_latest_answers_query(task_id: TaskId, users: list[User]) -> Query:
-    if task_id.is_global:
-        q = Answer.query.filter_by(task_id=task_id.doc_task).order_by(Answer.id.desc())
-    else:
+def get_answers_query(task_id: TaskId, users: list[User], only_valid: bool) -> Query:
+    q = Answer.query.filter_by(task_id=task_id.doc_task)
+    if only_valid:
+        q = q.filter_by(valid=True)
+    if not task_id.is_global:
         q = (
-            Answer.query.filter_by(task_id=task_id.doc_task)
-            .join(User, Answer.users)
+            q.join(User, Answer.users)
             .filter(User.id.in_([u.id for u in users]))
             .group_by(Answer.id)
             .with_entities(Answer.id)
@@ -62,9 +62,9 @@ def get_latest_answers_query(task_id: TaskId, users: list[User]) -> Query:
                 (func.array_agg(aggregate_order_by(User.id, User.id)))
                 == sorted(u.id for u in users)
             )
-            .subquery()
-        )
-        q = Answer.query.filter(Answer.id.in_(q)).order_by(Answer.id.desc())
+        ).subquery()
+        q = Answer.query.filter(Answer.id.in_(q))
+    q = q.order_by(Answer.id.desc())
     return q
 
 
@@ -155,7 +155,7 @@ def save_answer(
         )
     if tags is None:
         tags = []
-    answerinfo = get_existing_answers_info(users, task_id)
+    answerinfo = get_existing_answers_info(users, task_id, False)
     if (
         is_redundant_answer(content_str, answerinfo, plugintype, valid)
         and not force_save
@@ -487,9 +487,9 @@ def get_all_answer_initial_query(
 
 
 def get_existing_answers_info(
-    users: list[User], task_id: TaskId
+    users: list[User], task_id: TaskId, only_valid: bool
 ) -> ExistingAnswersInfo:
-    q = get_latest_valid_answers_query(task_id, users)
+    q = get_answers_query(task_id, users, only_valid)
     latest = q.first()
     count = q.count()
     return ExistingAnswersInfo(latest_answer=latest, count=count)

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -320,7 +320,7 @@ def get_iframehtml_answer_impl(
 
     users = [ctx_user]
 
-    answerinfo = get_existing_answers_info(users, tid)
+    answerinfo = get_existing_answers_info(users, tid, True)
 
     info = plugin.get_info(users, answerinfo.count)
 
@@ -691,7 +691,7 @@ def get_postanswer_plugin_etc(
     if newtask:  # found_plugin.par.get_attr("seed") == "answernr":
         force_answer = True  # variable tasks are always saved even with same answer
 
-    answerinfo = get_existing_answers_info(users, tid)
+    answerinfo = get_existing_answers_info(users, tid, True)
     answernr = -1
     answernr_to_user = None
 

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1084,7 +1084,9 @@ def post_answer_impl(
             is_valid, explanation = plugin.is_answer_valid(answerinfo.count, tim_info)
             if vr.is_invalid:
                 is_valid = False
-                explanation = vr.invalidate_reason
+                explanation = (
+                    vr.invalidate_reason + "Your answer was saved but marked as invalid"
+                )
             elif vr.is_expired:
                 fixed_time = (
                     receive_time

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1085,7 +1085,8 @@ def post_answer_impl(
             if vr.is_invalid:
                 is_valid = False
                 explanation = (
-                    vr.invalidate_reason + "Your answer was saved but marked as invalid"
+                    vr.invalidate_reason
+                    + " Your answer was saved but marked as invalid."
                 )
             elif vr.is_expired:
                 fixed_time = (

--- a/timApp/modules/cs/js/editor/ace.ts
+++ b/timApp/modules/cs/js/editor/ace.ts
@@ -118,6 +118,17 @@ export class AceEditorComponent implements IEditor {
         this.updateDisabled();
         this.content = this.content_ ?? "";
         this.content_ = undefined;
+
+        this.aceEditor?.commands.addCommand({
+            name: "toggleCommentLines",
+            bindKey: {
+                win: "Ctrl-'",
+                mac: "Command-'",
+            },
+            exec: () => {
+                this.aceEditor?.toggleCommentLines();
+            },
+        });
     }
 
     get content(): string {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1437,7 +1437,11 @@ export class AnswerBrowserComponent
         if (this.taskInfo == null) {
             return null;
         }
-        return Math.max(this.taskInfo.answerLimit - this.answers.length, 0);
+        return Math.max(
+            this.taskInfo.answerLimit -
+                this.answers.filter((a) => a.valid).length,
+            0
+        );
     }
 
     public setInfo(info: ITaskInfo) {

--- a/timApp/static/scripts/tim/editor/AceParEditor.ts
+++ b/timApp/static/scripts/tim/editor/AceParEditor.ts
@@ -217,6 +217,16 @@ export class AceParEditor extends BaseParEditor {
                 this.pageBreakClicked();
             },
         });
+        this.editor.commands.addCommand({
+            name: "toggleCommentLines",
+            bindKey: {
+                win: "Ctrl-'",
+                mac: "Command-'",
+            },
+            exec: () => {
+                this.editor.toggleCommentLines();
+            },
+        });
         this.editor.keyBinding.setKeyboardHandler({
             handleKeyboard: () => {
                 this.checkWrap();

--- a/timApp/tests/server/test_answers.py
+++ b/timApp/tests/server/test_answers.py
@@ -177,11 +177,13 @@ class AnswerTest(TimRouteTest):
         a = self.add_answer(d, "t", "z", user=self.test_user_1)
         a.users_all.append(self.test_user_2)
         answers = get_existing_answers_info(
-            [self.test_user_1, self.test_user_2], TaskId(doc_id=d.id, task_name="t")
+            [self.test_user_1, self.test_user_2],
+            TaskId(doc_id=d.id, task_name="t"),
+            only_valid=False,
         )
         self.assertEqual(1, answers.count)
         answers = get_existing_answers_info(
-            [self.test_user_1], TaskId(doc_id=d.id, task_name="t")
+            [self.test_user_1], TaskId(doc_id=d.id, task_name="t"), only_valid=False
         )
         self.assertEqual(3, answers.count)
 

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -99,7 +99,7 @@ class PluginTest(TimRouteTest):
             expect_content="Task not found in the document: mmcqexamplez",
         )
 
-        doc.document.set_settings({"global_plugin_attrs": {"all": {"answerLimit": 3}}})
+        doc.document.set_settings({"global_plugin_attrs": {"all": {"answerLimit": 2}}})
         resp = self.post_answer(plugin_type, task_id, [True, True, False])
         self.check_ok_answer(resp)
 

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -2377,7 +2377,7 @@ accessField:
 accessField:
  field: %d.access_ext
  limit: 1
- error: "You already locked your access to this task"
+ error: "You already locked your access to this task."
 """
                 % d_ext.id
             )
@@ -2386,7 +2386,7 @@ accessField:
         self.test_user_2.grant_access(d_ext, AccessType.view)
         db.session.commit()
         self.login_test2()
-        access_error_default = "You have expired your access to this task."
+        access_error_default = "You have expired your access to this task. Your answer was saved but marked as invalid."
         resp = self.post_answer(
             "textfield", f"{d.id}.question", user_input={"c": "testuser2@d part 1"}
         )
@@ -2416,7 +2416,10 @@ accessField:
             f"{d.id}.question_ext_accessfield",
             user_input={"c": "testuser2@d_ext"},
         )
-        self.assertEqual("You already locked your access to this task", resp["error"])
+        self.assertEqual(
+            "You already locked your access to this task. Your answer was saved but marked as invalid.",
+            resp["error"],
+        )
         self.assertFalse(resp["valid"])
         self.assertEqual(
             1, len(self.get_task_answers(f"{d.id}.question_ext_accessfield"))
@@ -2437,7 +2440,7 @@ accessField:
 """
             )
         )
-        access_error_default = "You have expired your access to this task."
+        access_error_default = "You have expired your access to this task. Your answer was saved but marked as invalid."
         self.post_answer("textfield", f"{d.id}.access", user_input={"c": "1"})
         resp = self.post_answer("textfield", f"{d.id}.question", user_input={"c": "ok"})
         # only invalid answers on access source, answer is successful


### PR DESCRIPTION
Muuttaa answerLimit-asetuksen toimintaa niin että invalid-vastauksia ei lasketa käytettyihin yrityskertoihin.

Lisäksi ylimääräinen ctrl+' pikanäppäin, jolla voi firefoxilla muuttaa ace-editorissa maalatut koodirivit kommenteiksi #3347

https://timdevs01-3.it.jyu.fi/view/kooditehtava