### PR TITLE
Add saveTeacher markup attribute

### DIFF
--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -377,7 +377,7 @@ export class AnswerBrowserComponent
             // TODO: implement secure initial user check (including user via urlParam), change answer here if needed
         }
         this.saveTeacher =
-            ((markup?.saveTeacher ?? this.viewctrl.docSettings.save_teacher) &&
+            ((markup?.saveTeacher ?? this.viewctrl.docSettings.saveTeacher) &&
                 this.viewctrl.teacherMode) ??
             false;
         this.showDelete = isAdmin() && getURLParameter("showAdmin") != null;

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -377,7 +377,7 @@ export class AnswerBrowserComponent
             // TODO: implement secure initial user check (including user via urlParam), change answer here if needed
         }
         this.saveTeacher =
-            (this.viewctrl.docSettings.save_teacher &&
+            ((markup?.saveTeacher ?? this.viewctrl.docSettings.save_teacher) &&
                 this.viewctrl.teacherMode) ??
             false;
         this.showDelete = isAdmin() && getURLParameter("showAdmin") != null;

--- a/timApp/static/scripts/tim/document/IDocSettings.ts
+++ b/timApp/static/scripts/tim/document/IDocSettings.ts
@@ -32,7 +32,7 @@ export interface IDocSettings {
     hideBrowser?: boolean;
     login?: ILoginSettings;
     timeLeft?: ITimeLeftSettings;
-    save_teacher?: boolean;
+    saveTeacher?: boolean;
     show_scoreboard?: boolean;
     exam_mode?: string;
     sidemenu_initial_state?: string;

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -59,6 +59,7 @@ export const GenericPluginMarkup = t.partial({
     answerBrowser: nullable(AnswerBrowserSettings),
     warningFilter: nullable(t.string),
     previousTask: nullable(previousTaskType),
+    saveTeacher: t.boolean,
     spellcheck: t.boolean,
 });
 

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -141,6 +141,7 @@ class KnownMarkupFields(HiddenFieldsMixin):
     postprogram: str | Missing = missing
     postoutput: str | Missing = missing
     previousTask: PreviousTaskInfo | None | Missing = missing
+    saveTeacher: bool | None | Missing = missing
     showPoints: bool | None | Missing = missing
     starttime: PluginDateTime | datetime | None | Missing = missing
     showInView: bool | Missing = missing


### PR DESCRIPTION
Lisää saveTeacher-attribuutin joilla voi laittaa tehtävään valmiiksi Save teacher's fix -asetuksen päälle. Käyttötapauksena tilanne jossa opettaja käyttää tehtävää (esim tekstikenttää) kommentoimaan opiskelijan vastausta, vaikka answerbrowser on osittain piilotettuna.
Lisäksi vaihtaa save_teacher-dokumenttiasetuksen syntaksin vastaamaan tätä (tuo pitää käydä skriptillä vaihtamassa muutamassa dokumentista uuteen)

https://timdevs01-3.it.jyu.fi/teacher/saveteacher