### PR TITLE
Refactor velp group permissions

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -7940,7 +7940,7 @@
       </trans-unit>
       <trans-unit id="372586075998659024" datatype="html">
         <source>Peer review: </source>
-        <target state="translated">Vertaisarviointi:</target>
+        <target state="translated">Vertaisarviointi: </target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/templates/answerBrowser.html</context>
           <context context-type="linenumber">201</context>

--- a/timApp/item/manage.py
+++ b/timApp/item/manage.py
@@ -619,7 +619,7 @@ def add_perm(
                 require_confirm=p.confirm,
                 replace_active_duration=replace_active_duration,
             )
-            accs.append((a, d))
+            accs.append(a)
     return accs
 
 
@@ -637,7 +637,7 @@ def remove_permission(m: PermissionRemoveModel) -> Response:
     check_ownership_loss(had_ownership, i)
 
     log_right(
-        f"removed {a[0].info_str} for {ug.name} in {seq_to_str(list(str(x.block.id) for x in a))}"
+        f"removed {a[0].info_str} for {ug.name} in {seq_to_str(list(str(x.block_id) for x in a))}"
     )
 
     db.session.commit()

--- a/timApp/item/manage.py
+++ b/timApp/item/manage.py
@@ -340,16 +340,9 @@ def add_permission(m: PermissionSingleEditModel):
     if accs:
         check_ownership_loss(is_owner, i)
 
-        for perm in accs:
-            ba, block = perm
-            path = (
-                block.path
-                if isinstance(block, DocInfo)
-                else block.docentries[0].path
-                if not isinstance(block, Folder)
-                else f"{block.location}/{block.name}"
-            )
-            log_right(f"added {ba.info_str} for {seq_to_str(m.groups)} in {path}")
+        log_right(
+            f"added {accs[0].info_str} for {seq_to_str(m.groups)} in {seq_to_str(list(str(x.block.id) for x in accs))}"
+        )
 
         db.session.commit()
     return permission_response(m)
@@ -643,16 +636,9 @@ def remove_permission(m: PermissionRemoveModel) -> Response:
     )
     check_ownership_loss(had_ownership, i)
 
-    for perm in a:
-        ba, block = perm
-        path = (
-            block.path
-            if isinstance(block, DocInfo)
-            else block.docentries[0].path
-            if not isinstance(block, Folder)
-            else f"{block.location}/{block.name}"
-        )
-        log_right(f"removed {ba.info_str} for {ug.name} in {path}")
+    log_right(
+        f"removed {a[0].info_str} for {ug.name} in {seq_to_str(list(str(x.block.id) for x in a))}"
+    )
 
     db.session.commit()
     return ok_response()
@@ -751,7 +737,7 @@ def remove_perm(
     t: AccessType,
     process_translations: bool = True,
     process_velp_groups: bool = True,
-) -> list[tuple[BlockAccess, Block]]:
+) -> list[BlockAccess]:
     """
     Remove permissions from items.
     :param group: UserGroup whose permissions will be revoked.
@@ -789,7 +775,7 @@ def remove_perm(
         # remove_access returns None if the permissions wasn't found in the item's BlockAccess list,
         # we do not want to carry it further
         if perm:
-            removed_perms.append((perm, d))
+            removed_perms.append(perm)
     return removed_perms
 
 

--- a/timApp/item/manage.py
+++ b/timApp/item/manage.py
@@ -338,19 +338,18 @@ def add_permission(m: PermissionSingleEditModel):
     is_owner = verify_permission_edit_access(i, m.type)
     accs = add_perm(m, i)
     if accs:
-        a = accs[0]
         check_ownership_loss(is_owner, i)
 
         for perm in accs:
-            item = get_item_or_abort(perm.block.id)
-            log_right(
-                f"added {perm.info_str} for {seq_to_str(m.groups)} in {item.path}"
+            ba, block = perm
+            path = (
+                block.path
+                if isinstance(block, DocInfo)
+                else block.docentries[0].path
+                if not isinstance(block, Folder)
+                else f"{block.location}/{block.name}"
             )
-
-        # copy permissions to document's velp groups
-        # TODO refactor this into add_perm
-        if m.edit_velp_group_perms:
-            add_doc_velp_group_permissions(i, m)
+            log_right(f"added {ba.info_str} for {seq_to_str(m.groups)} in {path}")
 
         db.session.commit()
     return permission_response(m)
@@ -549,24 +548,12 @@ def edit_permissions(m: PermissionMassEditModel) -> Response:
             accs = add_perm(m, i)
             if accs:
                 modified_permissions.extend(accs)
-            # copy permissions to item's/document's velp groups, if any
-            if m.edit_velp_group_perms:
-                # Currently only document velp group permissions are supported
-                if i.type_id == BlockType.Document.value:
-                    doc = DocInfo.find_by_id(i.id)
-                    if doc:
-                        velp_groups = add_velp_group_permissions(m, doc)
-                        modified_permissions.extend(velp_groups)
         else:
             for g in groups:
-                removed = remove_perm(g, i, m.type, m.edit_translation_perms)
+                removed = remove_perm(
+                    g, i, m.type, m.edit_translation_perms, m.edit_velp_group_perms
+                )
                 modified_permissions.extend(removed)
-                # Also remove permissions to item's/document's velp groups, if any
-                doc = DocInfo.find_by_id(i.id)
-                if doc and m.edit_velp_group_perms:
-                    if i.type_id == BlockType.Document.value:
-                        velp_groups = remove_velp_group_perms(doc, g, m.type)
-                        modified_permissions.extend(velp_groups)
 
     if m.type == AccessType.owner:
         owned_items_after = set()
@@ -610,11 +597,26 @@ def add_perm(
         )
         else [doc]
     )
-    for tr in docs:
+
+    if p.edit_velp_group_perms:
+        # Unfortunately we have to do a db query here
+        if isinstance(item, DocInfo):
+            vgs = get_groups_from_document_table(item.id, None)
+            for vg in vgs:
+                # Don't add permissions to users' personal velp groups,
+                # only add perms to document velp groups in the path:
+                # [doc_folder]/velp-groups/[doc-name]/[velp_group]
+                if (
+                    not vg.name == DEFAULT_PERSONAL_VELP_GROUP_NAME
+                    and is_velp_group_in_document(vg, doc)
+                ):
+                    docs.append(vg.block)
+
+    for d in docs:
         for group in p.group_objects:
             a = grant_access(
                 group,
-                tr,
+                d,
                 p.type,
                 accessible_from=opt.ffrom,
                 accessible_to=opt.to,
@@ -624,104 +626,8 @@ def add_perm(
                 require_confirm=p.confirm,
                 replace_active_duration=replace_active_duration,
             )
-            accs.append(a)
+            accs.append((a, d))
     return accs
-
-
-def add_velp_group_permissions(
-    p: PermissionEditModel,
-    doc: DocInfo | DocEntry,
-    replace_active_duration: bool = True,
-) -> list[BlockAccess]:
-
-    opt = p.time.effective_opt
-    accs = []
-    vgs: list[VelpGroup] = get_groups_from_document_table(doc.id, None)
-
-    for vg in vgs:
-        # Don't add permissions to users' personal velp groups,
-        # only add perms to document velp groups in the path:
-        # [doc_folder]/velp-groups/[doc-name]/[velp_group]
-        if (
-            not vg.name == DEFAULT_PERSONAL_VELP_GROUP_NAME
-            and is_velp_group_in_document(vg, doc)
-        ):
-            for group in p.group_objects:
-                a = grant_access(
-                    group,
-                    vg.block,
-                    p.type,
-                    accessible_from=opt.ffrom,
-                    accessible_to=opt.to,
-                    duration_from=opt.durationFrom,
-                    duration_to=opt.durationTo,
-                    duration=opt.duration,
-                    require_confirm=False,  # Parent doc has been confirmed, no need to confirm VelpGroups
-                    replace_active_duration=replace_active_duration,
-                )
-                accs.append(a)
-    return accs
-
-
-def add_doc_velp_group_permissions(
-    i: Item, m: PermissionEditModel
-) -> list[BlockAccess]:
-    """Add access permissions to a document's VelpGroups
-
-    :param i: Document
-    :param m: PermissionEditModel detailing the access permissions to be added
-    :return: Added permissions as a list of BlockAccess objects
-    """
-
-    # Currently only document velp group permissions are supported
-    if isinstance(i, DocInfo | DocEntry):
-        acc = add_velp_group_permissions(m, i)
-        for a in acc:
-            gr_path = get_item_or_abort(a.block_id).path
-            log_right(f"added {a.info_str} for {seq_to_str(m.groups)} in {gr_path}")
-        return acc
-
-
-def copy_doc_perms_to_velp_groups(i: ItemOrBlock) -> list[BlockAccess]:
-    """Copy permissions from document to its attached VelpGroups
-
-    NOTE: Any changes to the document's permissions should be committed
-    to the database before calling this function, otherwise the returned
-    list of BlockAccesses may contain outdated permissions for VelpGroups.
-
-    :param i: Document that the VelpGroups are attached to
-    :return: List of BlockAccess objects for the document's VelpGroups
-    """
-    vgs = (
-        VelpGroupsInDocument.query.filter_by(doc_id=i.id)
-        .join(VelpGroup)
-        .with_entities(VelpGroup)
-        .all()
-    )
-    ap_groups = []
-    doc_rights = get_rights_holders(i.id)
-    for vg in vgs:
-        if vg.name == DEFAULT_PERSONAL_VELP_GROUP_NAME and is_velp_group_in_document(
-            vg, i
-        ):
-            pass  # don't add permissions to users' personal velp groups
-        else:
-            for right in doc_rights:
-                a = grant_access(
-                    right.usergroup,
-                    vg.block,
-                    access_type=right.access_type,
-                    accessible_from=right.accessible_from,
-                    accessible_to=right.accessible_to,
-                    duration_from=right.duration_from,
-                    duration_to=right.duration_to,
-                    duration=right.duration,
-                    # 'parent' document access is confirmed already, no need for it here
-                    require_confirm=False,
-                    replace_active_duration=True,
-                )
-                ap_groups.append(a)
-    return ap_groups
 
 
 @manage_page.put("/permissions/remove", model=PermissionRemoveModel)
@@ -732,20 +638,21 @@ def remove_permission(m: PermissionRemoveModel) -> Response:
     ug: UserGroup = UserGroup.query.filter_by(id=m.group).first()
     if not ug:
         raise RouteException("User group not found")
-    a = remove_perm(ug, i.block, m.type, m.edit_translation_perms)
+    a = remove_perm(
+        ug, i.block, m.type, m.edit_translation_perms, m.edit_velp_group_perms
+    )
     check_ownership_loss(had_ownership, i)
 
     for perm in a:
-        item = get_item_or_abort(perm.block_id)
-        log_right(f"removed {perm.info_str} for {ug.name} in {item.path}")
-
-    # Also remove permissions to item's/document's velp groups, if any
-    if m.edit_velp_group_perms and isinstance(i, DocInfo | DocEntry):
-        rm_groups = remove_velp_group_perms(i, ug, m.type)
-        for rm in rm_groups:
-            rm_path = Item.find_by_id(rm.block_id).path
-            if rm_path:
-                log_right(f"removed {rm.info_str} for {ug.name} in {rm_path}")
+        ba, block = perm
+        path = (
+            block.path
+            if isinstance(block, DocInfo)
+            else block.docentries[0].path
+            if not isinstance(block, Folder)
+            else f"{block.location}/{block.name}"
+        )
+        log_right(f"removed {ba.info_str} for {ug.name} in {path}")
 
     db.session.commit()
     return ok_response()
@@ -839,8 +746,12 @@ def self_expire_permission(id: int, set_field: str | None = None) -> Response:
 
 
 def remove_perm(
-    group: UserGroup, b: Block, t: AccessType, process_translations: bool = True
-) -> list[BlockAccess]:
+    group: UserGroup,
+    b: Block,
+    t: AccessType,
+    process_translations: bool = True,
+    process_velp_groups: bool = True,
+) -> list[tuple[BlockAccess, Block]]:
     """
     Remove permissions from items.
     :param group: UserGroup whose permissions will be revoked.
@@ -848,12 +759,13 @@ def remove_perm(
     :param t: Type of permission to remove.
     :param process_translations: Whether a document's Translations should also have the corresponding
                               permissions removed.
+    :param process_velp_groups: Whether a document's VelpGroups should also have the corresponding
+                              permissions removed.
     :return: List of removed permissions.
     """
 
-    # TODO Fetch velp group docs for this document as well
     item = b.docentries[0] if (isinstance(b, Block) and b.docentries) else b
-    items = (
+    items: list[Block] = (
         item.translations
         if (
             isinstance(item, DocInfo)
@@ -863,35 +775,22 @@ def remove_perm(
         else [item]
     )
 
-    # items = b.translations if (isinstance(b, DocInfo) and process_translations) else [b]
+    if process_velp_groups:
+        # Unfortunately we have to do a db query here
+        vgs = get_groups_from_document_table(b.docentries[0].id, None)
+        for vg in vgs:
+            # Remove perms only from velp groups attached to the document
+            if is_velp_group_in_document(vg, b):
+                items.append(vg.block)
+
     removed_perms = []
     for d in items:
         perm = remove_access(group, d, t)
         # remove_access returns None if the permissions wasn't found in the item's BlockAccess list,
         # we do not want to carry it further
         if perm:
-            removed_perms.append(perm)
+            removed_perms.append((perm, d))
     return removed_perms
-
-
-def remove_velp_group_perms(
-    i: DocInfo | DocEntry, ug: UserGroup, acc: AccessType
-) -> list[BlockAccess]:
-    """Remove a UserGroup's permissions to Velp Groups that are attached to a specific document
-
-    :param i: Document that the Velp Groups are attached to
-    :param ug: UserGroup whose permissions will be removed
-    :param acc: AccessType of the permissions that will be removed
-    """
-    vgs = get_groups_from_document_table(i.id, None)
-    rm_groups = []
-    for vg in vgs:
-        # Remove perms only from velp groups attached to the document
-        if is_velp_group_in_document(vg, i):
-            a = remove_perm(ug, vg.block, acc, False)
-            if a:
-                rm_groups.extend(a)
-    return rm_groups
 
 
 def check_ownership_loss(had_ownership, item):

--- a/timApp/plugin/userselect/userselect.py
+++ b/timApp/plugin/userselect/userselect.py
@@ -717,7 +717,7 @@ def apply_permission_actions(
     for to_remove in remove:
         doc_entry = doc_entries[to_remove.doc_path]
         a = remove_perm(user_group, doc_entry.block, to_remove.type)
-        # A document's translations will have their permissions removed by default as well,
+        # A document's translations and velp groups will have their permissions removed by default as well,
         # so we need to iterate the list returned from remove_perm
         for p in a:
             update_messages.append(

--- a/timApp/tests/server/test_velp.py
+++ b/timApp/tests/server/test_velp.py
@@ -34,6 +34,7 @@ from timApp.velp.velp_models import (
     VelpGroupDefaults,
     VelpGroupsInDocument,
 )
+from timApp.velp.velpgroups import get_groups_from_document_table
 
 
 class VelpTest(TimRouteTest):
@@ -432,7 +433,7 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
         # Case 1:
         # Test user 2 should initially not be able to access velp group
         self.login_test2()
-        res = self.get(g_doc.url, expect_status=403)
+        self.get(g_doc.url, expect_status=403)
 
         # Should be able to access velp group with view permissions
         self.login_test1()
@@ -450,22 +451,26 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
             },
         )
         self.login_test2()
-        res = self.get(g_doc.url, expect_status=200)
+        self.get(g_doc.url, expect_status=200)
 
-        usergroup = UserGroup.query.filter_by(name="testuser2").first()
         self.login_test1()
         self.json_put(
             f"/permissions/remove",
             {
                 "id": d.id,
                 "type": AccessType.view.value,
-                "group": usergroup.id,
+                "group": self.test_user_2.get_personal_group().id,
             },
             expect_status=200,
         )
         # Should no longer be able to access velp group
         self.login_test2()
-        res = self.get(g_doc.url, expect_status=403)
+        vgs = get_groups_from_document_table(
+            d.id, self.test_user_2.get_personal_group().id
+        )
+        for vg in vgs:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
 
     def test_velp_group_permissions_edit(self):
         d, g_doc = self.setup_velp_group_test()
@@ -496,20 +501,23 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
         self.login_test2()
         self.get(g_doc.url, expect_status=200)
 
-        usergroup = UserGroup.query.filter_by(name="testuser2").first()
-
         self.login_test1()
         self.json_put(
             f"/permissions/remove",
             {
                 "id": d.id,
                 "type": AccessType.edit.value,
-                "group": usergroup.id,
+                "group": self.test_user_2.get_personal_group().id,
             },
         )
         # Should no longer be able to access velp group
         self.login_test2()
-        self.get(g_doc.url, expect_status=403)
+        vgs = get_groups_from_document_table(
+            d.id, self.test_user_2.get_personal_group().id
+        )
+        for vg in vgs:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
 
     def test_velp_group_permissions_teacher(self):
         d, g_doc = self.setup_velp_group_test()
@@ -541,20 +549,23 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
         self.login_test2()
         self.get(g_doc.url, expect_status=200)
 
-        usergroup = UserGroup.query.filter_by(name="testuser2").first()
-
         self.login_test1()
         self.json_put(
             f"/permissions/remove",
             {
                 "id": d.id,
                 "type": AccessType.teacher.value,
-                "group": usergroup.id,
+                "group": self.test_user_2.get_personal_group().id,
             },
         )
         # Should no longer be able to access velp group
         self.login_test2()
-        self.get(g_doc.url, expect_status=403)
+        vgs = get_groups_from_document_table(
+            d.id, self.test_user_2.get_personal_group().id
+        )
+        for vg in vgs:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
 
     def test_velp_group_permissions_manage(self):
         d, g_doc = self.setup_velp_group_test()
@@ -570,7 +581,6 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
 
         # Case 4:
         # Should be able to access velp group with manage permissions
-        usergroup = UserGroup.query.filter_by(name="testuser2").first()
         self.login_test1()
         self.json_put(
             f"/permissions/add",
@@ -587,20 +597,23 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
         self.login_test2()
         self.get(g_doc.url, expect_status=200)
 
-        usergroup = UserGroup.query.filter_by(name="testuser2").first()
-
         self.login_test1()
         self.json_put(
             f"/permissions/remove",
             {
                 "id": d.id,
                 "type": AccessType.manage.value,
-                "group": usergroup.id,
+                "group": self.test_user_2.get_personal_group().id,
             },
         )
         # Should no longer be able to access velp group
         self.login_test2()
-        self.get(g_doc.url, expect_status=403)
+        vgs = get_groups_from_document_table(
+            d.id, self.test_user_2.get_personal_group().id
+        )
+        for vg in vgs:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
 
     def test_velp_group_permissions_owner(self):
         d, g_doc = self.setup_velp_group_test()
@@ -632,20 +645,23 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
         self.login_test2()
         self.get(g_doc.url, expect_status=200)
 
-        usergroup = UserGroup.query.filter_by(name="testuser2").first()
-
         self.login_test1()
         self.json_put(
             f"/permissions/remove",
             {
                 "id": d.id,
                 "type": AccessType.owner.value,
-                "group": usergroup.id,
+                "group": self.test_user_2.get_personal_group().id,
             },
         )
         # Should no longer be able to access velp group
         self.login_test2()
-        self.get(g_doc.url, expect_status=403)
+        vgs = get_groups_from_document_table(
+            d.id, self.test_user_2.get_personal_group().id
+        )
+        for vg in vgs:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
 
     def test_velp_group_permissions_new_group(self):
         d, g_doc = self.setup_velp_group_test()
@@ -873,19 +889,24 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
             },
         )
         self.login_test2()
-        self.get(g_doc1.url, expect_status=200)
-        self.get(g_doc2.url, expect_status=200)
-        self.get(g_doc3.url, expect_status=200)
-        self.get(g_doc4.url, expect_status=200)
-        self.get(g_doc5.url, expect_status=200)
-        self.get(g_doc6.url, expect_status=200)
+        tu2_velp_groups = []
+        tu2id = self.test_user_2.get_personal_group().id
+        tu2_velp_groups.extend(get_groups_from_document_table(d1.id, tu2id))
+        tu2_velp_groups.extend(get_groups_from_document_table(d2.id, tu2id))
+        tu2_velp_groups.extend(get_groups_from_document_table(d3.id, tu2id))
+        for vg in tu2_velp_groups:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=200)
+
         self.login_test3()
-        self.get(g_doc1.url, expect_status=200)
-        self.get(g_doc2.url, expect_status=200)
-        self.get(g_doc3.url, expect_status=200)
-        self.get(g_doc4.url, expect_status=200)
-        self.get(g_doc5.url, expect_status=200)
-        self.get(g_doc6.url, expect_status=200)
+        tu3_velp_groups = []
+        tu3id = self.test_user_3.get_personal_group().id
+        tu3_velp_groups.extend(get_groups_from_document_table(d1.id, tu3id))
+        tu3_velp_groups.extend(get_groups_from_document_table(d2.id, tu3id))
+        tu3_velp_groups.extend(get_groups_from_document_table(d3.id, tu3id))
+        for vg in tu3_velp_groups:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=200)
 
         self.login_test1()
         self.json_put(
@@ -1006,12 +1027,22 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
             {
                 "id": d.id,
                 "type": AccessType.view.value,
-                "group": self.get_test_user_2_group_id(),
+                "group": self.test_user_2.get_personal_group().id,
             },
         )
         self.login_test2()
         self.get(g_persnl_doc.url, expect_status=200)
-        self.get(g_docmnt_doc.url, expect_status=403)
+
+        # Should not be able to access document groups
+        vgs = get_groups_from_document_table(
+            d.id, self.test_user_2.get_personal_group().id
+        )
+        for vg in vgs:
+            if vg.id != g_docmnt_doc.id:
+                continue
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
+
         self.get(g_folder_doc.url, expect_status=200)
 
         self.login_test1()
@@ -1020,7 +1051,7 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
             {
                 "id": g_persnl_doc.id,
                 "type": AccessType.view.value,
-                "group": self.get_test_user_2_group_id(),
+                "group": self.test_user_2.get_personal_group().id,
                 "edit_velp_group_perms": False,
             },
         )
@@ -1029,14 +1060,14 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
             {
                 "id": g_folder_doc.id,
                 "type": AccessType.view.value,
-                "group": self.get_test_user_2_group_id(),
+                "group": self.test_user_2.get_personal_group().id,
                 "edit_velp_group_perms": False,
             },
         )
         self.login_test2()
-        self.get(g_persnl_doc.url, expect_status=403)
-        self.get(g_docmnt_doc.url, expect_status=403)
-        self.get(g_folder_doc.url, expect_status=403)
+        for vg in vgs:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
 
         # Case 13:
         # Should edit permissions only for document velp group
@@ -1094,7 +1125,11 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
         )
         self.login_test2()
         self.get(g_persnl_doc.url, expect_status=200)
-        self.get(g_docmnt_doc.url, expect_status=403)
+        for vg in vgs:
+            if vg.id != g_docmnt_doc.id:
+                continue
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
         self.get(g_folder_doc.url, expect_status=200)
 
         self.login_test1()
@@ -1112,9 +1147,9 @@ class VelpGroupPermissionsPropagationTest(TimRouteTest):
             },
         )
         self.login_test2()
-        self.get(g_persnl_doc.url, expect_status=403)
-        self.get(g_docmnt_doc.url, expect_status=403)
-        self.get(g_folder_doc.url, expect_status=403)
+        for vg in vgs:
+            vgd = DocInfo.find_by_id(vg.id)
+            self.get(vgd.url, expect_status=403)
 
     def test_modify_perms_for_no_vg_perms_user(self):
         """Test modifying document permissions (remove, edit, expire, clear)

--- a/timApp/tests/server/test_velp.py
+++ b/timApp/tests/server/test_velp.py
@@ -13,10 +13,6 @@ Tested routes from velp.py:
 """
 import json
 
-from timApp.user.users import remove_access
-
-from timApp.item.manage import remove_velp_group_perms
-
 from timApp.util.utils import get_current_time
 from timApp.user.usergroup import UserGroup
 


### PR DESCRIPTION
Closes #3400.

(This is a cherry-picked branch from [`velp-group-permissions`](https://github.com/TIM-JYU/TIM/tree/velp-group-permissions) that avoids conflicts due to 'dirty' branching)
Refactors setting velp group permissions, simplifies logging permissions.
