### PR TITLE
Always warn about blocked ip

### DIFF
--- a/timApp/admin/global_notification.py
+++ b/timApp/admin/global_notification.py
@@ -28,7 +28,7 @@ def inject_global_notifications() -> dict:
             notifications.append(("global-message", f.read()))
     except FileNotFoundError:
         pass
-    if not logged_in() and not is_allowed_ip():
+    if not is_allowed_ip():
         ip_block_msg = current_app.config["IP_BLOCK_MESSAGE"]
         if ip_block_msg:
             notifications.append(("ip-block-message", ip_block_msg))

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -608,7 +608,10 @@ def post_answer(
     :param abData: Data applied from answer browser
     """
     curr_user = get_current_user_object()
-    blocked_msg = "Answering is not allowed from this IP address."
+    blocked_msg = (
+        current_app.config["IP_BLOCK_ROUTE_MESSAGE"]
+        or "Answering is not allowed from this IP address."
+    )
     allowed = verify_ip_ok(user=curr_user, msg=blocked_msg)
     return json_response(
         post_answer_impl(

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1261,7 +1261,7 @@ def post_answer_impl(
     except:
         pass
     if result_errors:
-        result["errors"] = result.get("errors", []) + result_errors
+        result["errors"] = result_errors
 
     return AnswerRouteResult(result=result, plugin=plugin)
 

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -608,7 +608,8 @@ def post_answer(
     :param abData: Data applied from answer browser
     """
     curr_user = get_current_user_object()
-    verify_ip_ok(user=curr_user, msg="Answering is not allowed from this IP address.")
+    blocked_msg = "Answering is not allowed from this IP address."
+    allowed = verify_ip_ok(user=curr_user, msg=blocked_msg)
     return json_response(
         post_answer_impl(
             task_id_ext,
@@ -619,6 +620,7 @@ def post_answer(
             get_urlmacros_from_request(),
             get_other_session_users_objs(),
             get_origin_from_request(),
+            error=blocked_msg if not allowed else None,
         ).result
     )
 
@@ -703,6 +705,7 @@ def post_answer_impl(
     urlmacros: UrlMacros,
     other_session_users: list[User],
     origin: OriginInfo | None,
+    error: str | None = None,
 ) -> AnswerRouteResult:
     receive_time = get_current_time()
     tid = TaskId.parse(task_id_ext)
@@ -867,6 +870,7 @@ def post_answer_impl(
     }
 
     result = {}
+    result_errors: list[str] = [error] if error else []
     web = ""
 
     def set_postoutput(result: dict, output: Any | None, outputname: str) -> None:
@@ -891,7 +895,11 @@ def post_answer_impl(
 
     def postprogram_result(data: dict, output: Any | None, outputname: str) -> None:
         result["web"] = data.get("web", web)
-        add_value(result, "error", data)
+        err = data.get("error", None)
+        if err:
+            if err.startswith("md:"):
+                err = call_dumbo([err[3:]])[0]
+            result_errors.append(err)
         add_value(result, "feedback", data)
         add_value(result, "topfeedback", data)
         if output.startswith("md:"):
@@ -1069,7 +1077,7 @@ def post_answer_impl(
                 try:
                     points = plugin.validate_points(answer_browser_data.get("points"))
                 except PluginException as e:
-                    result["error"] = str(e)
+                    result_errors.append(str(e))
                 else:
                     points_given_by = get_current_user_group()
 
@@ -1169,7 +1177,7 @@ def post_answer_impl(
             # Validity info can be different from error (e.g. answer can be valid but error is given by postprogram)
             result["valid"] = is_valid
             if not is_valid:
-                result["error"] = explanation
+                result_errors.append(explanation)
         elif save_teacher:
             # Getting points from teacher ignores points automatically computed by the task
             # For now we accept task points since most of the time that's what a teacher might want
@@ -1249,6 +1257,8 @@ def post_answer_impl(
             )  # TODO: stdy why someone puts markup here
     except:
         pass
+    if result_errors:
+        result["errors"] = result.get("errors", []) + result_errors
 
     return AnswerRouteResult(result=result, plugin=plugin)
 

--- a/timApp/auth/accesshelper.py
+++ b/timApp/auth/accesshelper.py
@@ -886,7 +886,7 @@ def get_ipblocklist_path() -> Path:
     return Path(current_app.config["FILES_PATH"]) / "ipblocklist"
 
 
-def verify_ip_ok(user: User | None, msg: str = "IPNotAllowed"):
+def verify_ip_ok(user: User | None, msg: str = "IPNotAllowed") -> bool:
     if (not user or not user.is_admin) and not is_allowed_ip():
         username = user.name if user else "Anonymous"
         cfg = current_app.config
@@ -921,6 +921,9 @@ User: {username}
             )
         if should_block:
             raise AccessDenied(msg)
+        return False
+    else:
+        return True
 
 
 def verify_user_create_right(curr_user: User) -> None:

--- a/timApp/auth/accesshelper.py
+++ b/timApp/auth/accesshelper.py
@@ -886,7 +886,7 @@ def get_ipblocklist_path() -> Path:
     return Path(current_app.config["FILES_PATH"]) / "ipblocklist"
 
 
-def verify_ip_ok(user: User | None, msg: str = "IPNotAllowed") -> bool:
+def verify_ip_ok(user: User | None, msg: str | None = None) -> bool:
     if (not user or not user.is_admin) and not is_allowed_ip():
         username = user.name if user else "Anonymous"
         cfg = current_app.config
@@ -920,7 +920,7 @@ User: {username}
                 """.strip(),
             )
         if should_block:
-            raise AccessDenied(msg)
+            raise AccessDenied(msg or cfg["IP_BLOCK_ROUTE_MESSAGE"] or "IPNotAllowed")
         return False
     else:
         return True

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -328,6 +328,9 @@ IP_BLOCK_ALLOWLIST = None
 # The informational message to display in TIM header if the IP is outside the allowlist.
 IP_BLOCK_MESSAGE = None
 
+# The message sent as reply whenever a blocked route is called by an IP outside the allowlist.
+IP_BLOCK_ROUTE_MESSAGE = None
+
 # If true, IPs that are:
 # * outside allowed networks and
 # * not in blocklist

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -118,7 +118,7 @@ export interface ITaskInfo {
 
 export interface IAnswerSaveEvent {
     savedNew: number | false;
-    error?: string;
+    errors?: [string];
     topfeedback?: string;
     feedback?: string;
     valid?: boolean;
@@ -317,15 +317,20 @@ export class AnswerBrowserComponent
             // HACK: for some reason the math mode is lost because of the above call, so we restore it here
             ParCompiler.processAllMathDelayed(this.loader.getPluginElement());
         }
-        if (args.error) {
+        if (args.errors) {
             const markup = this.pluginMarkup();
-            let displayAlert = true;
-            if (markup?.warningFilter) {
-                const pattern = new RegExp(markup.warningFilter, "i");
-                displayAlert = !pattern.test(args.error);
-            }
-            if (displayAlert) {
-                this.alerts.push({msg: args.error, type: "warning"});
+            const pattern = markup?.warningFilter
+                ? new RegExp(markup.warningFilter, "i")
+                : undefined;
+
+            for (const e of args.errors) {
+                let displayAlert = true;
+                if (pattern) {
+                    displayAlert = !pattern.test(e);
+                }
+                if (displayAlert) {
+                    this.alerts.push({msg: e, type: "warning"});
+                }
             }
         }
         this.showFeedback(args.topfeedback);

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -324,6 +324,9 @@ export class AnswerBrowserComponent
                 : undefined;
 
             for (const e of args.errors) {
+                if (e == undefined) {
+                    continue;
+                }
                 let displayAlert = true;
                 if (pattern) {
                     displayAlert = !pattern.test(e);

--- a/timApp/static/scripts/tim/document/interceptor.ts
+++ b/timApp/static/scripts/tim/document/interceptor.ts
@@ -121,7 +121,7 @@ timApp.config([
                         const resp =
                             response as IHttpResponse<IAnswerSaveEvent>;
                         handleAnswerResponse(taskIdFull, {
-                            error: resp.data.error,
+                            errors: resp.data.errors,
                             feedback: resp.data.feedback,
                             topfeedback: resp.data.topfeedback,
                             savedNew: resp.data.savedNew,
@@ -141,7 +141,7 @@ timApp.config([
                         const resp =
                             response as IHttpResponse<IAnswerSaveEvent>;
                         handleAnswerResponse(taskIdFull, {
-                            error: resp.data.error,
+                            errors: resp.data.errors,
                             savedNew: false,
                             valid: false,
                         });

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -254,7 +254,7 @@ export abstract class AngularPluginBase<
         if (result.ok) {
             handleAnswerResponse(dt, {
                 savedNew: result.result.savedNew,
-                error: result.result.error,
+                errors: result.result.errors,
                 feedback: result.result.feedback,
                 topfeedback: result.result.topfeedback,
                 valid: result.result.valid,
@@ -265,7 +265,7 @@ export abstract class AngularPluginBase<
             handleAnswerResponse(dt, {
                 savedNew: false,
                 valid: false,
-                error: result.result.error.error,
+                errors: [result.result.error.error],
             });
         }
         return result;

--- a/timApp/static/scripts/tim/plugin/import-data/import-data.component.ts
+++ b/timApp/static/scripts/tim/plugin/import-data/import-data.component.ts
@@ -315,8 +315,8 @@ export class ImportDataComponent extends AngularPluginBase<
             this.error = r.result.error.error;
             return;
         }
-        if (r.result.error) {
-            this.error = r.result.error;
+        if (r.result.errors) {
+            this.error = r.result.errors.join("\n");
             return;
         }
         this.importResult = r.result.web.fieldresult;

--- a/timApp/static/scripts/tim/plugin/mmcq/mmcq.ts
+++ b/timApp/static/scripts/tim/plugin/mmcq/mmcq.ts
@@ -183,7 +183,7 @@ export class MMCQ extends MCQBase<null | boolean[]> {
             this.checked = true;
             handleAnswerResponse(ident, {
                 savedNew: r.result.savedNew,
-                error: r.result.error,
+                errors: r.result.errors,
                 feedback: r.result.feedback,
                 topfeedback: r.result.topfeedback,
                 valid: r.result.valid,
@@ -194,7 +194,7 @@ export class MMCQ extends MCQBase<null | boolean[]> {
             handleAnswerResponse(ident, {
                 savedNew: false,
                 valid: false,
-                error: r.result.error.error,
+                errors: [r.result.error.error],
             });
             await showMessageDialog(r.result.error.error);
         }
@@ -262,7 +262,7 @@ export class MCQ extends MCQBase<number | null> {
             this.content = r.result.web;
             handleAnswerResponse(ident, {
                 savedNew: r.result.savedNew,
-                error: r.result.error,
+                errors: r.result.errors,
                 feedback: r.result.feedback,
                 topfeedback: r.result.topfeedback,
                 valid: r.result.valid,
@@ -273,7 +273,7 @@ export class MCQ extends MCQBase<number | null> {
             handleAnswerResponse(ident, {
                 savedNew: false,
                 valid: false,
-                error: r.result.error.error,
+                errors: [r.result.error.error],
             });
             await showMessageDialog(r.result.error.error);
         }

--- a/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
+++ b/timApp/static/scripts/tim/plugin/reviewcanvas/review-canvas.component.ts
@@ -538,7 +538,7 @@ export class ReviewCanvasComponent
 
         if (r.ok) {
             const data = r.result;
-            this.error = data.error;
+            this.error = data.errors?.join("\n");
             this.changes = false;
             if (r.result.savedNew) {
                 this.updatePDFDownloadUrl(r.result.savedNew);

--- a/timApp/tests/server/test_late_answers.py
+++ b/timApp/tests/server/test_late_answers.py
@@ -27,7 +27,13 @@ answerLimit: 1
         a = self.post_answer("textfield", f"{d.id}.t", user_input={"c": "x"})
         err = "Your view access to this document has expired, so this answer was saved but marked as invalid."
         self.assertEqual(
-            {"error": err, "savedNew": 1, "valid": False, "web": {"result": "saved"}}, a
+            {
+                "errors": [err],
+                "savedNew": 1,
+                "valid": False,
+                "web": {"result": "saved"},
+            },
+            a,
         )
         self.test_user_2.grant_access(
             d, AccessType.view, accessible_to=get_current_time() - timedelta(minutes=5)
@@ -41,7 +47,13 @@ answerLimit: 1
         )
         a = self.post_answer("textfield", f"{d.id}.t", user_input={"c": "z"})
         self.assertEqual(
-            {"error": err, "savedNew": 2, "valid": False, "web": {"result": "saved"}}, a
+            {
+                "errors": [err],
+                "savedNew": 2,
+                "valid": False,
+                "web": {"result": "saved"},
+            },
+            a,
         )
         d.document.set_settings({"answer_grace_period": "x"})
         self.post_answer(
@@ -64,7 +76,7 @@ answerLimit: 1
                 "web": {"result": "saved"},
                 "savedNew": 5,
                 "valid": False,
-                "error": "You have exceeded the answering limit.",
+                "errors": ["You have exceeded the answering limit."],
             },
             a,
         )

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -229,6 +229,7 @@ class GenericMarkupModel(KnownMarkupFields):
     undo: UndoInfo | Missing | None = missing
     answerBrowser: AnswerBrowserInfo | Missing | None = missing
     spellcheck: bool | None | Missing = missing
+    warningFilter: str | Missing | None = missing
 
     def get_visible_data(self) -> dict:
         assert isinstance(self.hidden_keys, list)


### PR DESCRIPTION
- Näyttää väärästä ip:stä tuleville varoituksen myös sisäänkirjautumisen jälkeen (myös admineille)
- Näyttää jokaisessa vastausyrityksessä ip-varoituksen (ei admineille)
  - Toistaiseksi `Answering is not allowed from this IP address.`, ehkä parempi jos näyttäisi configin ip_block_messagea? 
- Answer-reitin onnistuneesta kutsusta voi tulla nyt useampi virhe, jotka kaikki näytetään erillisinä virheinä. 

Devsissä on muuten sama haara paitsi sähköpostivaroitukset poistettu
https://timdevs01-3.it.jyu.fi/view/answerlimit