### PR TITLE
Allow PeerReview data in jsrunner without teacher rights, add peer_review_allow_invalid docsetting

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -68,10 +68,14 @@ def get_answers_query(task_id: TaskId, users: list[User], only_valid: bool) -> Q
     return q
 
 
-def get_latest_valid_answers_query(task_id: TaskId, users: list[User]) -> Query:
+def get_latest_answers_query(
+    task_id: TaskId, users: list[User], only_valid: bool
+) -> Query:
+    q = Answer.query.filter_by(task_id=task_id.doc_task)
+    if only_valid:
+        q = q.filter_by(valid=True)
     sq = (
-        Answer.query.filter_by(task_id=task_id.doc_task, valid=True)
-        .join(User, Answer.users)
+        q.join(User, Answer.users)
         .filter(User.id.in_([u.id for u in users]))
         .group_by(User.id)
         .with_entities(func.max(Answer.id).label("aid"), User.id.label("uid"))

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1357,8 +1357,14 @@ def preprocess_jsrunner_answer(
     )
     if runnermarkup.peerReview:
         if not curr_user.has_teacher_access(d):
-            raise AccessDenied("Teacher access required to browse all peer reviews")
-        answerdata["peerreviews"] = get_reviews_for_document(d)
+            # TODO: Query reviews targeting current user, needs to implement anonymization if anonymize_reviewers
+            # TODO: Query peer reviews from another document
+            prs = get_reviews_where_user_is_reviewer(d, curr_user)
+            for pr in prs:
+                pr.reviewable.hide_name = True
+            answerdata["peerreviews"] = prs
+        else:
+            answerdata["peerreviews"] = get_reviews_for_document(d)
         answerdata["velps"] = get_annotations_with_comments_in_document(curr_user, d)
     else:
         answerdata["peerreviews"] = None

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1356,15 +1356,10 @@ def preprocess_jsrunner_answer(
         else None,
     )
     if runnermarkup.peerReview:
-        if not curr_user.has_teacher_access(d):
-            # TODO: Query reviews targeting current user, needs to implement anonymization if anonymize_reviewers
-            # TODO: Query peer reviews from another document
-            prs = get_reviews_where_user_is_reviewer(d, curr_user)
-            for pr in prs:
-                pr.reviewable.hide_name = True
-            answerdata["peerreviews"] = prs
-        else:
-            answerdata["peerreviews"] = get_reviews_for_document(d)
+        # TODO: Query peer reviews from another document, check need for review anonymization
+        # For now we only query PeerReviews/velps in the same document as the jsrunner, so we assume
+        # that jsrunners runnable by non-teacher users were created by someone with at least edit access
+        answerdata["peerreviews"] = get_reviews_for_document(d)
         answerdata["velps"] = get_annotations_with_comments_in_document(curr_user, d)
     else:
         answerdata["peerreviews"] = None

--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -90,6 +90,7 @@ class DocSettingTypes:
     sync_answerbrowsers: bool
     peer_review_start: datetime
     peer_review_stop: datetime
+    peer_review_allow_invalid: bool
     anonymize_reviewers: str
     answerBrowser: AnswerBrowserInfo
     groupSelfJoin: GroupSelfJoinSettings
@@ -609,6 +610,9 @@ class DocSettings:
 
     def peer_review_stop(self) -> datetime | None:
         return self._get_datetime_option("peer_review_stop")
+
+    def peer_review_allow_invalid(self) -> bool | None:
+        return self.get_setting_or_default("peer_review_allow_invalid", False)
 
     def access_denied_message(self) -> str | None:
         return self.get_setting_or_default("access_denied_message", None)

--- a/timApp/peerreview/util/groups.py
+++ b/timApp/peerreview/util/groups.py
@@ -4,7 +4,7 @@ from random import shuffle
 from typing import DefaultDict
 
 from timApp.answer.answer import Answer
-from timApp.answer.answers import get_points_by_rule, get_latest_valid_answers_query
+from timApp.answer.answers import get_points_by_rule, get_latest_answers_query
 from timApp.document.docinfo import DocInfo
 from timApp.peerreview.peerreview import PeerReview
 from timApp.plugin.plugin import Plugin
@@ -30,8 +30,8 @@ def generate_review_groups(doc: DocInfo, task_ids: list[TaskId]) -> None:
                 .all()
             )
         ]
-
-    points = get_points_by_rule(None, task_ids, user_ids)
+    valid_only = not settings.peer_review_allow_invalid()
+    points = get_points_by_rule(None, task_ids, user_ids, show_valid_only=valid_only)
 
     users = []
     for user in points:
@@ -82,7 +82,7 @@ def generate_review_groups(doc: DocInfo, task_ids: list[TaskId]) -> None:
     # PeerReview rows and pairings will be the same for every task, even if target did not answer to some of tasks
     # If target has an answer in a task, try to add it to PeerReview table. If not, just leave it empty
     for t in task_ids:
-        answers: list[Answer] = get_latest_valid_answers_query(t, users).all()
+        answers: list[Answer] = get_latest_answers_query(t, users, valid_only).all()
         excluded_users: list[User] = []
         filtered_answers = []
         for answer in answers:

--- a/timApp/plugin/jsrunner/util.py
+++ b/timApp/plugin/jsrunner/util.py
@@ -14,6 +14,7 @@ from timApp.auth.accesshelper import (
     get_doc_or_abort,
     AccessDenied,
     verify_task_access,
+    verify_teacher_access,
 )
 from timApp.auth.accesstype import AccessType
 from timApp.auth.login import create_or_update_user
@@ -262,6 +263,7 @@ def save_fields(
                         # TODO: Add new reviewer or if reviewable have none
                         pass
                     if new and old and task and current_doc and user_id:
+                        verify_teacher_access(current_doc)
                         change_peerreviewers_for_user(
                             current_doc, task, user_id, old, new
                         )


### PR DESCRIPTION
Lisää peer_review_allow_invalid-dokumenttiasetuksen, jonka myötä myös invalidit vastaukset otetaan myös vertaisarviointiparien generointiin mukaan. 

Lisäksi poistaa vaatimuksen opettajaoikeuksista mikäli jsrunnerilla käsitellään vertaisarviointidataa tai velppejä. Nuo ovat olleet piilossa lähinnä siksi että velpit ja vertaisarvioinnit haetaan yhtenä pötkönä, ja sitä kautta voi periaatteessa kurkkia velppejä tai vertaisarviointeja joita käyttäjä ei näkisi normaalisti ilman opettajaoikeutta. Mutta koska noita datoja haetaan toistaiseksi vain samasta dokumentista kuin itse jsrunner, noita käsitellessä voinee olettaa että jsrunnerin on tehnyt (ja jättänyt näkyville) joku jolla on vähintään edit-oikeus kyseiseen dokumenttin. Tämän myötä voi antaa vastaajan pyörittää esim jsrunnerin joka näyttää kentissä kuinka monta vertaisarviointia on tullut tehtyä