### PR TITLE
UserSelect: Speed up group and distribution action registering

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -135,6 +135,12 @@ CELERYD_TASK_LOG_FORMAT = (
 )
 BEAT_DBURI = DB_URI
 
+USERSELECT_QUEUED_ACTIONS_CELERY = True
+"""
+If enabled, UserSelect will automatically schedule running the queued actions with celery.
+When disabled, the actions must be run manually with /userSelect/applyPendingActions
+"""
+
 MAIL_HOST = "smtpauth2.jyu.fi"
 MAIL_SIGNATURE = "\n\n-- \nThis message was automatically sent by TIM"
 WTF_CSRF_METHODS = ["POST", "PUT", "PATCH", "DELETE"]

--- a/timApp/plugin/userselect/action_queue.py
+++ b/timApp/plugin/userselect/action_queue.py
@@ -393,7 +393,8 @@ def _register_action(action: Action) -> None:
 
     action_file_path.write_text(action.to_str())
 
-    if not _check_lock_acquired("queue"):
+    send_to_celery = app.config["USERSELECT_QUEUED_ACTIONS_CELERY"]
+    if send_to_celery and not _check_lock_acquired("queue"):
         apply_pending_userselect_actions.delay()
 
 

--- a/timApp/plugin/userselect/action_queue.py
+++ b/timApp/plugin/userselect/action_queue.py
@@ -1,0 +1,452 @@
+"""
+Fast queue-based action handler for UserSelect.
+"""
+import datetime
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import filelock
+from sqlalchemy import tuple_
+
+from timApp.answer.backup import sync_user_group_memberships_if_enabled
+from timApp.plugin.userselect.dist_right_util import (
+    DistributeRightAction,
+    DistributeRightActionSchema,
+    apply_dist_right_actions,
+)
+from timApp.plugin.userselect.utils import group_expired_offset
+from timApp.tim_app import app
+from timApp.tim_celery import apply_pending_userselect_actions
+from timApp.timdb.sqa import db
+from timApp.user.user import User
+from timApp.user.usergroup import UserGroup
+from timApp.user.usergroupmember import membership_current, UserGroupMember
+from timApp.util.flask.responsehelper import to_json_str
+from timApp.util.logger import log_warning, log_info
+
+"""
+General idea:
+
+* Actions are stored in a queue folder.
+* Each action is stored as a file
+    - File's name is UNIX timestamp in nanoseconds. This allows to remove excessive name collisions.
+    - Action file contains new-line (\n) separated values. The values are:
+        ACTION_TYPE
+        ACTION_METADATA
+    - ACTION_TYPE is an identifier for the action.
+    - ACTION_METADATA is one or more values specific to the action.
+    - For example, GroupAction is serialized as the following file:
+        r
+        testuser1
+        testgroup1
+* Queue is processed with Celery
+    - Processing is protected by two locks: "processing" and "queue" locks
+    - "processing" lock ensures only one worker applies the actions
+    - "queue" lock allows another worker to wait for "processing" lock to be released and prevents task spam
+"""
+
+
+def _get_action_queue_path() -> Path:
+    """
+    Get the path to the action queue folder.
+
+    :return: The path to the action queue folder.
+    """
+    result = Path(app.config["FILES_PATH"]) / "actions_queue"
+    result.mkdir(exist_ok=True)
+    return result
+
+
+@dataclass(slots=True, frozen=True)
+class Action:
+    """
+    Base class for a recorded action
+    """
+
+    timestamp: int
+    """
+    UNIX timestamp of when the action was recorded.
+    Used for sorting the actions to apply them in correct order.
+    """
+
+    def to_str(self) -> str:
+        """
+        Return a string representation of the action.
+        The string encodes all the information necessary to load the action from string.
+
+        :return: A string representation of the action.
+        """
+        raise NotImplementedError
+
+
+@dataclass(slots=True, frozen=True)
+class GroupAction(Action):
+    """
+    Action for adding user to or removing user from a group.
+    """
+
+    action: Literal["a", "r"]
+    """
+    Action identifier. 
+    
+    a = Add user to group
+    r = Remove user from group
+    """
+    user: str
+    """
+    Username of the user to apply the action to.
+    """
+    group: str
+    """
+    Name of the UserGroup to apply the action to.
+    """
+
+    @staticmethod
+    def from_str(timestamp: int, action: Literal["a", "r"], text: str) -> "GroupAction":
+        """
+        Parse a group action from a string.
+
+        :param timestamp: UNIX timestamp of when the action was recorded.
+        :param action: Action identifier.
+        :param text: Action metadata encoded as a string.
+
+        :return: A GroupAction object
+        """
+        username, group = text.split("\n", maxsplit=1)
+        return GroupAction(
+            timestamp=timestamp,
+            user=username,
+            group=group,
+            action=action,
+        )
+
+    def to_str(self) -> str:
+        return f"{self.action}\n{self.user}\n{self.group}"
+
+
+@dataclass(slots=True, frozen=True)
+class DistRightAction(Action):
+    """
+    Action for right distribution.
+    """
+
+    action: Literal["dr"]
+    """
+    Action identifier.
+    """
+    user: str
+    """
+    User to apply the action to.
+    """
+    dist_right: DistributeRightAction
+    """
+    DistributeRightAction object, which encodes the distribution action.
+    """
+
+    @staticmethod
+    def from_str(timestamp: int, text: str) -> "DistRightAction":
+        """
+        Parse a DistRightAction from a string.
+
+        :param timestamp: UNIX timestamp of when the action was recorded.
+        :param text: Action metadata encoded as a string.
+        """
+        username, dist_right = text.split("\n", maxsplit=1)
+        dr = DistributeRightActionSchema().loads(dist_right)
+        return DistRightAction(
+            timestamp=timestamp,
+            user=username,
+            dist_right=dr,
+            action="dr",
+        )
+
+    def to_str(self) -> str:
+        return f"{self.action}\n{self.user}\n{to_json_str(self.dist_right)}"
+
+
+def _get_pending_actions() -> list[Action]:
+    """
+    Read pending group actions from disk.
+
+    :return: The pending actions that were fully written to disk.
+    """
+    actions: list[Action] = []
+
+    for action_file in _get_action_queue_path().iterdir():
+        if action_file.name.endswith(".lock"):
+            continue
+        try:
+            timestamp = int(action_file.name)
+            action, more = action_file.read_text().split("\n", maxsplit=1)
+            match action:
+                case "a":
+                    actions.append(GroupAction.from_str(timestamp, "a", more))
+                case "r":
+                    actions.append(GroupAction.from_str(timestamp, "r", more))
+                case "dr":
+                    actions.append(DistRightAction.from_str(timestamp, more))
+        except Exception as e:
+            log_warning(f"Error reading action file {action_file}: {e}, skipping")
+
+    return actions
+
+
+def _purge_actions(actions: list[Action]) -> None:
+    """
+    Purge specified actions from disk.
+
+    :param actions: The actions to purge.
+    """
+    queue_path = _get_action_queue_path()
+    for action in actions:
+        action_path = queue_path / str(action.timestamp)
+        action_path.unlink(missing_ok=True)
+
+
+def _optimize_group_actions(actions: list[GroupAction]) -> list[GroupAction]:
+    """
+    Optimize the group actions by resolving the effective action for each user.
+
+    :param actions: The group actions to optimize.
+    :return: The optimized actions. The list contains only the final effective action for each user.
+    """
+    latest_actions_by_name: dict[tuple[str, str], GroupAction] = {}
+    for a in actions:
+        latest_action = latest_actions_by_name.get((a.group, a.user), None)
+        if not latest_action:
+            latest_actions_by_name[(a.group, a.user)] = a
+            continue
+        if latest_action.timestamp < a.timestamp:
+            latest_actions_by_name[(a.group, a.user)] = a
+    return list(latest_actions_by_name.values())
+
+
+def _group_dist_right_actions(
+    actions: list[DistRightAction],
+) -> dict[str, list[DistributeRightAction]]:
+    """
+    Group distribute right actions together by user.
+
+    :param actions: The actions to group. The list will be sorted in place.
+    :return: A dictionary mapping group name to a list of distribute right actions.
+    """
+    result: dict[str, list[DistributeRightAction]] = {}
+    actions.sort(key=lambda act: act.timestamp)
+    for a in actions:
+        if a.user not in result:
+            result[a.user] = []
+        result[a.user].append(a.dist_right)
+    return result
+
+
+def _get_apply_lock(name: str) -> filelock.BaseFileLock:
+    """
+    Get a lock for applying actions.
+
+    :param name: The name of the lock.
+    :return: A file lock.
+    """
+    return filelock.FileLock((_get_action_queue_path() / f"{name}.lock").as_posix())
+
+
+def apply_pending_actions_impl() -> None:
+    """
+    Applies currently pending actions and flushes them.
+    """
+
+    # Two-lock system:
+    # 1. Processing lock ensures that only one task processes the pending actions
+    # 2. Queue lock allows another task to wait for the processing lock to process new actions
+    queue_lock = _get_apply_lock("queue")
+    processing_lock = _get_apply_lock("processing")
+
+    # FIXME: This still will not 100% prevent some actions being left unprocessed in time
+    # Example: We acquire the lock here...
+    queue_lock.acquire()
+    # ...but the user registers an action here so no second processing is registered
+    processing_lock.acquire()
+    # ... and the user registers an action here
+    queue_lock.release()
+
+    try:
+        now = datetime.datetime.now()
+        actions = _get_pending_actions()
+        if not actions:
+            return
+
+        group_actions = [a for a in actions if isinstance(a, GroupAction)]
+        dist_right_actions = [a for a in actions if isinstance(a, DistRightAction)]
+        effective_group_actions = _optimize_group_actions(group_actions)
+        grouped_dist_right_actions = _group_dist_right_actions(dist_right_actions)
+
+        group_names: set[str] = {a.group for a in effective_group_actions}
+        user_names: set[str] = {a.user for a in effective_group_actions} | {
+            a.user for a in dist_right_actions
+        }
+        memberships_to_expire: set[tuple[str, str]] = {
+            (a.group, a.user) for a in group_actions if a.action == "r"
+        }
+
+        # noinspection PyUnresolvedReferences
+        group_cache: dict[str, UserGroup] = {
+            ug.name: ug
+            for ug in UserGroup.query.filter(UserGroup.name.in_(group_names))
+        }
+        # noinspection PyUnresolvedReferences
+        user_cache: dict[str, User] = {
+            u.name: u for u in User.query.filter(User.name.in_(user_names))
+        }
+        memberships_cache: dict[tuple[int, int], UserGroupMember] = {
+            (m.usergroup_id, m.user_id): m
+            for m in UserGroupMember.query.join(UserGroup, UserGroupMember.group)
+            .join(User, UserGroupMember.user)
+            .filter(
+                tuple_(UserGroup.name, User.name).in_(memberships_to_expire)
+                & membership_current
+            )
+        }
+
+        for a in effective_group_actions:
+            ug = group_cache.get(a.group, None)
+            if not ug:
+                log_warning(
+                    f"Group {a.group} not found on '{a.action}' action for user {a.user} (timestamp: {a.timestamp})"
+                )
+                continue
+
+            u = user_cache.get(a.user, None)
+            if not u:
+                log_warning(
+                    f"User {a.user} not found on '{a.action}' action for group {a.group} (timestamp: {a.timestamp})"
+                )
+                continue
+
+            # Don't apply actions via mass query to ensure mail lists will get synced
+            if a.action == "a":
+                u.add_to_group(ug, None)
+            elif a.action == "r":
+                m = memberships_cache.get((ug.id, u.id), None)
+                if m:
+                    m.set_expired(time_offset=group_expired_offset)
+
+        db.session.commit()
+
+        for u in user_cache.values():
+            sync_user_group_memberships_if_enabled(u)
+
+        for usr_name, drs in grouped_dist_right_actions.items():
+            usr = user_cache.get(usr_name, None)
+            if not usr:
+                log_warning(f"User {usr_name} not found")
+                continue
+            errors = apply_dist_right_actions(usr, drs)
+            if errors:
+                errors_str = "\n".join(errors)
+                log_warning(
+                    f"Error applying dist right actions for user {usr_name}: {errors_str}"
+                )
+
+        _purge_actions(actions)
+
+        time_diff = datetime.datetime.now() - now
+        log_info(
+            f"Applied {len(actions)} actions in {time_diff.total_seconds()} seconds"
+        )
+    except Exception as e:
+        traceback_str = traceback.format_exc()
+        log_warning(f"Error applying pending actions: {e}, {traceback_str}")
+    finally:
+        processing_lock.release()
+
+
+def _check_lock_acquired(name: str) -> bool:
+    """
+    Check if the specified lock is already acquired by some task.
+
+    :param name: The name of the lock.
+    :return: True if the lock is acquired, False otherwise.
+    """
+    lock = _get_apply_lock(name)
+    try:
+        lock.acquire(blocking=False)  # type: ignore
+    except filelock.Timeout:
+        return True
+    lock.release()
+    return False
+
+
+def _register_action(action: Action) -> None:
+    """
+    Register an action to the action queue.
+
+    :param action: The action to register.
+    """
+    now = int(time.time() * 1000000)  # ns resolution + space for jumping if file exists
+    action_file_path = _get_action_queue_path() / str(now)
+    # Increase timestamp and try again
+    while action_file_path.exists():
+        now += 1
+        action_file_path = _get_action_queue_path() / str(now)
+
+    action_file_path.write_text(action.to_str())
+
+    if not _check_lock_acquired("queue"):
+        apply_pending_userselect_actions.delay()
+
+
+def _register_group_action(user: User, group: str, action: Literal["a", "r"]) -> None:
+    """
+    Registers a group action.
+
+    :param user: The user to process.
+    :param group: The group to process.
+    :param action: The action to register.
+    """
+    _register_action(
+        GroupAction(
+            timestamp=-1,
+            user=user.name,
+            group=group,
+            action=action,
+        )
+    )
+
+
+def register_dist_right_action(user: User, da: DistributeRightAction) -> None:
+    """
+    Registers a distribute right action.
+
+    :param user: The user to add to the group.
+    :param da: The distribute right action to register.
+    """
+    _register_action(
+        DistRightAction(
+            timestamp=-1,
+            user=user.name,
+            dist_right=da,
+            action="dr",
+        )
+    )
+
+
+def register_group_add_action(user: User, group: str) -> None:
+    """
+    Registers a group add action.
+
+    :param user: The user to add to the group.
+    :param group: The group to add the user to.
+    """
+    _register_group_action(user, group, "a")
+
+
+def register_group_remove_action(user: User, group: str) -> None:
+    """
+    Registers a group remove action.
+
+    :param user: The user to remove from the group.
+    :param group: The group to remove the user from.
+    """
+    _register_group_action(user, group, "r")

--- a/timApp/plugin/userselect/dist_right_util.py
+++ b/timApp/plugin/userselect/dist_right_util.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal, Callable
+
+from timApp.item.distribute_rights import (
+    RightOp,
+    ConfirmOp,
+    QuitOp,
+    UndoQuitOp,
+    UnlockOp,
+    ChangeTimeOp,
+    register_right_impl,
+    UndoConfirmOp,
+)
+from timApp.user.user import User
+from timApp.util.utils import get_current_time
+from tim_common.marshmallow_dataclass import class_schema
+
+
+@dataclass
+class DistributeRightAction:
+    operation: Literal[
+        "confirm",
+        "quit",
+        "unlock",
+        "changetime",
+        "undoquit",
+        "undoconfirm",
+    ]
+    target: str | list[str]
+    timestamp: datetime | None = None
+    minutes: float = 0.0
+
+    @property
+    def timestamp_or_now(self) -> datetime:
+        return self.timestamp or get_current_time()
+
+
+DistributeRightActionSchema = class_schema(DistributeRightAction)
+
+
+RIGHT_TO_OP: dict[str, Callable[[DistributeRightAction, str], RightOp]] = {
+    "confirm": lambda r, usr: ConfirmOp(
+        type="confirm",
+        email=usr,
+        timestamp=r.timestamp_or_now,
+    ),
+    "quit": lambda r, usr: QuitOp(
+        type="quit",
+        email=usr,
+        timestamp=r.timestamp_or_now,
+    ),
+    "undoquit": lambda r, usr: UndoQuitOp(
+        type="undoquit",
+        email=usr,
+        timestamp=r.timestamp_or_now,
+    ),
+    "unlock": lambda r, usr: UnlockOp(
+        type="unlock",
+        email=usr,
+        timestamp=r.timestamp_or_now,
+    ),
+    "changetime": lambda r, usr: ChangeTimeOp(
+        type="changetime",
+        email=usr,
+        secs=int(r.minutes * 60),
+        timestamp=r.timestamp_or_now,
+    ),
+    "undoconfirm": lambda r, usr: UndoConfirmOp(
+        type="undoconfirm",
+        email=usr,
+        timestamp=r.timestamp_or_now,
+    ),
+}
+
+
+def apply_dist_right_actions(
+    user_acc: User, dist_right: list[DistributeRightAction]
+) -> list[str]:
+    errors = []
+    for distribute in dist_right:
+        convert = RIGHT_TO_OP[distribute.operation]
+        right_op = convert(distribute, user_acc.email)
+        apply_errors = register_right_impl(right_op, distribute.target)
+
+        if isinstance(right_op, QuitOp):
+            # Ignore failing to undo twice. It is an error but it's not strictly an issue for UserSelect
+            # However, do this only for QuitOp to prevent other issues like trying to confirm users who has already quit
+            # TODO: Don't depend on string matching to filter out the error
+            apply_errors = [
+                e for e in apply_errors if "Cannot register a non-UndoQuitOp" not in e
+            ]
+
+        errors.extend(apply_errors)
+
+    return errors

--- a/timApp/plugin/userselect/utils.py
+++ b/timApp/plugin/userselect/utils.py
@@ -1,0 +1,4 @@
+from datetime import timedelta
+
+# It can be useful to offset the time a little to ensure any checks for expired memberships can pass
+group_expired_offset = timedelta(seconds=1)

--- a/timApp/tests/server/test_userselect.py
+++ b/timApp/tests/server/test_userselect.py
@@ -1,0 +1,152 @@
+from timApp.tests.server.timroutetest import TimRouteTest
+from timApp.timdb.sqa import db
+from timApp.user.user import UserInfo, User
+from timApp.user.usergroup import UserGroup
+
+
+class UserSelectTest(TimRouteTest):
+    """
+    Tests for UserSelect plugin.
+    """
+
+    def test_userselect_queued_group_actions(self) -> None:
+        """UserSelect: Test that basic queued group actions work"""
+
+        # Note: we need to run these test in sequence because the processing queue is shared
+
+        User.create_with_group(
+            UserInfo(
+                username="testadmin1",
+                full_name="Test Admin 1",
+                email="testadmin1@test.org",
+                password="testadmin1",
+            ),
+            is_admin=True,
+        )
+        all_g = UserGroup.create("queue-testusers-all1")
+        target_g = UserGroup.create("queue-testusers-target1")
+        db.session.flush()
+
+        self.test_user_1.add_to_group(all_g, None)
+        self.test_user_2.add_to_group(all_g, None)
+        self.test_user_3.add_to_group(all_g, None)
+
+        db.session.commit()
+
+        self.login(
+            username="testadmin1", email="testadmin1@test.org", passw="testadmin1"
+        )
+        d = self.create_doc(
+            initial_par="""
+``` {#user_select1 plugin="userSelect"}
+groups:
+    - queue-testusers-all1
+useActionQueues: true
+actions:
+    addToGroups: [queue-testusers-target1]
+```
+
+``` {#user_select2 plugin="userSelect"}
+groups:
+    - queue-testusers-all1
+useActionQueues: true
+actions:
+    removeFromGroups: [queue-testusers-target1]
+```
+"""
+        )
+
+        db.session.commit()
+
+        pars = d.document.get_paragraphs()
+
+        add_group_block_id = pars[0].id
+        remove_group_block_id = pars[1].id
+        doc_id = d.document.doc_id
+
+        with self.temp_config({"USERSELECT_QUEUED_ACTIONS_CELERY": False}):
+            self.subtest_queued_group_actions_add(
+                doc_id, add_group_block_id, remove_group_block_id, target_g.name
+            )
+            self.subtest_queued_group_actions_remove_add_concurrent(
+                doc_id, add_group_block_id, remove_group_block_id, target_g.name
+            )
+
+    def subtest_queued_group_actions_add(
+        self,
+        doc_id: int,
+        add_group_block_id: str,
+        remove_group_block_id: str,
+        target_g_name: str,
+    ) -> None:
+        self.json_post(
+            "/userSelect/apply",
+            {
+                "par": {
+                    "doc_id": doc_id,
+                    "par_id": add_group_block_id,
+                },
+                "username": self.test_user_1.name,
+            },
+        )
+
+        self.get("/userSelect/applyPendingActions")
+
+        ug = UserGroup.get_by_name(target_g_name)
+
+        self.assertEqual({self.test_user_1.name}, {u.name for u in ug.users})
+
+        self.json_post(
+            "/userSelect/apply",
+            {
+                "par": {
+                    "doc_id": doc_id,
+                    "par_id": remove_group_block_id,
+                },
+                "username": self.test_user_1.name,
+            },
+        )
+
+        self.get("/userSelect/applyPendingActions")
+
+        ug = UserGroup.get_by_name(target_g_name)
+        db.session.refresh(ug)
+
+        self.assertEqual(set(), {u.name for u in ug.users})
+
+    def subtest_queued_group_actions_remove_add_concurrent(
+        self,
+        doc_id: int,
+        add_group_block_id: str,
+        remove_group_block_id: str,
+        target_g_name: str,
+    ) -> None:
+        # Applying two operations for the same user only should apply the latest action
+        self.json_post(
+            "/userSelect/apply",
+            {
+                "par": {
+                    "doc_id": doc_id,
+                    "par_id": add_group_block_id,
+                },
+                "username": self.test_user_2.name,
+            },
+        )
+
+        self.json_post(
+            "/userSelect/apply",
+            {
+                "par": {
+                    "doc_id": doc_id,
+                    "par_id": remove_group_block_id,
+                },
+                "username": self.test_user_2.name,
+            },
+        )
+
+        self.get("/userSelect/applyPendingActions")
+
+        ug = UserGroup.get_by_name(target_g_name)
+        db.session.refresh(ug)
+
+        self.assertEqual(set(), {u.name for u in ug.users})

--- a/timApp/tim_celery.py
+++ b/timApp/tim_celery.py
@@ -276,3 +276,10 @@ def cleanup_oauth2_tokens():
     from timApp.auth.oauth2.oauth2 import delete_expired_oauth2_tokens
 
     delete_expired_oauth2_tokens()
+
+
+@celery.task(ignore_result=True)
+def apply_pending_userselect_actions() -> None:
+    from timApp.plugin.userselect.action_queue import apply_pending_actions_impl
+
+    apply_pending_actions_impl()

--- a/timApp/util/logger.py
+++ b/timApp/util/logger.py
@@ -14,10 +14,18 @@ wz = logging.getLogger("werkzeug")
 wz.setLevel(logging.ERROR)
 
 
+IN_CELERY_WORKER_PROCESS = (
+    sys.argv and sys.argv[0].endswith("celery") and "worker" in sys.argv
+)
+
+
 def setup_logging(app: Flask) -> None:
     if not app.config["TESTING"]:
         logging.getLogger("alembic").level = logging.INFO
-    formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s ")
+    log_format = "%(asctime)s %(levelname)s: %(message)s "
+    if IN_CELERY_WORKER_PROCESS:
+        log_format = "%(asctime)s [CELERY] %(levelname)s: %(message)s "
+    formatter = logging.Formatter(log_format)
     os.makedirs(app.config["LOG_DIR"], exist_ok=True)
     file_handler = TIMRotatingLogFileHandler(
         app.config["LOG_PATH"],

--- a/tim_common/collections.py
+++ b/tim_common/collections.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+from typing import Any, Callable
+
+
+class keydefaultdict(defaultdict):
+    """
+    Extended defaultdict that invokes the default factory while passing the key to it.
+    """
+
+    def __init__(
+        self, default_factory: Callable[[Any], Any], *args: Any, **kwargs: Any
+    ) -> None:
+        super().__init__(default_factory, *args, **kwargs)  # type: ignore
+
+    def __missing__(self, key: Any) -> Any:
+        if self.default_factory is None:
+            raise KeyError(key)
+        else:
+            def_key: Callable[[Any], Any] = self.default_factory  # type: ignore
+            ret = self[key] = def_key(key)
+            return ret


### PR DESCRIPTION
Tämä PR lisää UserSelect-komponenttiin `useActionQueues`-attribuutin, joka puskuroi ryhmä- ja oikeuslevitystoimintojen ajamista. Lisäksi pari pientä muutosta:

* Celerystä tulevat lokit merkitään `[CELERY]`-tagilla
* Lisätty `keydefaultdict`, joka toimii kuten `defaultdict`, mutta `default_factory` saa parametriksi avaimen, jolla alkio haettiin

Olennaisin puskuroinnin käyttötarkoitus ovat valtavat tentit, jossa tenttijöitä kirjataan sisään saliryhmiin UserSelectilla. Näissä tenteissa UserSelect on usein konfiguroitu seuraavasti:

```yaml
    changeGroup:
      changeTo: %%saliryhma%%
      allGroups:
        - sali1
        - sali2
        - sali3
      verify: true
```

Kun tenttijä "piipataan" sisään UserSelectilla, yllä oleva esimerkki tomii seuraavasti:

* Tarkistetaan, kuuluuko tenttijä johonkin listattuun saliryhmään. Jos on, laitetaan asiasta varoitus.
* Lisätään tenttijä saliin `%%saliryhma%%`
* Poistetaan tenttijä muista salirymistä

Massatenteissa (esim. valintakokeissa) on usein kymmeniä valvojia kirjaamassa monta tenttijää sisään. Koska nyt muutokset ajetaan suoraan tietokantaan, joudutaan synkronoimaan operaatiot lukituksella. Viime vuonna havaittiin, että tällainen suora tietokantaan ajo + synkronointi on pullonkaula massatenteissa: jossain tapauksissa valvoja on joutunut odottamaan jopa 10 sekuntia yhden tenttijän kirjaamiseksi. Toisen pullonkaulan aiheuttaa oikeuksien levitys ja siihen liittyvä lukitus.

Tämä PR lisää UserSelectiin käsittelyjonon, joka puretaan taustalla Celery-workerissa. Käsittelyjonon ansiosta valvojan ei tarvitse odottaa sisäänkirjauksen viimeistelyä, vaan se hoituu taustalla. Täten valvojan kokema sisäänkirjaus on nopeampi, ja käsittelyoperaatiot puskuroidaan yhdeksi operaatioksi vähentäen tietokantakutsuja.

## Nopeustestausta

### Asetukset

Ajoin nopeustestit lokaalisti, koska niiden toistaminen palvelimella on hieman hankalaa. Testien tarkoitus on vain verrata kahta tapaa, joten riittää lokaali setuppi.
Testausympäristö:

* CPU: 12 ydintä
* SSD-levy
* TIM-palvelimella 6 workeria
* Testipalvelimelle tehty 5000 testitunnusta tunnuksella `mass{1..5000}`. Tunnukset lisättiin ryhmään `userselectgroup0`
* Testipalvelimelle tehty myös ryhmät `userselectgroup{1..10}`
* Kuormitus ajettu admin-käyttäjällä

<details><summary>Testausskripti</summary>
<p>

Skripti on pastettu sellaisenaan ja vaatii muokkausta. Pohjana on käytetty [tim-api](https://gitlab.jyu.fi/dezhidki/tim-api-py)-kirjastoa.

```py
import math
import datetime
import multiprocessing

domain = "http://localhost"

def apply_user(num: int) -> float:
    import os

    os.environ["TIM_DOMAIN"] = domain
    os.environ["TIM_USERNAME"] = "dz"
    os.environ["TIM_PASSWORD"] = "dz"

    from tim import get_session

    session = get_session()

    now = datetime.datetime.now()

    session.post(f"{domain}/userSelect/apply", json={
        "par": {
            "doc_id": 158,
            "par_id": "ntk7H4WsuOCg"
        },
        "username": f"mass{num}"
    })

    time_diff = datetime.datetime.now() - now
    time_diff_ms = time_diff.total_seconds() * 1000
    return int(time_diff_ms)


MIN = 1
MAX = 1000
BATCH_SIZE = 12


if __name__ == "__main__":
    with multiprocessing.Pool(processes=BATCH_SIZE) as pool:
        now = datetime.datetime.now()
        results = pool.map(apply_user, range(MIN, MAX + 1))
        time_diff = datetime.datetime.now() - now
        time_diff_ms = time_diff.total_seconds() * 1000
        print(results)
        # print standard deviation and standard error of mean
        mean = sum(results) / len(results)
        std_dev_sample = math.sqrt(sum([(x - mean) ** 2 for x in results]) / (len(results) - 1))
        se = std_dev_sample / math.sqrt(len(results))
        print("total time:", time_diff_ms)
        print("req/sec:", len(results) / (time_diff_ms / 1000))
        print("mean:", mean)
        print(f"min: {min(results)}, max: {max(results)}")
        print(f"std dev: {std_dev_sample}")
        print(f"se: {se}")
        print(f"n over 1000: {sum(1 for x in results if x > 1000)}")

        import matplotlib.pyplot as plt
        
        # histogram with bins between 100 ms
        plt.hist(results, bins=[i for i in range(0, max(results), 100)])
        # set grid lines for x and y
        plt.grid(True)
        # set x ticks between 100 starting at 0
        plt.xticks(range(0, max(results), 500))
        # Set x axis title to "time (ms)" and y axis title to ("frequency")
        plt.xlabel("time (ms)")
        plt.ylabel("frequency")
        plt.show()
```

</p>
</details> 

<details><summary>Testausdokumentin markup</summary>
<p>

````md
``` {#user_select plugin="userSelect" id="ntk7H4WsuOCg"}
groups:
    - userselectgroup0
useActionQueues: true
actions:
    changeGroup:
      changeTo: userselectgroup2
      allGroups:
        - userselectgroup1
        - userselectgroup2
        - userselectgroup3
        - userselectgroup4
        - userselectgroup5
        - userselectgroup6
        - userselectgroup7
        - userselectgroup8
        - userselectgroup9
        - userselectgroup10
      verify: false

    distributeRight:
      - operation: confirm
        target: ["leikki"]

    setValue:
      - taskId: 158.salimeni
        value: "testvalue1"
```

#- {defaultplugin="textfield" readonly="view" .fieldCell id="24TLdKuuaitb"}
{#salimeni #}
````

</p>
</details> 

<details><summary>`timApp/tim_files/leikki.rights.initial`</summary>
<p>

```
{"require_confirm":true,"accessible_from":"2023-05-06T15:00:00+00:00","accessible_to":"2023-05-06T18:00:00+00:00","duration":null,"duration_from":null,"duration_to":null}
{"type":"changetime","email":"mass1@test.org","secs":3600,"timestamp":"2023-05-30T15:00:00+00:00"}
{"type":"changestarttimegroup","group":"userselectgroup1","starttime":"2023-05-06T15:11:00+00:00","timestamp":"2023-05-30T15:00:00+00:00"}
{"type":"changestarttimegroup","group":"userselectgroup2","starttime":"2023-05-06T15:12:00+00:00","timestamp":"2023-05-30T15:00:00+00:00"}
{"type":"changestarttimegroup","group":"userselectgroup3","starttime":"2023-05-06T15:13:00+00:00","timestamp":"2023-05-30T15:00:00+00:00"}
```

</p>
</details> 

### Tulokset

**`useActionQueues: false`**

Tämä edustaa nykyistä tilannetta masterissa.

```
total time: 82961.63 ms
req/sec: 12.05 ms
mean: 947.76 ms
min: 74 ms, max: 8933 ms
std dev: 1171.84 ms
se: 37.05 ms
n over 1000 ms: 285
```

Histogrammi kaikkien kutsujen kestosta:
![plot_userselect_synchronized_12batch_6workers](https://user-images.githubusercontent.com/5202606/236645745-ba0b24db-d8dc-45b7-9eb3-8d5030bf4d41.png)

Huomioita:

* 285 kutsun kohdalla jouduttu odottamaan yli 1 sekunti piippauksen loppuun
* Suurin osa kuitenkin silti nopeat, monet kutstut alle 100ms
* Yhteensä 1000 tenttijän prosessointiin meni 1 min 23 sek

**`useActionQueues: true`**

Tämä vastaa tämän PR:n muutoksia

```
total time: 30757.74 ms
req/sec: 32.51 ms
mean: 343.46 ms
min: 99 ms, max: 841 ms
std dev: 104.53 ms
se: 3.30 ms
n over 1000: 0
```

Histogrammi kaikkien kutsujen kestosta:
![plot_userselect_queried_12batch_6workers](https://user-images.githubusercontent.com/5202606/236645857-61c49143-a4b6-48db-9437-65e66dc5cbe5.png)

Huomioita:

* Noin 2,5 -kertainen prosessointivolyymi (req/sec)
* Mikään piippaus ei kestänyt yli 1 sekunnnin
* **Mutta:** koko jonon käsittelyyn meni noin 1 min 30 sek. Toisin sanoin piippauksen jälkeen meni noin 1,5 min kunnes tenttijä pääsi saliryhmään. Tässä toki pitää ottaa huomioon, että samaan aikaan yritettiin ajaa 1000 tenttijää niin nopeasti kuin pystyy, mikä kasvatti käsittelyjonon liian nopeasti suureksi. Oikeassa tentissä tuskin tällaiseen tilanteeseen päädytään. 

Kaikkiaan siis käsittelyjono nopeutti merkittävästi valvojien piippausta.
