### PR TITLE
Migrate containers to GHCR

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,11 +1,25 @@
 name: Check formatting
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+        - id: skip_check
+          uses: fkirc/skip-duplicate-actions@v5
+          with:
+              concurrent_skipping: 'same_content_newer'
+              skip_after_successful_duplicate: 'true'
+
   ts_format:
     name: Check TypeScript formatting
     runs-on: ubuntu-latest
+
+    needs: skip_check
+    if: needs.skip_check.outputs.should_skip != 'true'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,25 @@
 name: Lint code
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+        - id: skip_check
+          uses: fkirc/skip-duplicate-actions@v5
+          with:
+              concurrent_skipping: 'same_content_newer'
+              skip_after_successful_duplicate: 'true'
+
   ts_lint:
     name: Lint TypeScript
     runs-on: ubuntu-latest
+
+    needs: skip_check
+    if: needs.skip_check.outputs.should_skip != 'true'
 
     steps:
       - uses: actions/checkout@v3
@@ -33,6 +47,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: "3.10"
+
+    needs: skip_check
+    if: needs.skip_check.outputs.should_skip != 'true'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,11 +1,26 @@
 name: Check spelling
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+        - id: skip_check
+          uses: fkirc/skip-duplicate-actions@v5
+          with:
+              concurrent_skipping: 'same_content_newer'
+              skip_after_successful_duplicate: 'true'
+
   check_spelling:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+
+    needs: skip_check
+    if: needs.skip_check.outputs.should_skip != 'true'
+
     steps:
       - uses: actions/checkout@v3
       - name: Check spelling of repository files

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,11 +1,25 @@
 name: Generate code statistics
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+        - id: skip_check
+          uses: fkirc/skip-duplicate-actions@v5
+          with:
+              concurrent_skipping: 'same_content_newer'
+              skip_after_successful_duplicate: 'true'
+
   ts_bundle_stats:
     name: Bundle stats for TypeScript
     runs-on: ubuntu-latest
+
+    needs: skip_check
+    if: needs.skip_check.outputs.should_skip != 'true'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,25 @@
 name: Run tests
 
-on: push
+on: [push, pull_request]
 
 jobs:
+  skip_check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+        - id: skip_check
+          uses: fkirc/skip-duplicate-actions@v5
+          with:
+              concurrent_skipping: 'same_content_newer'
+              skip_after_successful_duplicate: 'true'
+
   ci_tests:
     name: CI tests (${{ matrix.test_module }})
     runs-on: ubuntu-latest
+
+    needs: skip_check
+    if: needs.skip_check.outputs.should_skip != 'true'
 
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
           submodules: true
       - name: Cache Angular build assets
         uses: actions/cache@v3
+        if: "${{ matrix.test_module == 'browser' }}"
         with:
           path: timApp/.angular/cache
           key: ${{ runner.os }}-angular-cache-${{ hashFiles('**/*.ts') }}
@@ -28,6 +29,7 @@ jobs:
             ${{ runner.os }}-angular-cache-
       - name: Cache node modules
         uses: actions/cache@v3
+        if: "${{ matrix.test_module == 'browser' || matrix.test_module == 'server'  }}"
         with:
           path: |
             timApp/node_modules
@@ -43,9 +45,11 @@ jobs:
       - name: Download images
         run: ./tim dc pull --quiet
       - name: Install dependencies
+        if: "${{ matrix.test_module == 'browser' || matrix.test_module == 'server'  }}"
         run: ./tim npmi
       - name: Compile JS
-        run: ./tim js
+        if: "${{ matrix.test_module == 'browser' || matrix.test_module == 'server'  }}"
+        run: ./tim js --target ${{ matrix.test_module }}
       - name: Run tests
         run: ./tim test --dc-up ${{ matrix.test_module }}
         timeout-minutes: 40

--- a/cli/commands/dev/build.py
+++ b/cli/commands/dev/build.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 from typing import List, Optional, Callable, Dict, NamedTuple
 
+from cli.config import get_config
 from cli.docker.run import run_docker
 from cli.docker.service_variables import tim_image_tag, csplugin_image_tag
 from cli.util.logging import log_info
@@ -27,7 +28,8 @@ If no tag is specified, the task is built with all tags.
 
 
 def build_tim(_: Optional[str], no_cache: bool) -> Optional[str]:
-    image_name = f"timimages/tim:{tim_image_tag()}"
+    config = get_config()
+    image_name = f"{config.images_repository}/tim:{tim_image_tag()}"
     cwd = Path.cwd()
     dockerfile = cwd / "timApp" / "Dockerfile"
     run_docker(
@@ -46,7 +48,8 @@ def build_tim(_: Optional[str], no_cache: bool) -> Optional[str]:
 
 def build_csplugin(tag: Optional[str], no_cache: bool) -> Optional[str]:
     assert tag is not None
-    image_name = f"timimages/cs3:{tag}-{csplugin_image_tag()}"
+    config = get_config()
+    image_name = f"{config.images_repository}/cs3:{tag}-{csplugin_image_tag()}"
     context = Path.cwd() / "timApp" / "modules" / "cs"
     run_docker(
         [

--- a/cli/commands/js.py
+++ b/cli/commands/js.py
@@ -10,19 +10,22 @@ info = {"help": "Compile JavaScript files for production mode"}
 
 class Arguments:
     npmi: bool
+    target: str
     args: List[str]
 
 
-def js(run_npmi: bool, extra_args: List[str]) -> None:
+def js(run_npmi: bool, extra_args: List[str], target: str = "browser") -> None:
     if run_npmi or needs_npmi():
         log_info("Running `npm install` to install build dependencies.")
         npmi()
-    run_npm(["run", "buildtools"], "timApp/modules/jsrunner/server", True)
-    run_npm(["run", "b", "--", *extra_args], "timApp")
+    if target in ("server", "browser"):
+        run_npm(["run", "buildtools"], "timApp/modules/jsrunner/server", True)
+    if target in ("browser",):
+        run_npm(["run", "b", "--", *extra_args], "timApp")
 
 
 def run(args: Arguments) -> None:
-    js(args.npmi, args.args)
+    js(args.npmi, args.args, args.target)
 
 
 def init(parser: ArgumentParser) -> None:
@@ -30,6 +33,12 @@ def init(parser: ArgumentParser) -> None:
         "--npmi",
         help="Run `npm install` to install TIM dependencies.",
         action="store_true",
+    )
+    parser.add_argument(
+        "--target",
+        help="Build only the specified JS (for server-only or for both).",
+        choices=["server", "browser"],
+        default="browser",
     )
     parser.add_argument(
         "args", nargs=REMAINDER, help="Arguments to pass to docker-compose"

--- a/cli/config/config_file.py
+++ b/cli/config/config_file.py
@@ -45,6 +45,10 @@ class TIMConfig(ConfigParser):
     def host(self) -> str:
         return self.get("tim", "host")
 
+    @property
+    def images_repository(self) -> str:
+        return self.get("compose", "images_repository")
+
     def add_comment(self, section: str, option: str, comment: str) -> None:
         self._comment_lines[(section, option)] = comment.strip()
 

--- a/cli/config/default_config.py
+++ b/cli/config/default_config.py
@@ -36,6 +36,13 @@ Name of the Docker Compose project.
 Modify only if there are multiple TIM instances in the same host.
 """,
         ),
+        "images_repository": (
+            "ghcr.io/tim-jyu",
+            """
+Docker images repository to use when pulling images.
+With this, you can self-host custom images if need-be.
+""",
+        ),
     },
     "tim": {
         "host": (

--- a/cli/templates/docker/docker-compose.tmpl.yml
+++ b/cli/templates/docker/docker-compose.tmpl.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
  tim:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   build:
     dockerfile: ./timApp/Dockerfile
     context: ./
@@ -53,7 +53,7 @@ services:
    - prod
    - dev
  timagent:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   profiles:
    - dev
   command: sleep infinity
@@ -106,7 +106,7 @@ services:
   environment:
    POSTGRES_PASSWORD: postgresql
  csplugin:
-  image: timimages/cs3:${csplugin.target}-${csplugin.image_tag}
+  image: ${compose.images_repository}/cs3:${csplugin.target}-${csplugin.image_tag}
   build:
    context: ./timApp/modules/cs
    target: ${csplugin.target}
@@ -129,7 +129,7 @@ services:
   environment:
    PYTHONUNBUFFERED: "1"
    COMPOSE_PROJECT_NAME: ${COMPOSE_PROJECT_NAME:?}
-   CSPLUGIN_IMAGE_TAG: ${csplugin.target}-${csplugin.image_tag}
+   CSPLUGIN_IMAGE: "${compose.images_repository}/cs3:${csplugin.target}-${csplugin.image_tag}"
    TIM_ROOT: ${default.dir}
    TIM_HOST: ${tim.host}
    CASSANDRA_ENABLED: ${ "1" if csplugin.is_cassandra_enabled else "0" }
@@ -140,13 +140,13 @@ services:
 ${ partial("docker", "csplugin_cassandra.tmpl.yml") if csplugin.is_cassandra_enabled else "" }
 ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled else "" }
  haskellplugins:
-  image: timimages/haskellplugins:2022-10-14-ecb29513e0759a32a49ce5efb4373794f073190e
+  image: ${compose.images_repository}/haskellplugins:2022-10-14-ecb29513e0759a32a49ce5efb4373794f073190e
   restart: unless-stopped
   logging:
    driver: none
   read_only: true
  showfile:
-  image: timimages/cs3:${csplugin.target}-${csplugin.image_tag}
+  image: ${compose.images_repository}/cs3:${csplugin.target}-${csplugin.image_tag}
   volumes:
    - ./timApp/modules/svn:/app/svn:ro
    - ./tim_common:/app/tim_common:ro
@@ -159,7 +159,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   tmpfs:
     - /tmp
  imagex:
-  image: timimages/cs3:${csplugin.target}-${csplugin.image_tag}
+  image: ${compose.images_repository}/cs3:${csplugin.target}-${csplugin.image_tag}
   volumes:
    - ./timApp/modules/imagex:/app/imagex:ro
    - ./tim_common:/app/tim_common:ro
@@ -170,7 +170,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   restart: unless-stopped
   read_only: true
  pali:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   volumes:
    - ./timApp/modules/pali:/app/pali:ro
    - ./tim_common:/app/tim_common:ro
@@ -184,7 +184,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   tmpfs:
    - /tmp
  fields:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   build: ./timApp/modules/fields
   volumes:
    - ./timApp/modules/fields:/app/fields:ro
@@ -198,7 +198,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   tmpfs:
    - /tmp
  jsrunner:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   volumes:
    - ./timApp/modules/jsrunner:/timApp/modules/jsrunner:rw
    - ./timApp/static/scripts:/timApp/static/scripts:ro
@@ -211,7 +211,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
    - /root/.config
    - /tmp
  drag:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   volumes:
    - ./timApp/modules/drag:/app/drag:ro
    - ./tim_common:/app/tim_common:ro
@@ -224,7 +224,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   tmpfs:
    - /tmp
  feedback:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   volumes:
    - ./timApp/modules/feedback:/app/feedback:ro
    - ./tim_common:/app/tim_common:ro
@@ -237,7 +237,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   tmpfs:
    - /tmp
  dumbo:
-  image: timimages/dumbo:latest
+  image: ${compose.images_repository}/dumbo:latest
   volumes:
    - ./Dumbo/cache:/dumbo_cache
    - ./Dumbo/tmp:/dumbo_tmp
@@ -253,7 +253,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   volumes:
    - redis_data:/data
  celery:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   command: celery worker -A timApp.tim_celery.celery --concurrency 4
   profiles:
    - prod
@@ -281,7 +281,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   tmpfs:
    - /tmp
  celery-beat:
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   profiles:
    - prod
    - dev
@@ -317,20 +317,20 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   profiles:
    - prod
    - dev
-  image: timimages/goemaxima:2020113001-latest
+  image: ${compose.images_repository}/goemaxima:2020113001-latest
   restart: unless-stopped
  stack-api-server:
   profiles:
    - prod
    - dev
-  image: timimages/stack-api:latest
+  image: ${compose.images_repository}/stack-api:latest
   depends_on:
    - maxima
   restart: unless-stopped
   environment:
    BROWSER_URL: ${tim.host}
  oiko:
-  image: timimages/oiko:latest
+  image: ${compose.images_repository}/oiko:latest
   restart: unless-stopped
   read_only: true
   tmpfs:
@@ -369,7 +369,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
      )
  }
  mailman-test:
-  image: timimages/mailman-core:dev
+  image: ${compose.images_repository}/mailman-core:dev
   restart: unless-stopped
   profiles:
    - test
@@ -386,7 +386,7 @@ ${ partial("docker", "csplugin_mongodb.tmpl.yml") if csplugin.is_mongodb_enabled
   profiles:
    - test
    - dev
-  image: timimages/tim:${tim.image_tag}
+  image: ${compose.images_repository}/tim:${tim.image_tag}
   command: ${ f'''${{TEST_COMMAND:-{"python3 -m unittest discover tests/ 'test_*.py' ." if not tim.is_dev else "sleep infinity"}}}''' }
   volumes:
    - .:/service:rw

--- a/cli/templates/docker/mailman.tmpl.yml
+++ b/cli/templates/docker/mailman.tmpl.yml
@@ -1,5 +1,5 @@
  mailman-core:
-   image: timimages/mailman-core:latest
+   image: ${compose.images_repository}/mailman-core:latest
    restart: unless-stopped
    volumes:
      - ./mailman/db:/opt/mailmandb
@@ -14,7 +14,7 @@
      INIT_DEV: 1
      TIM_DEV: 1
  mailman-web:
-   image: timimages/mailman-web:latest
+   image: ${compose.images_repository}/mailman-web:latest
    restart: unless-stopped
    depends_on:
      - mailman-core

--- a/timApp/Dockerfile
+++ b/timApp/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 as base
 
 ENV APT_INSTALL="DEBIAN_FRONTEND=noninteractive apt-get -qq update && DEBIAN_FRONTEND=noninteractive apt-get -q install --no-install-recommends -y" \
     APT_CLEANUP="rm -rf /var/lib/apt/lists /dvisvgm-2.4 /usr/share/doc ~/.cache"
@@ -90,6 +90,8 @@ RUN FILE=`mktemp`; wget "https://github.com/mgieseki/dvisvgm/releases/download/$
  cd / && \
  ${APT_CLEANUP} && \
  rm -rf /dvisvgm-$DVISVGM_VERSION
+
+FROM base as complete
 
 # Install Python, pip and other necessary packages
 

--- a/timApp/modules/cs/csi.sh
+++ b/timApp/modules/cs/csi.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker run  --name cs --rm=true  -t -i -v /opt/tim/timApp/modules/cs:/cs -v /var/run/docker.sock:/var/run/docker.sock -v /opt/tim/timApp/modules/cs/generated:/csgenerated -v /opt/tim/timApp/modules/cs/static:/csstatic:ro -v /opt/tim/tim_common:/cs/tim_common:ro -v /tmp/${COMPOSE_PROJECT_NAME}_uhome:/tmp timimages/cs3:compose
+docker run  --name cs --rm=true  -t -i -v /opt/tim/timApp/modules/cs:/cs -v /var/run/docker.sock:/var/run/docker.sock -v /opt/tim/timApp/modules/cs/generated:/csgenerated -v /opt/tim/timApp/modules/cs/static:/csstatic:ro -v /opt/tim/tim_common:/cs/tim_common:ro -v /tmp/${COMPOSE_PROJECT_NAME}_uhome:/tmp ${CSPLUGIN_IMAGE}

--- a/timApp/modules/cs/languages.py
+++ b/timApp/modules/cs/languages.py
@@ -22,12 +22,12 @@ from modifiers import Modifier
 from points import give_points
 from run import (
     generate_filename,
-    CS3_TAG,
     get_imgsource,
     run2_subdir,
     copy_file,
     wait_file,
     run,
+    CS3_IMAGE,
 )
 from tim_common.cs_sanitizer import cs_min_sanitize
 from tim_common.fileParams import (
@@ -135,7 +135,7 @@ class Language:
             query.jso,
             "markup",
             "dockercontainer",
-            f"timimages/cs3:{CS3_TAG}",
+            CS3_IMAGE,
         )
         self.ulimit = get_param(query, "ulimit", None)
         self.savestate = get_param(query, "savestate", "")
@@ -2209,7 +2209,7 @@ class Octave(Language):
             self.query.jso,
             "markup",
             "dockercontainer",
-            f"timimages/cs3:{CS3_TAG}",
+            CS3_IMAGE,
         )
         code, out, err, pwddir = self.runself(
             ["octave", "--no-window-system", "--no-gui", "-qf", self.pure_exename],

--- a/timApp/modules/cs/run.py
+++ b/timApp/modules/cs/run.py
@@ -12,7 +12,8 @@ from subprocess import PIPE, Popen
 from file_util import write_safe, is_safe_path, rm_safe
 from tim_common.fileParams import mkdirs, tquote, get_param
 
-CS3_TAG = os.environ.get("CSPLUGIN_IMAGE_TAG", "")
+CS3_IMAGE = os.environ.get("CSPLUGIN_IMAGE", "")
+CS3_TAG = CS3_IMAGE.split(":")[-1]
 
 
 def wait_file(f1, tries=10):
@@ -150,7 +151,7 @@ def run2(
     ulimit=None,
     no_x11=False,
     savestate="",
-    dockercontainer=f"timimages/cs3:{CS3_TAG}",
+    dockercontainer=CS3_IMAGE,
     compile_commandline="",
     mounts=[],
     extra_mappings=None,

--- a/timApp/modules/cs/ur.sh
+++ b/timApp/modules/cs/ur.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Ajetaan docker yhden cs-ajon ajaksi ja liitet‰‰n siihen k‰ytt‰j‰n hakemisto hakemistoksi /home/me
-docker run -t -i -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/me/ cs3 /cs/rcmd.sh

--- a/timApp/modules/cs/urs.sh
+++ b/timApp/modules/cs/urs.sh
@@ -1,5 +1,0 @@
-docker rm urs
-#docker run -privileged -t -i -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/me/ -w /home/agent cs3 /bin/bash 
-# docker run  --name urs --rm=true -t -i -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3 /bin/bash 
-# docker run  -t -i -v /var/run/docker.sock:/var/run/docker.sock -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3 /bin/bash 
-docker run  --name urs --rm=true  -t -i -v /tmp/uhome/cs:/cst:ro -v /var/run/docker.sock:/var/run/docker.sock -v $(which docker):/bin/docker -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent timimages/cs3 /bin/bash # /cs/limit.sh  # /cs/rcmd.sh # /bin/bash

--- a/timApp/modules/cs/urss.sh
+++ b/timApp/modules/cs/urss.sh
@@ -1,5 +1,0 @@
-docker rm urss
-#docker run -privileged -t -i -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/me/ -w /home/agent cs3 /bin/bash 
-# docker run  --name urs --rm=true -t -i -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3 /bin/bash 
-# docker run  -t -i -v /var/run/docker.sock:/var/run/docker.sock -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3 /bin/bash 
-docker run  --name urss --rm=true  -t -i -v /tmp/uhome/cs:/cst:ro -v /var/run/docker.sock:/var/run/docker.sock -v $(which docker):/bin/docker -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3sudo /bin/bash # /cs/limit.sh  # /cs/rcmd.sh # /bin/bash 

--- a/timApp/modules/cs/usrs.sh
+++ b/timApp/modules/cs/usrs.sh
@@ -1,5 +1,0 @@
-docker rm urs
-#docker run -privileged -t -i -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/me/ -w /home/agent cs3 /bin/bash 
-# docker run  --name urs --rm=true -t -i -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3 /bin/bash 
-# docker run  -t -i -v /var/run/docker.sock:/var/run/docker.sock -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3 /bin/bash 
-docker run  --name urss --rm=true  -t -i -v /tmp/uhome/cs:/cst:ro -v /var/run/docker.sock:/var/run/docker.sock -v $(which docker):/bin/docker -v /opt/cs:/cs/:ro  -v /tmp/uhome/user/4d859744c28dbca8348fc24833ece03aa3050371f98a882bbd4b54e5da617114:/home/agent/ -w /home/agent cs3s /bin/bash # /cs/limit.sh  # /cs/rcmd.sh # /bin/bash 

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -87,6 +87,7 @@ from timApp.util.flask.cache import cache
 from timApp.util.flask.requesthelper import (
     get_request_message,
     NotExist,
+    is_testing,
 )
 from timApp.util.flask.responsehelper import json_response, ok_response
 from timApp.util.flask.search import search_routes
@@ -187,6 +188,9 @@ def inject_angular_scripts() -> dict:
         try:
             return get_angularscripts(f"static/scripts/build/index.html")
         except FileNotFoundError:
+            # Don't raise issues for missing JS during testing. JS might not be built to speed up tests.
+            if is_testing():
+                return dict(angularscripts="")
             raise Exception(
                 "TypeScript files have not been built (compiled JavaScript files are missing).\n"
                 'If this is a local development TIM instance, start the "bdw" NPM script (in timApp/package.json) '


### PR DESCRIPTION
Tämä PR ottaa käyttöön GitHubin konttirekisterin ja siirtää kaikkien konttien pohjakuvat siihen Docker Hubista.
Docker Hub on sulkemassa ilmaiset organisaatiot (ks. tim-jyu/tim-private#70) ja jatkossa tarjoaa vain erillisellä haulla saatavat lisenssit. Lisäksi Docker Hubin ylläpito on ollut hankalaa, koska se sijaitsi erillään projektista (ja organisaation koko oli rajoitettu 3 tunnukseen).

Lisäksi PR tekee muutaman korjauksen CIhin nopeuttamaan ja parantamaan sen toimintaa.

Tämän PR:n muutokset:

* Kaikkien konttien pohjakuvat siirretty GitHubin konttirekisteriin. Jatkossa siis konttien nimi on muotoa `ghcr.io/tim-jyu/kontti` vanhan `timimages/kontti` sijaan. 
* Päivitetty TIM CLI osaamaan käsitellä uusi rekisteri. Täten peruskäytössä ei tarvitse välittää konttien sijainnista, vaan tavalliset komennot toimivat.
* Päivitetty ja siivottu csplugin hieman, jotta se osaa käsitellä uuden rekisterin.
* Optimoitu Dumbo-kontin kokoa, mikä nopeuttaa konttien lataamista ja rakentamista.
* Nopeutettu CI-ajoa yksikkö-, tietokanta-, ja palvelintesteille
* Korjattu CI toimimaan forkeista tehdyillä PRillä

Mallipalvelinta ei ole, koska muutokset koskevat vain konttien sijaintia eikä toimintaa.

Tämä PR samalla testaa, että CI silti toimii oikein muutosten jälkeen.

Mergen jälkeen päivitykseen riittää `./tim update all`

