### PR TITLE
Peerreview input UI

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7986,6 +7986,14 @@
           <context context-type="linenumber">241,242</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1295614462098694869" datatype="html">
+        <source>Preview</source>
+        <target state="translated">Esikatsele</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">213</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7867,11 +7867,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="4518343884091856656" datatype="html">
-        <source><x id="START_LINK" ctype="x-a" equiv-text="ocusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</source>
-        <target state="translated"><x id="START_LINK" ctype="x-a" equiv-text="ocusMe>"/>Virkistä sivu<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> jatkaaksesi.</target>
+        <source><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</source>
+        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">306,307</context>
+          <context context-type="linenumber">312,314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6393364220046549775" datatype="html">
@@ -7946,36 +7946,44 @@
           <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4458576809160517635" datatype="html">
-        <source> (no points given)</source>
-        <target state="translated"> (ei annettuja pisteitä)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
-          <context context-type="linenumber">203</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3365234171765176059" datatype="html">
-        <source> (average of <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> reviews)</source>
-        <target state="translated"> (keskiarvo <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> arvioinnista)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
-          <context context-type="linenumber">204,205</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8484486376764744044" datatype="html">
-        <source> (no reviews given)</source>
-        <target state="translated"> (ei annettuja arviointeja)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
-          <context context-type="linenumber">205</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4252733983010879653" datatype="html">
         <source>Save your review</source>
         <target state="translated">Tallenna arviointisi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/templates/answerBrowser.html</context>
           <context context-type="linenumber">226,227</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4958705091035749812" datatype="html">
+        <source>(no reviews given)</source>
+        <target state="translated">(ei annettuja arviointeja)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answer-browser.component.ts</context>
+          <context context-type="linenumber">1547,1545</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6796532343204294212" datatype="html">
+        <source>Add your review</source>
+        <target state="translated">Anna arviointisi</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">210,212</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5047027031469424130" datatype="html">
+        <source>(no points given)</source>
+        <target state="translated">(ei annettuja pisteitä)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">240</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5993276252268776410" datatype="html">
+        <source>(average of <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> reviews)</source>
+        <target state="translated">(keskiarvo <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> arvioinnista)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">241,242</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7868,7 +7868,7 @@
       </trans-unit>
       <trans-unit id="4518343884091856656" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</source>
-        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</target>
+        <target state="translated"><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Virkistä sivu<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> jatkaaksesi.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">312,314</context>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7888,6 +7888,14 @@
           <context context-type="linenumber">241,242</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1295614462098694869" datatype="html">
+        <source>Preview</source>
+        <target state="translated">Förhandsvisa</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">213</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7770,7 +7770,7 @@
       </trans-unit>
       <trans-unit id="4518343884091856656" datatype="html">
         <source><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</source>
-        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</target>
+        <target state="translated"><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Uppdatera<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> sidan för att fortsätta.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
           <context context-type="linenumber">312,314</context>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -7769,11 +7769,11 @@
         </context-group>
       </trans-unit>
       <trans-unit id="4518343884091856656" datatype="html">
-        <source><x id="START_LINK" ctype="x-a" equiv-text="ocusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</source>
-        <target state="translated"><x id="START_LINK" ctype="x-a" equiv-text="ocusMe>"/>Uppdatera<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> sidan för att fortsätta.</target>
+        <source><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</source>
+        <target state="new"><x id="START_LINK" ctype="x-a" equiv-text="focusMe>"/>Refresh<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> the page to continue.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/login-dialog.component.ts</context>
-          <context context-type="linenumber">306,307</context>
+          <context context-type="linenumber">312,314</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6393364220046549775" datatype="html">
@@ -7848,36 +7848,44 @@
           <context context-type="linenumber">201</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4458576809160517635" datatype="html">
-        <source> (no points given)</source>
-        <target state="translated"> (inga poäng ges)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
-          <context context-type="linenumber">203</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3365234171765176059" datatype="html">
-        <source> (average of <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> reviews)</source>
-        <target state="translated"> (genomsnitt av <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> recensioner)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
-          <context context-type="linenumber">204,205</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8484486376764744044" datatype="html">
-        <source> (no reviews given)</source>
-        <target state="translated"> (inga recensioner ges)</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
-          <context context-type="linenumber">205</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4252733983010879653" datatype="html">
         <source>Save your review</source>
         <target state="translated">Spara din recension</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/templates/answerBrowser.html</context>
           <context context-type="linenumber">226,227</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4958705091035749812" datatype="html">
+        <source>(no reviews given)</source>
+        <target state="translated">(inga recensioner ges)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/answer-browser.component.ts</context>
+          <context context-type="linenumber">1547,1545</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6796532343204294212" datatype="html">
+        <source>Add your review</source>
+        <target state="translated">Lägg till din recension</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">210,212</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5047027031469424130" datatype="html">
+        <source>(no points given)</source>
+        <target state="translated">(inga poäng ges)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">240</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5993276252268776410" datatype="html">
+        <source>(average of <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> reviews)</source>
+        <target state="translated">(genomsnitt av <x id="INTERPOLATION" equiv-text="{{peerReviews.length}}"/> recensioner)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/templates/answerBrowser.html</context>
+          <context context-type="linenumber">241,242</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -157,8 +157,16 @@ export class AnswerBrowserComponent
     @Input() public taskId!: TaskId;
     @ViewChild("modelAnswerDiv") modelAnswerRef?: ElementRef<HTMLDivElement>;
     @ViewChild("feedback") feedBackElement?: ElementRef<HTMLDivElement>;
-    @ViewChild("peerReviewContentDiv")
-    peerReviewElement?: ElementRef<HTMLDivElement>;
+    peerReviewElementRef?: ElementRef<HTMLDivElement>;
+    @ViewChild("peerReviewContentDiv") set peerReviewContentDiv(
+        el: ElementRef<HTMLDivElement> | undefined
+    ) {
+        if (!el || this.peerReviewElementRef == el) {
+            return;
+        }
+        this.peerReviewElementRef = el;
+        ParCompiler.processAllMath($(el.nativeElement));
+    }
     loading: number; // Answerbrowser is fetching data
     updating = false; // Plugin html is reloading
     viewctrl!: Require<ViewCtrl>;
@@ -1540,9 +1548,9 @@ export class AnswerBrowserComponent
             }
             this.savedReviewPoints = this.reviewPoints;
             this.savedReviewComment = this.reviewComment;
-            if (!this.isPeerReview && this.peerReviewElement) {
+            if (!this.isPeerReview && this.peerReviewElementRef) {
                 ParCompiler.processAllMathDelayed(
-                    $(this.peerReviewElement.nativeElement)
+                    $(this.peerReviewElementRef.nativeElement)
                 );
             }
         }

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1578,7 +1578,7 @@ export class AnswerBrowserComponent
         }
         this.refreshPeerReview();
     }
-    peerReviewLoaded = false;
+
     refreshPeerReview() {
         if (this.hasPeerReviewers || this.isPeerReview) {
             this.filteredPeerReviews = this.peerReviews.filter(
@@ -1609,7 +1609,6 @@ export class AnswerBrowserComponent
             }
             this.savedReviewPoints = this.reviewPoints;
             this.savedReviewComment = this.reviewComment;
-            this.peerReviewLoaded = true;
             this.renderPeerReviewMath();
         }
     }

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -222,6 +222,7 @@ export class AnswerBrowserComponent
     formMode = false;
     showBrowseAnswers = true;
     isPeerReview = false;
+    previewingPeerReview = false;
     peerReviewEnabled = false;
     showNewTask = false;
     buttonNewTask = $localize`New task`;
@@ -1548,7 +1549,7 @@ export class AnswerBrowserComponent
             }
             this.savedReviewPoints = this.reviewPoints;
             this.savedReviewComment = this.reviewComment;
-            if (!this.isPeerReview && this.peerReviewElementRef) {
+            if (this.peerReviewElementRef) {
                 ParCompiler.processAllMathDelayed(
                     $(this.peerReviewElementRef.nativeElement)
                 );

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -157,6 +157,8 @@ export class AnswerBrowserComponent
     @Input() public taskId!: TaskId;
     @ViewChild("modelAnswerDiv") modelAnswerRef?: ElementRef<HTMLDivElement>;
     @ViewChild("feedback") feedBackElement?: ElementRef<HTMLDivElement>;
+    @ViewChild("peerReviewContentDiv")
+    peerReviewElement?: ElementRef<HTMLDivElement>;
     loading: number; // Answerbrowser is fetching data
     updating = false; // Plugin html is reloading
     viewctrl!: Require<ViewCtrl>;
@@ -1529,13 +1531,20 @@ export class AnswerBrowserComponent
                     ) / this.filteredPeerReviews.length;
                 this.reviewComment = this.filteredPeerReviews
                     .map((r) => r.comment)
-                    .join("\n---\n");
+                    .join("\n\n---\n\n");
             } else {
                 this.reviewPoints = undefined;
-                this.reviewComment = undefined;
+                this.reviewComment = this.isPeerReview
+                    ? undefined
+                    : $localize`(no reviews given)`;
             }
             this.savedReviewPoints = this.reviewPoints;
             this.savedReviewComment = this.reviewComment;
+            if (!this.isPeerReview && this.peerReviewElement) {
+                ParCompiler.processAllMathDelayed(
+                    $(this.peerReviewElement.nativeElement)
+                );
+            }
         }
     }
 

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -209,6 +209,9 @@ export class AnswerBrowserComponent
         }
         el.style.height = this.peerReviewResizeHeight;
         el.style.width = this.peerReviewResizeWidth;
+        if (this.previewingPeerReview) {
+            this.renderPeerReviewMath();
+        }
     }
 
     savePeerReviewResize() {
@@ -1607,11 +1610,15 @@ export class AnswerBrowserComponent
             this.savedReviewPoints = this.reviewPoints;
             this.savedReviewComment = this.reviewComment;
             this.peerReviewLoaded = true;
-            if (this.peerReviewElementRef) {
-                ParCompiler.processAllMathDelayed(
-                    $(this.peerReviewElementRef.nativeElement)
-                );
-            }
+            this.renderPeerReviewMath();
+        }
+    }
+
+    renderPeerReviewMath() {
+        if (this.peerReviewElementRef) {
+            ParCompiler.processAllMathDelayed(
+                $(this.peerReviewElementRef.nativeElement)
+            );
         }
     }
 

--- a/timApp/static/scripts/tim/header/header.component.ts
+++ b/timApp/static/scripts/tim/header/header.component.ts
@@ -21,7 +21,7 @@ import type {
 import {TagType} from "tim/item/IItem";
 import {Users} from "tim/user/userService";
 import {genericglobals, someglobals} from "tim/util/globals";
-import {getViewName, to} from "tim/util/utils";
+import {getUrlParams, getViewName, to} from "tim/util/utils";
 
 /**
  * Checks if the tag type is course code.
@@ -127,7 +127,19 @@ export class HeaderComponent implements OnInit {
         if (!this.item) {
             return "";
         }
-        return `/${link.route}/${this.item.path}${location.search}`;
+        return `/${link.route}/${this.item.path}${this.sanitizeSearch()}`;
+    }
+
+    sanitizeSearch(): string {
+        if (getViewName() != "review") {
+            return location.search;
+        } else {
+            const urlParams = getUrlParams();
+            urlParams.delete("b");
+            urlParams.delete("size");
+            const str = urlParams.toString();
+            return `${str.length > 0 ? "?" : ""}${str}`;
+        }
     }
 
     getMainCourseDocPath() {

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -1248,26 +1248,19 @@ p.docsettings {
     width: 100%;
 }
 
-.peer-review-resize-area{
-    width: 100%;
-    height: 6em;
-    resize: both;
-    overflow-y: auto;
-    padding: 2px;
-    border: 1px solid;
-}
 .peer-review-text {
     width: 100%;
-    resize: none;
-    height: 100%;
-    overflow: hidden;
-    border: none;
+    resize: both;
+    border: 1px solid;
 }
 
 .peer-review-render{
     padding: 2px;
     white-space: break-spaces;
-    height: 100%;
+    overflow-y: auto;
+    resize: both;
+    border: 1px solid;
+    height: 10em
 }
 
 .less-opacity {

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -1244,17 +1244,30 @@ p.docsettings {
     display: inline;
 }
 
-.peer-review-area {
+.peer-review-area{
     width: 100%;
+}
+
+.peer-review-resize-area{
+    width: 100%;
+    height: 6em;
+    resize: both;
+    overflow-y: auto;
+    padding: 2px;
+    border: 1px solid;
+}
+.peer-review-text {
+    width: 100%;
+    resize: none;
+    height: 100%;
+    overflow: hidden;
+    border: none;
 }
 
 .peer-review-render{
     padding: 2px;
-    resize: both;
-    white-space: pre-line;
-    height: 6em;
-    border: 1px solid;
-    overflow-y: scroll
+    white-space: break-spaces;
+    height: 100%;
 }
 
 .less-opacity {

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -1248,6 +1248,15 @@ p.docsettings {
     width: 100%;
 }
 
+.peer-review-render{
+    padding: 2px;
+    resize: both;
+    white-space: pre-line;
+    height: 6em;
+    border: 1px solid;
+    overflow-y: scroll
+}
+
 .less-opacity {
     opacity: 0.66;
 }

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -1256,7 +1256,7 @@ p.docsettings {
 
 .peer-review-render{
     padding: 2px;
-    white-space: break-spaces;
+    white-space: pre-wrap;
     overflow-y: auto;
     resize: both;
     border: 1px solid;

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -201,8 +201,16 @@
                                     <ng-container i18n>Peer review: </ng-container>
                                 </label>
                                <div class="peer-review-area">
-                                    <textarea class="peer-review-area" [(ngModel)]="reviewComment" *ngIf="isPeerReview" rows="2" name="reviewComment" [placeholder]="isPeerReview ? 'Add your review' : 'No review given'"></textarea>
-                                    <div #peerReviewContentDiv class="peer-review-render math" [innerHtml]="reviewComment | purify" *ngIf="!isPeerReview"></div>
+                                <textarea class="peer-review-area"
+                                          (keydown.control.s)="$event.preventDefault(); saveReview()"
+                                          (keydown.meta.s)="$event.preventDefault(); saveReview()"
+                                          [(ngModel)]="reviewComment" *ngIf="isPeerReview"
+                                          rows="2"
+                                          name="reviewComment"
+                                          [placeholder]="isPeerReview ? 'Add your review' : 'No review given'">
+
+                                </textarea>
+                                <div #peerReviewContentDiv class="peer-review-render math" [innerHtml]="reviewComment | purify" *ngIf="!isPeerReview"></div>
                                </div>
                                <div class="ab-option-row">
                                    <span><ng-container i18n>Points:</ng-container>
@@ -213,6 +221,8 @@
                                                   (blur)="shouldFocus = false"
                                                   [(ngModel)]="reviewPoints"
                                                   (keydown)="handlePointScroll($event)"
+                                                  (keydown.control.s)="$event.preventDefault(); saveReview()"
+                                                  (keydown.meta.s)="$event.preventDefault(); saveReview()"
                                                   [disabled]="!isPeerReview"
                                                   name="reviewPoints"
                                                   type="number"

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -197,24 +197,28 @@
                     </div><!-- end flex-->
                  <div class="flex review-row">
                            <form (ngSubmit)="saveReview()" *ngIf="hasPeerReviewers || isPeerReview" class="point-form peer-review-area form-inline">
-                                <label class="inline">
-                                    <ng-container i18n>Peer review: </ng-container>
-                                </label>
-                               <ng-container *ngIf="isPeerReview">
-                                    <label class="radio-inline"><input [(ngModel)]="previewingPeerReview"
-                                               name="previewingPeerReview"
-                                               [value]="false"
-                                               (ngModelChange)="peerReviewPreviewChanged()"
-                                           type="radio"> <ng-container i18n>Edit</ng-container>
-                                   </label>
-                                    <label class="radio-inline">
-                                    <input [(ngModel)]="previewingPeerReview"
-                                               name="previewingPeerReview"
-                                               [value]="true"
-                                                (ngModelChange)="peerReviewPreviewChanged()"
-                                           type="radio"> <ng-container i18n>Preview</ng-container>
-                                   </label>
-                               </ng-container>
+                               <span class="ab-option-row">
+                                   <span>
+                                       <label class="inline">
+                                            <ng-container i18n>Peer review: </ng-container>
+                                        </label>
+                                   </span>
+                                   <span *ngIf="isPeerReview">
+                                        <label class="radio-inline"><input [(ngModel)]="previewingPeerReview"
+                                                   name="previewingPeerReview"
+                                                   [value]="false"
+                                                   (ngModelChange)="peerReviewPreviewChanged()"
+                                               type="radio"> <ng-container i18n>Edit</ng-container>
+                                       </label>
+                                        <label class="radio-inline">
+                                        <input [(ngModel)]="previewingPeerReview"
+                                                   name="previewingPeerReview"
+                                                   [value]="true"
+                                                    (ngModelChange)="peerReviewPreviewChanged()"
+                                               type="radio"> <ng-container i18n>Preview</ng-container>
+                                       </label>
+                                   </span>
+                               </span>
                                <div class="peer-review-area">
                                     <textarea i18n-placeholder class="peer-review-text"
                                               #peerReviewEditArea

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -200,11 +200,9 @@
                                 <label class="inline">
                                     <ng-container i18n>Peer review: </ng-container>
                                 </label>
-                                <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length == 1 && this.reviewPoints == undefined"> (no points given)</ng-container>
-                                <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length > 1"> (average of {{peerReviews.length}} reviews)</ng-container>
-                                <ng-container i18n *ngIf="!isPeerReview && filteredPeerReviews.length == 0"> (no reviews given)</ng-container>
                                <div class="peer-review-area">
-                                    <textarea class="peer-review-area" [(ngModel)]="reviewComment" [disabled]="!isPeerReview" rows="2" name="reviewComment" [placeholder]="isPeerReview ? 'Add your review' : 'No review given'"></textarea>
+                                    <textarea class="peer-review-area" [(ngModel)]="reviewComment" *ngIf="isPeerReview" rows="2" name="reviewComment" [placeholder]="isPeerReview ? 'Add your review' : 'No review given'"></textarea>
+                                    <div #peerReviewContentDiv class="peer-review-render math" [innerHtml]="reviewComment | purify" *ngIf="!isPeerReview"></div>
                                </div>
                                <div class="ab-option-row">
                                    <span><ng-container i18n>Points:</ng-container>
@@ -227,6 +225,9 @@
                                            class="timButton btn-xs"
                                            *ngIf="isPeerReview"
                                            [disabled]="reviewPoints == savedReviewPoints && reviewComment == savedReviewComment">Save your review</button>
+                                    <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length == 1 && this.reviewPoints == undefined"> (no points given)</ng-container>
+                                    <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length > 1"> (average of {{peerReviews.length}} reviews)</ng-container>
+                                    <ng-container i18n *ngIf="!isPeerReview && filteredPeerReviews.length == 0"> (no reviews given)</ng-container>
                                </div>
                             </form>
                  </div>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -201,16 +201,19 @@
                                     <ng-container i18n>Peer review: </ng-container>
                                 </label>
                                <ng-container *ngIf="isPeerReview">
-                                    <input [(ngModel)]="previewingPeerReview"
+                                    <label class="radio-inline"><input [(ngModel)]="previewingPeerReview"
                                                name="previewingPeerReview"
                                                [value]="false"
                                                (ngModelChange)="peerReviewPreviewChanged()"
-                                               type="radio"> Edit
+                                           type="radio"> <ng-container i18n>Edit</ng-container>
+                                   </label>
+                                    <label class="radio-inline">
                                     <input [(ngModel)]="previewingPeerReview"
                                                name="previewingPeerReview"
                                                [value]="true"
                                                 (ngModelChange)="peerReviewPreviewChanged()"
-                                               type="radio"> Preview
+                                           type="radio"> <ng-container i18n>Preview</ng-container>
+                                   </label>
                                </ng-container>
                                <div class="peer-review-area">
                                     <textarea i18n-placeholder class="peer-review-text"

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -200,18 +200,27 @@
                                 <label class="inline">
                                     <ng-container i18n>Peer review: </ng-container>
                                 </label>
-                               <div class="peer-review-area">
-                                <textarea i18n-placeholder class="peer-review-area"
+                               <ng-container *ngIf="isPeerReview">
+                                    <input [(ngModel)]="previewingPeerReview"
+                                               name="previewingPeerReview"
+                                               [value]="false"
+                                               type="radio"> Edit
+                                    <input [(ngModel)]="previewingPeerReview"
+                                               name="previewingPeerReview"
+                                               [value]="true"
+                                               type="radio"> Preview
+                               </ng-container>
+                               <div class="peer-review-resize-area">
+                                <textarea i18n-placeholder class="peer-review-text"
                                           (keydown.control.s)="$event.preventDefault(); saveReview()"
                                           (keydown.meta.s)="$event.preventDefault(); saveReview()"
-                                          [(ngModel)]="reviewComment" *ngIf="isPeerReview"
+                                          [(ngModel)]="reviewComment" *ngIf="isPeerReview && !previewingPeerReview"
                                           rows="2"
                                           name="reviewComment"
                                           placeholder="Add your review">
-
                                 </textarea>
-                                   <div #peerReviewContentDiv *ngIf="!isPeerReview">
-                                       <div class="peer-review-render math" [innerHtml]="reviewComment | purify"></div>
+                                   <div #peerReviewContentDiv class="peer-review-render" *ngIf="!isPeerReview || previewingPeerReview">
+                                       <div class="math" [innerHtml]="reviewComment | purify"></div>
                                    </div>
                                </div>
                                <div class="ab-option-row">
@@ -237,6 +246,7 @@
                                            class="timButton btn-xs"
                                            *ngIf="isPeerReview"
                                            [disabled]="reviewPoints == savedReviewPoints && reviewComment == savedReviewComment">Save your review</button>
+
                                     <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length == 1 && this.reviewPoints == undefined">(no points given)</ng-container>
                                     <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length > 1">(average of {{peerReviews.length}} reviews)</ng-container>
                                     <ng-container i18n *ngIf="!isPeerReview && filteredPeerReviews.length == 0">(no reviews given)</ng-container>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -201,13 +201,13 @@
                                     <ng-container i18n>Peer review: </ng-container>
                                 </label>
                                <div class="peer-review-area">
-                                <textarea class="peer-review-area"
+                                <textarea i18n-placeholder class="peer-review-area"
                                           (keydown.control.s)="$event.preventDefault(); saveReview()"
                                           (keydown.meta.s)="$event.preventDefault(); saveReview()"
                                           [(ngModel)]="reviewComment" *ngIf="isPeerReview"
                                           rows="2"
                                           name="reviewComment"
-                                          [placeholder]="isPeerReview ? 'Add your review' : 'No review given'">
+                                          placeholder="Add your review">
 
                                 </textarea>
                                    <div #peerReviewContentDiv *ngIf="!isPeerReview">
@@ -237,9 +237,9 @@
                                            class="timButton btn-xs"
                                            *ngIf="isPeerReview"
                                            [disabled]="reviewPoints == savedReviewPoints && reviewComment == savedReviewComment">Save your review</button>
-                                    <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length == 1 && this.reviewPoints == undefined"> (no points given)</ng-container>
-                                    <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length > 1"> (average of {{peerReviews.length}} reviews)</ng-container>
-                                    <ng-container i18n *ngIf="!isPeerReview && filteredPeerReviews.length == 0"> (no reviews given)</ng-container>
+                                    <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length == 1 && this.reviewPoints == undefined">(no points given)</ng-container>
+                                    <ng-container i18n *ngIf="!isPeerReview && this.filteredPeerReviews.length > 1">(average of {{peerReviews.length}} reviews)</ng-container>
+                                    <ng-container i18n *ngIf="!isPeerReview && filteredPeerReviews.length == 0">(no reviews given)</ng-container>
                                </div>
                             </form>
                  </div>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -210,7 +210,9 @@
                                           [placeholder]="isPeerReview ? 'Add your review' : 'No review given'">
 
                                 </textarea>
-                                <div #peerReviewContentDiv class="peer-review-render math" [innerHtml]="reviewComment | purify" *ngIf="!isPeerReview"></div>
+                                   <div #peerReviewContentDiv *ngIf="!isPeerReview">
+                                       <div class="peer-review-render math" [innerHtml]="reviewComment | purify"></div>
+                                   </div>
                                </div>
                                <div class="ab-option-row">
                                    <span><ng-container i18n>Points:</ng-container>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -204,22 +204,26 @@
                                     <input [(ngModel)]="previewingPeerReview"
                                                name="previewingPeerReview"
                                                [value]="false"
+                                               (ngModelChange)="peerReviewPreviewChanged()"
                                                type="radio"> Edit
                                     <input [(ngModel)]="previewingPeerReview"
                                                name="previewingPeerReview"
                                                [value]="true"
+                                                (ngModelChange)="peerReviewPreviewChanged()"
                                                type="radio"> Preview
                                </ng-container>
-                               <div class="peer-review-resize-area">
-                                <textarea i18n-placeholder class="peer-review-text"
-                                          (keydown.control.s)="$event.preventDefault(); saveReview()"
-                                          (keydown.meta.s)="$event.preventDefault(); saveReview()"
-                                          [(ngModel)]="reviewComment" *ngIf="isPeerReview && !previewingPeerReview"
-                                          rows="2"
-                                          name="reviewComment"
-                                          placeholder="Add your review">
-                                </textarea>
-                                   <div #peerReviewContentDiv class="peer-review-render" *ngIf="!isPeerReview || previewingPeerReview">
+                               <div class="peer-review-area">
+                                    <textarea i18n-placeholder class="peer-review-text"
+                                              #peerReviewEditArea
+                                              (keydown.control.s)="$event.preventDefault(); saveReview()"
+                                              (keydown.meta.s)="$event.preventDefault(); saveReview()"
+                                              [(ngModel)]="reviewComment"
+                                              [hidden]="!isPeerReview || previewingPeerReview"
+                                              rows="6"
+                                              name="reviewComment"
+                                              placeholder="Add your review">
+                                    </textarea>
+                                   <div #peerReviewContentDiv class="peer-review-render" [hidden]="isPeerReview && !previewingPeerReview">
                                        <div class="math" [innerHtml]="reviewComment | purify"></div>
                                    </div>
                                </div>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -115,7 +115,7 @@
                                     <i class="glyphicon glyphicon-ok"></i>
                                 </button>
                             </form>
-<!--in ab-option-row span elements have right margin, use div if selecting multiple elements for *ngIf -->
+<!--in ab-option-row span elements have right margin-->
                             <div *ngIf="selectedAnswer">
 
                             <span class="inline" *ngIf="points !== null && !(showTeacher() || (giveCustomPoints && allowCustomPoints())) && taskInfo?.pointsText">
@@ -195,7 +195,7 @@
                         </div>
                         </span>
                     </div><!-- end flex-->
-                 <div class="flex ab-option-row review-row">
+                 <div class="flex review-row">
                            <form (ngSubmit)="saveReview()" *ngIf="hasPeerReviewers || isPeerReview" class="point-form peer-review-area form-inline">
                                 <label class="inline">
                                     <ng-container i18n>Peer review: </ng-container>


### PR DESCRIPTION
Lisää selainpohjaisen matikkarenderöinnin vertaisarviointikenttiin. Tätä varten vertaisarviointinäkymässä on "preview"-valinta jolla voi esikatsella matikkaa. Tuota pitäisi myöhemmin hienosäätää niin että esikatselu sekä muokkaus olisivat selkeästi erinäköiset (esikatselu aukeaisi kelluvaan ikkunaan, erilainen tausta tms). Toistaikseksi vain selainrenderöinti, eli markdown ja svg-matikka pitää tehdä myöhemmin.

Lisäksi vertaisarviointinäkymässä ei lisätä enää b tai size -urlparametreja timin valikkolinkkeihin

https://timdevs01-3.it.jyu.fi/view/pr_input