### PR TITLE
Add task_count support for pointsumrule tally

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -726,22 +726,26 @@ class SumFields(TypedDict):
     total_sum: float | None
 
 
+class CountFields(TypedDict):
+    task_count: int
+    velped_task_count: int
+
+
 class DateFields(TypedDict):
     first_answer_on: datetime | None
     last_answer_on: datetime | None
     answer_duration: timedelta | None
 
 
-class UserPointGroup(SumFields, DateFields):
+class UserPointGroup(SumFields, DateFields, CountFields):
     tasks: list[UserTaskEntry]
-    velped_task_count: int
 
 
 class UserPointInfo(SumFields):
     groups: DefaultDict[str, UserPointGroup]
 
 
-class ResultGroup(SumFields, DateFields):
+class ResultGroup(SumFields, DateFields, CountFields):
     text: str
     link: bool
     linktext: str
@@ -807,6 +811,7 @@ def get_points_by_rule(
                     "task_sum": None,
                     "velp_sum": None,
                     "total_sum": None,
+                    "task_count": 0,
                     "velped_task_count": 0,
                     "first_answer_on": None,
                     "last_answer_on": None,
@@ -876,6 +881,7 @@ def get_points_by_rule(
             group["velped_task_count"] = sum(
                 1 for t in group["tasks"] if t["velped_task_count"] > 0
             )
+            group["task_count"] = len(group["tasks"])
             if task_sum is not None and velp_sum is not None:
                 total_sum: float | None = task_sum + velp_sum
             elif task_sum is not None:
@@ -1004,6 +1010,8 @@ def flatten_points_result(
                 first_answer_on = gr["first_answer_on"]
                 last_answer_on = gr["last_answer_on"]
                 answer_duration = gr["answer_duration"]
+                task_count = gr["task_count"]
+                velped_task_count = gr["velped_task_count"]
             else:
                 task_sum = None
                 velp_sum = None
@@ -1011,6 +1019,8 @@ def flatten_points_result(
                 first_answer_on = None
                 last_answer_on = None
                 answer_duration = None
+                task_count = 0
+                velped_task_count = 0
             try:
                 linktext = rg.linktext or rule.linktext
                 link = rg.link
@@ -1036,6 +1046,8 @@ def flatten_points_result(
                 "first_answer_on": first_answer_on,
                 "last_answer_on": last_answer_on,
                 "answer_duration": answer_duration,
+                "task_count": task_count,
+                "velped_task_count": velped_task_count,
             }
         result_list.append(row)
     return result_list

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -892,6 +892,8 @@ user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re
                             "first_answer_on": None,
                             "last_answer_on": None,
                             "answer_duration": None,
+                            "task_count": 3,
+                            "velped_task_count": 3,
                         },
                     ),
                     (
@@ -906,6 +908,8 @@ user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re
                             "first_answer_on": None,
                             "last_answer_on": None,
                             "answer_duration": None,
+                            "task_count": 3,
+                            "velped_task_count": 3,
                         },
                     ),
                     (
@@ -920,6 +924,8 @@ user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re
                             "first_answer_on": None,
                             "last_answer_on": None,
                             "answer_duration": None,
+                            "task_count": 3,
+                            "velped_task_count": 2,
                         },
                     ),
                 ]
@@ -938,6 +944,8 @@ user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re
                             "first_answer_on": None,
                             "last_answer_on": None,
                             "answer_duration": None,
+                            "task_count": 3,
+                            "velped_task_count": 3,
                         },
                     ),
                     (
@@ -952,6 +960,8 @@ user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re
                             "first_answer_on": None,
                             "last_answer_on": None,
                             "answer_duration": None,
+                            "task_count": 3,
+                            "velped_task_count": 3,
                         },
                     ),
                     (
@@ -966,6 +976,8 @@ user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re
                             "first_answer_on": None,
                             "last_answer_on": None,
                             "answer_duration": None,
+                            "task_count": 3,
+                            "velped_task_count": 2,
                         },
                     ),
                 ]

--- a/timApp/util/get_fields.py
+++ b/timApp/util/get_fields.py
@@ -387,7 +387,7 @@ def get_fields_and_users(
             .with_entities(User.id, Answer.task_id, cnt)
             .all()
         )
-        for (uid, taskid, count) in answer_counts:
+        for uid, taskid, count in answer_counts:
             counts[uid][taskid] = count
     last_user = None
     user_tasks = None
@@ -538,8 +538,8 @@ def get_tally_field_values(
                         field.field
                     ]  # The group should exist because the field was validated above.
                     value = (
-                        value[field.subfield]
-                        if field.subfield in value
+                        value.get(field.subfield, None)
+                        if field.subfield
                         else value["total_sum"]
                     )
                 tally_field_values[u.id].append((value, alias or field.doc_and_field))


### PR DESCRIPTION
Fixes #3389 

Salli oikeanlaisen tehtyjen tehtävien lukumäärän selvittämisen pisteryhmittelijästä käyttäen `tally:123.rule.task_count` ja `tally:123.rule.velped_task_count` -kenttiä. Tässä tapauksessa `task_count` kertoo, kuinka monta pisteryhmittelijän tehtävää käyttäjä on tehnyt ja `velped_task_count` kertoo, kuinka monessa pisteryhmittelijän tehtävää on velpattu.

Lisäksi korjaa bugin, jossa määritelmättömän pisteryhmittelijäkentän käyttö (esim. `tally:123.rule.joku`) palautti automaattisesti `total_points`.

Testi/esimerkki: <https://timdevs01-5.it.jyu.fi/view/users/test-user-1/test-tally-taskcount> 