### PR TITLE
JSRunner: Add gtools.addItemRightAction

### DIFF
--- a/timApp/admin/fix_settings_references.py
+++ b/timApp/admin/fix_settings_references.py
@@ -16,7 +16,7 @@ def fix_settings_references(d: DocInfo, args: DryrunnableArguments) -> int:
     for _, p in enum_pars(d):
         if p.is_reference() and not p.is_translation():
             try:
-                ref = p.get_referenced_pars()[0]
+                ref = p.get_referenced_pars(blind_settings=False)[0]
             except InvalidReferenceException:
                 continue
             else:

--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -682,7 +682,9 @@ def __resolve_final_settings_impl(
                 # so that we always get the original markdown.
                 tr_attr = curr.get_attr("r")
                 curr.set_attr("r", None)
-                refs = curr.get_referenced_pars()
+                refs = curr.get_referenced_pars(
+                    blind_settings=False
+                )  # Don't blind when resolving and parsing settings
                 curr.set_attr("r", tr_attr)
             except InvalidReferenceException:
                 break

--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -94,6 +94,7 @@ class DocSettingTypes:
     answerBrowser: AnswerBrowserInfo
     groupSelfJoin: GroupSelfJoinSettings
     showValidAnswersOnly: bool
+    manageKey: str
 
 
 doc_setting_field_map: dict[str, Field] = {
@@ -197,6 +198,7 @@ class DocSettings:
     def get_safe_dict(self) -> dict:
         result = dict(self.__dict.values)
         result.pop("macros", None)
+        result.pop("manageKey", None)
         return result
 
     def global_plugin_attrs(self) -> dict:
@@ -638,6 +640,9 @@ class DocSettings:
         return self.get_setting_or_default(
             "groupSelfJoin", GroupSelfJoinSettings.default()
         )
+
+    def manage_key(self) -> str | None:
+        return self.get("manageKey", None)
 
 
 def resolve_settings_for_pars(pars: Iterable[DocParagraph]) -> YamlBlock:

--- a/timApp/document/document.py
+++ b/timApp/document/document.py
@@ -522,7 +522,7 @@ class Document:
         for p in pars:
             if p.is_reference():
                 try:
-                    referenced_pars = p.get_referenced_pars()
+                    referenced_pars = p.get_referenced_pars(blind_settings=False)
                 except TimDbException:
                     pass
                 else:
@@ -1048,7 +1048,7 @@ class Document:
         for p in source:
             if p.is_reference():
                 try:
-                    referenced_pars = p.get_referenced_pars()
+                    referenced_pars = p.get_referenced_pars(blind_settings=False)
                 except TimDbException:
                     pass
                 else:

--- a/timApp/document/editing/routes.py
+++ b/timApp/document/editing/routes.py
@@ -373,7 +373,7 @@ def modify_paragraph_common(doc_id: int, md: str, par_id: str, par_next_id: str 
 
 def mark_as_translated(p: DocParagraph):
     try:
-        deref = p.get_referenced_pars()
+        deref = p.get_referenced_pars(blind_settings=False)
     except TimDbException:
         deref = None
     if deref:

--- a/timApp/item/item.py
+++ b/timApp/item/item.py
@@ -206,3 +206,26 @@ class Item(ItemBase):
             else:
                 raise NotImplementedError
         return None
+
+    @staticmethod
+    def find_by_path(path: str, fallback_to_id: bool = False) -> Item | None:
+        """
+        Finds an item by path. If the item is not found, None is returned.
+
+        :param path: The path of the item to find.
+        :param fallback_to_id: If True, the path is treated as an ID if the item is not found by path.
+        :return: The item, or None if not found.
+        """
+        from timApp.document.docentry import DocEntry
+
+        doc = DocEntry.find_by_path(path, fallback_to_id)
+        if doc:
+            return doc
+
+        from timApp.folder.folder import Folder
+
+        folder = Folder.find_by_path(path, fallback_to_id)
+        if folder:
+            return folder
+
+        return None

--- a/timApp/modules/jsrunner/server/routes/answer.ts
+++ b/timApp/modules/jsrunner/server/routes/answer.ts
@@ -11,6 +11,7 @@ import type {
     ErrorList,
     IError,
     IGroupData,
+    IItemRightActionData,
     IJsRunnerMarkup,
 } from "../../shared/jsrunnertypes";
 import type {
@@ -65,6 +66,7 @@ type RunnerResult =
           fatalError?: never;
           outdata: Record<string, unknown>;
           groups: IGroupData;
+          itemRightActions: IItemRightActionData[];
           newUsers: NewUserData[];
       }
     | {output: string; fatalError: IError; errorprg: string};
@@ -212,6 +214,7 @@ function runner(d: IRunnerData): RunnerResult {
             errors,
             outdata: gtools.outdata,
             groups: gtools.groups,
+            itemRightActions: gtools.itemRightActions,
             newUsers: gtools.newUsers,
         };
     } catch (e) {
@@ -332,6 +335,7 @@ router.put("/", async (req, res, next) => {
             r = {
                 savedata: result.res,
                 groups: result.groups,
+                itemRightActions: result.itemRightActions,
                 newUsers: result.newUsers,
                 web: {
                     output: result.output,

--- a/timApp/modules/jsrunner/server/routes/tools.ts
+++ b/timApp/modules/jsrunner/server/routes/tools.ts
@@ -15,6 +15,7 @@ import {widenFields} from "tim/util/common";
 import type {
     IError,
     IGroupData,
+    IItemRightActionData,
     IJsRunnerMarkup,
     INumbersObject,
 } from "../../shared/jsrunnertypes";
@@ -203,6 +204,37 @@ const NewUserDataT = t.intersection([
 
 // TODO: Figure out why this has to be exported from here (otherwise rollup fails)
 export type NewUserData = t.TypeOf<typeof NewUserDataT>;
+
+const DateString = t.brand(
+    t.string,
+    (s): s is t.Branded<string, {readonly DateValidator: unique symbol}> => {
+        const d = new Date(s);
+        return !isNaN(d.getTime());
+    },
+    "DateValidator"
+);
+
+// TODO: Add all possible right actions. The current implementation is missing
+//      - Confirming an existing right
+//      - Removing a right
+export const ItemRightActionT = t.intersection([
+    t.type({
+        action: t.union([t.literal("add"), t.literal("expire")]),
+    }),
+    t.partial({
+        manageKey: t.string,
+        accessType: t.union([
+            t.literal("view"),
+            t.literal("edit"),
+            t.literal("teacher"),
+            t.literal("see_answers"),
+            t.literal("manage"),
+            // Don't allow owner for now via JSRunner as it can maybe be a security issue
+        ]),
+        accessibleFrom: DateString,
+        accessibleTo: DateString,
+    }),
+]);
 
 // const dummyGTools: GTools = new GTools(
 
@@ -1030,6 +1062,7 @@ export class GTools extends ToolsBase {
     public stats: Record<string, Stats> = {};
     public tools: Tools;
     groups: IGroupData = {};
+    itemRightActions: IItemRightActionData[] = [];
     newUsers: NewUserData[] = [];
 
     constructor(
@@ -1178,6 +1211,33 @@ export class GTools extends ToolsBase {
             this.groups[key] = v;
         }
         v[name] = uids;
+    }
+
+    /**
+     * Adds a right action to be performed on an item (document or folder).
+     *
+     * The action will be performed after JSRunner has finished.
+     *
+     * @param item Item to which to apply the action (can be either a path or an ID).
+     * @param group Group name on which to perform the action.
+     * @param action Action to perform. This is an object with the following fields:
+     *              - action: Right action type. Available actions are "add" (adds a new right) or "expire" (expires an existing right).
+     *              - manageKey (optional): Management key of the document. Only required if the user executing the JSRunner does not have at least Manage right to the target item.
+     *              - accessType (optional): Access type to apply. Available types are "view", "edit", "teacher", "see_answers" and "manage". Default: "view".
+     *              - accessibleFrom (optional): Date string (ISO format) from which the right is valid. Default: now.
+     *              - accessibleTo (optional): Date string (ISO format) until which the right is valid. Default: never.
+     */
+    addItemRightAction(item: unknown, group: unknown, action: unknown) {
+        if (!checkString(item)) {
+            throw genericTypeError("item", item);
+        }
+        if (!checkString(group)) {
+            throw genericTypeError("group", group);
+        }
+        if (!ItemRightActionT.is(action)) {
+            throw genericTypeError("action", action);
+        }
+        this.itemRightActions.push({item, group, ...action});
     }
 }
 

--- a/timApp/modules/jsrunner/server/routes/tools.ts
+++ b/timApp/modules/jsrunner/server/routes/tools.ts
@@ -220,9 +220,9 @@ const DateString = t.brand(
 export const ItemRightActionT = t.intersection([
     t.type({
         action: t.union([t.literal("add"), t.literal("expire")]),
+        manageKey: t.string,
     }),
     t.partial({
-        manageKey: t.string,
         accessType: t.union([
             t.literal("view"),
             t.literal("edit"),
@@ -1222,7 +1222,7 @@ export class GTools extends ToolsBase {
      * @param group Group name on which to perform the action.
      * @param action Action to perform. This is an object with the following fields:
      *              - action: Right action type. Available actions are "add" (adds a new right) or "expire" (expires an existing right).
-     *              - manageKey (optional): Management key of the document. Only required if the user executing the JSRunner does not have at least Manage right to the target item.
+     *              - manageKey: Management key of the document. This must be provided to set the rights.
      *              - accessType (optional): Access type to apply. Available types are "view", "edit", "teacher", "see_answers" and "manage". Default: "view".
      *              - accessibleFrom (optional): Date string (ISO format) from which the right is valid. Default: now.
      *              - accessibleTo (optional): Date string (ISO format) until which the right is valid. Default: never.

--- a/timApp/modules/jsrunner/shared/jsrunnertypes.ts
+++ b/timApp/modules/jsrunner/shared/jsrunnertypes.ts
@@ -5,7 +5,11 @@ import {
     IncludeUsersOption,
     withDefault,
 } from "tim/plugin/attributes";
-import type {IToolsResult, NewUserData} from "../server/routes/tools";
+import type {
+    ItemRightActionT,
+    IToolsResult,
+    NewUserData,
+} from "../server/routes/tools";
 
 export {IncludeUsersOption} from "tim/plugin/attributes";
 
@@ -62,6 +66,12 @@ export interface IGroupData {
     remove?: Record<string, number[]>;
 }
 
+export interface IItemRightActionData
+    extends t.TypeOf<typeof ItemRightActionT> {
+    item: string;
+    group: string;
+}
+
 export interface IError {
     msg: string;
     stackTrace?: string;
@@ -89,6 +99,7 @@ interface AnswerReturnSuccess {
     };
     savedata: IToolsResult[];
     groups: IGroupData;
+    itemRightActions: IItemRightActionData[];
     newUsers: NewUserData[];
 }
 


### PR DESCRIPTION
Jatkoa PR:lle #3365 

Kortti on osa SUKOL-tehtäviä (#3199), joten tämä toteuttaa vain välttämättömät toiminnot saadakseen vaatimukset täytettyä.

Lisää `gtools.addItemRightAction`, jolla voi ohjelmallisesti antaa tai umpeuttaa dokumenttioikeuksia. 
Rajoitukset:
  * Funktiolla ei voi antaa owner-oikeuksia välttääkseen väärinkäyttöä
  * Kohdedokumentissa tulee olla asetettuna `manageKey`-dokumenttiasetus, jolla sallitaan oikeuksien muokkaamista. Tämä tehty välttääkseen JSRunnereiden väärinkäyttöä kunnes saadaan kehitettyä parempi järjestelmä pluginien oikeuksien hallintaan.
  * Toistaiseksi tuetaan vain oikeuksien lisääminen ja umpeuttaminen, mikä riittää SUKOL-käyttöön. Jatkossa muutkin oikeustyypit sekä oikeuksien konfirmointi voitaisiin sallia.

Esimerkki: <https://timdevs01-2.it.jyu.fi/view/users/admin-1-test/test-perms> (testuser1, testuser2, admin1)