### PR TITLE
qst: classes so that correct and false choices can be colored

### DIFF
--- a/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
+++ b/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
@@ -231,39 +231,59 @@ type MatrixElement = string | number;
                 <tr *ngFor="let row of processed.rows; let rowi = index" [ngClass]="getTableRowClass()">
                     <td *ngIf="isMatrix()" [innerHtml]="fixText(row.text) | purify" class="qst-row_text"></td>
                     <td *ngFor="let col of row.columns; let coli = index;" class="qst-td">
-                        <label>
-                            <input *ngIf="isRadio()"
-                                   [ngClass]="getInputClass(rowi, coli)"
+                        <div *ngIf="isRadio()"
+                                 [ngClass]="'qst-radio ' + getInputClass(rowi, coli, answerMatrix[isMatrix() ? rowi : 0][0] === (isMatrix() ? coli: rowi)+1 ? 1: 0)"
+                            >
+                            <label>
+                            <input
                                    [attr.disabled]="disabled || null"
                                    type="radio"
                                    [(ngModel)]="answerMatrix[isMatrix() ? rowi : 0][0]"
                                    (ngModelChange)="signalUpdate()"
                                    [name]="getGroupName(rowi)"
                                    [value]="getInputValue(rowi, coli)">
-                            <input *ngIf="isCheckbox()"
-                                   [ngClass]="getInputClass(rowi, coli)"
+                             &ngsp;<span [innerHtml]="getLabelText(row) | purify"></span>
+                             <p *ngIf="getPoints(rowi, coli) as p" class="qst-points" [innerText]="p"></p></label>
+                        </div>    
+                        <div *ngIf="isCheckbox()"
+                                   [ngClass]="'qst-checkBox ' + getInputClass(rowi, coli, answerMatrix[rowi][coli] === 1 ? 1: 0)"
+                            >
+                            <label>
+                            <input
                                    [attr.disabled]="disabled || null"
                                    type="checkbox"
                                    [checked]="answerMatrix[rowi][coli] === 1"
                                    (change)="checkBoxChanged(rowi, coli, $event)"
                                    [name]="getGroupName(rowi)">
+                             &ngsp;<span [innerHtml]="getLabelText(row) | purify"></span>
+                             <p *ngIf="getPoints(rowi, coli) as p" class="qst-points" [innerText]="p"></p></label>
+                        </div>    
+                        <div *ngIf="isText()" class="qst-text">
+                            <label>
                             <textarea
                                     class="form-control"
-                                    *ngIf="isText()"
                                     [attr.disabled]="disabled || null"
                                     [(ngModel)]="answerMatrix[rowi][coli]"
                                     [ngModelOptions]="{standalone: true}"
                                     (ngModelChange)="signalUpdate()"></textarea>
-                            <input *ngIf="isInputText()"
-                                   [ngClass]="getInputClass(rowi, coli)"
+                            &ngsp;<span [innerHtml]="getLabelText(row) | purify"></span>
+                            <p *ngIf="getPoints(rowi, coli) as p" class="qst-points" [innerText]="p"></p></label>
+                        </div>    
+                        <div *ngIf="isInputText()"
+                                   [ngClass]="'qst-input-text ' + getInputClass(rowi, coli, -1)"
+                            >
+                            <label>
+                            <input
+                                   [ngClass]="getInputClass(rowi, coli, -1)"
                                    [attr.disabled]="disabled || null"
                                    [(ngModel)]="answerMatrix[rowi][coli]"
                                    [ngModelOptions]="{standalone: true}"
                                    (ngModelChange)="signalUpdate()"
                                    type="text"
                                    [size]="json.size || 3">
-                            &ngsp;<span [innerHtml]="getLabelText(row) | purify"></span></label>
-                        <p *ngIf="getPoints(rowi, coli) as p" class="qst-points" [innerText]="p"></p>
+                            &ngsp;<span [innerHtml]="getLabelText(row) | purify"></span>
+                             <p *ngIf="getPoints(rowi, coli) as p" class="qst-points" [innerText]="p"></p></label>
+                        </div>    
                     </td>
                     <td *ngIf="getExpl(rowi) as p" [innerHtml]="p | purify" class="explanation"></td>
                 </tr>
@@ -354,11 +374,15 @@ export class AnswerSheetComponent implements OnChanges {
         return row.text;
     }
 
-    getInputClass(rowIndex: number, colIndex: number) {
+    getInputClass(rowIndex: number, colIndex: number, userCheck: number) {
         const pts = this.getPoints(rowIndex, colIndex);
+        let userChk = "";
+        if (userCheck >= 0 && this.questiondata?.showCorrectChoices) {
+            userChk = "qst-userCheck" + userCheck;
+        }
         return pts != null && parseFloat(pts) > 0
-            ? "qst-correct"
-            : "qst-normal";
+            ? "qst-correct " + userChk
+            : "qst-normal " + userChk;
     }
 
     canShowExpl(): boolean {

--- a/timApp/static/stylesheets/windowstyle.scss
+++ b/timApp/static/stylesheets/windowstyle.scss
@@ -83,12 +83,12 @@ tim-qst button.timButton:not(:first-child) {
   margin-bottom: 1pt;
 }
 
-.qst-correct {
+.qst-correct input {
   outline: 2pt solid $basic-color;
   outline-offset: 1pt;
 }
 
-.qst-normal {
+.qst-normal input {
   padding-left: 2pt;
   padding-right: 2pt;
 }


### PR DESCRIPTION
tarkista voi tuon:

[answer-sheet.component.ts ](https://github.com/TIM-JYU/TIM/blob/qst-classes/timApp/static/scripts/tim/document/question/answer-sheet.component.ts#L234)

tehdä fiksummin kun nyt siihen tuli toistoa kun piti ne span ja p jokainen pistää divin sisään.

Ideana on että td:n sisälle tehdään div jolle saadaan tyyli sen mukaan onko vastaus oikein vai väärin.
Esimerkiksi;

```
div.qst-correct.qst-userCheck1, div.qst-normal.qst-userCheck1 {
    margin: -5px;
    padding: 5px;
}
div.qst-correct.qst-userCheck1 {
    background-color: lime;
}

div.qst-normal.qst-userCheck1 {
    background-color: red;
}
```

Jos ei tee noita uusia värityylejä, niin pitäisi toimia kuten ennenkin.  Jos hyväksi joku tyyli havaitaan, voisi laittaa oletukseksi.

![image](https://user-images.githubusercontent.com/826392/236040341-d3049ecc-9896-4b7a-98b8-133cad0ef53a.png)

![image](https://user-images.githubusercontent.com/826392/236040387-36fde03a-6a6d-43fb-b626-2cec9fd3794b.png)

![image](https://user-images.githubusercontent.com/826392/236040482-3a45eb04-5fc2-46aa-a0fe-8acfc9d1a1f0.png)

![image](https://user-images.githubusercontent.com/826392/236040528-6577d89e-1f24-4e48-9006-0be2d96189f9.png)


