### PR TITLE
Hide reviewable name

### DIFF
--- a/timApp/velp/annotation.py
+++ b/timApp/velp/annotation.py
@@ -305,6 +305,8 @@ def get_annotations(doc_id: int, only_own: bool = False) -> Response:
         for p in peer_reviews:
             if p.reviewer_id != current_user.id:
                 p.reviewer.anonymize = True
+            if p.reviewable_id != current_user.id:
+                p.reviewable.anonymize = True
     elif not has_seeanswers_access(d):
         # TODO: these checks should be changed to something else
         #  - in future peerreview pairing may be changeable, but anonymization info should persist
@@ -316,6 +318,8 @@ def get_annotations(doc_id: int, only_own: bool = False) -> Response:
         for p in peer_reviews:
             if p.reviewer_id != current_user.id:
                 p.reviewer.hide_name = True
+            if p.reviewable_id != current_user:
+                p.reviewable.hide_name = True
 
     return no_cache_json_response(
         {"annotations": results, "peer_reviews": peer_reviews}, date_conversion=True

--- a/timApp/velp/annotation.py
+++ b/timApp/velp/annotation.py
@@ -302,11 +302,14 @@ def get_annotations(doc_id: int, only_own: bool = False) -> Response:
     if should_anonymize_annotations(d, current_user):
         curruser_id = current_user.id
         anonymize_annotations(results, curruser_id)
-        for p in peer_reviews:
-            if p.reviewer_id != current_user.id:
-                p.reviewer.anonymize = True
-            if p.reviewable_id != current_user.id:
-                p.reviewable.anonymize = True
+        # TODO: We can't anonymize pr rows yet:
+        #   - user id is needed to find correct target when saving the review,
+        #   and anonymized users get id -1.
+        # for p in peer_reviews:
+        #     if p.reviewer_id != current_user.id:
+        #         p.reviewer.anonymize = True
+        #     if p.reviewable_id != current_user.id:
+        #         p.reviewable.anonymize = True
     elif not has_seeanswers_access(d):
         # TODO: these checks should be changed to something else
         #  - in future peerreview pairing may be changeable, but anonymization info should persist


### PR DESCRIPTION
- Poistaa anonymize_reviewers-asetuksen vaikutuksen vertaisarviointeihin. Nykytoteutuksella tuota ei voi käyttää vertaisarvioijien anonymisointiin, sillä vertaisarviointia varten on pakko tietää selaimessa arvioitavan käyttäjäid. Aiemmin tuo oli käytössä niin että arvioijan id piilotettiin, mutta jos arvioija sattui myös vertaisarvioitavaksi kohteeksi niin kohteen id piilotettiin myös, mikä rikkoi vertaisarviointia
- Piilottaa get_annotations-reitissä myös arvioitavan nimen, eikä vain arvioijan nimeä