### PR TITLE
Fix pr generation in translations

### DIFF
--- a/timApp/item/partitioning.py
+++ b/timApp/item/partitioning.py
@@ -217,11 +217,18 @@ def get_document_areas(doc: DocInfo) -> list[Range]:
     :return: List of area ranges.
     """
     pars = doc.document.get_paragraphs()
+    is_translation = not doc.is_original_translation
+    if is_translation:
+        dereference_pars(pars, doc.document, None)
     areas = []
     area = {"index": None, "name": None}
     for i, par in enumerate(pars):
-        area_begin = par.get_attr("area")
-        area_end = par.get_attr("area_end")
+        if is_translation and par.is_translation():
+            targ_par = par.get_referenced_pars()[0]
+        else:
+            targ_par = par
+        area_begin = targ_par.get_attr("area")
+        area_end = targ_par.get_attr("area_end")
         if area["name"] is None and area_begin is not None:
             area = {"index": i, "name": area_begin}
         if area_end is not None and area_end == area["name"]:
@@ -244,13 +251,12 @@ def get_area_range(doc: DocInfo, name: str, view_ctx: ViewContext) -> Range | No
     begin = None
     end = None
     for i, par in enumerate(pars):
-        if not is_translation:
-            area_begin = par.get_attr("area")
-            area_end = par.get_attr("area_end")
+        if is_translation and par.is_translation():
+            targ_par = par.get_referenced_pars()[0]
         else:
-            # FIXME - find better way to get original par attrs
-            area_begin = par.ref_pars[view_ctx][0].get_attr("area")
-            area_end = par.ref_pars[view_ctx][0].get_attr("area_end")
+            targ_par = par
+        area_begin = targ_par.get_attr("area")
+        area_end = targ_par.get_attr("area_end")
         if area_begin == name:
             begin = i
         if area_end == name:

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -900,7 +900,7 @@ def render_doc_view(
                     if t.target_data.attrs.get("area_end") == m.area:
                         break
                     else:
-                        pars_in_area.append(t.target.id)
+                        pars_in_area.append(t.target.id if t.target else t.id)
             for task in post_process_result.plugins:
                 if task.par.id in pars_in_area and task.task_id:
                     tids.append(task.task_id)

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -640,7 +640,7 @@ def render_doc_view(
     if piece_size:
         areas = get_document_areas(doc_info)
     if m.area:
-        area = get_area_range(doc_info, m.area)
+        area = get_area_range(doc_info, m.area, view_ctx)
         if area is not None:
             # RequestedViewRange e returns paragraph e-1 as last paragraph, add +1 to render full area
             r_view_range = RequestedViewRange(b=area[0], e=area[1] + 1, size=None)
@@ -865,6 +865,7 @@ def render_doc_view(
                 raise RouteException(f"Area {m.area} not found")
         elif m.b and m.size == 1:
             if not areas:
+                # FIXME: get_document_areas returns empty in translations
                 areas = get_document_areas(doc_info)
                 for a in areas:
                     if a[0] <= view_range.b and a[1] >= view_range.e:
@@ -881,33 +882,40 @@ def render_doc_view(
         # plugins that match the requested b or are inside the requested area
         if m.b and m.size == 1:
             for task in post_process_result.plugins:
-                if task.par.id == m.b and task.task_id:
+                if (
+                    task.par.id == m.b
+                    or task.par.ref_chain
+                    and task.par.ref_chain.prev_deref.id == m.b
+                ) and task.task_id:
                     tids.append(task.task_id)
                     break
         else:
             area_started = False
             pars_in_area = []
             for t in post_process_result.texts:
-                if not area_started and t.attrs.get("area") == m.area:
+                if not area_started and t.target_data.attrs.get("area") == m.area:
                     area_started = True
                     continue
                 if area_started:
-                    if t.attrs.get("area_end") == m.area:
+                    if t.target_data.attrs.get("area_end") == m.area:
                         break
                     else:
-                        pars_in_area.append(t.id)
+                        pars_in_area.append(t.target.id)
             for task in post_process_result.plugins:
                 if task.par.id in pars_in_area and task.task_id:
                     tids.append(task.task_id)
         if len(tids) < 1:
             raise RouteException("No tasks to review in requested area or block")
-        if not check_review_grouping(doc_info, tids):
+        orig_doc_info = (
+            doc_info if doc_info.is_original_translation else doc_info.src_doc
+        )
+        if not check_review_grouping(orig_doc_info, tids):
             try:
-                generate_review_groups(doc_info, tids)
-                set_default_velp_group_selected_and_visible(doc_info)
+                generate_review_groups(orig_doc_info, tids)
+                set_default_velp_group_selected_and_visible(orig_doc_info)
             except PeerReviewException as e:
                 flash(str(e))
-        reviews = get_reviews_where_user_is_reviewer(doc_info, current_user)
+        reviews = get_reviews_where_user_is_reviewer(orig_doc_info, current_user)
         tidset = {tid.doc_task for tid in tids}
         for review in reviews:
             if f"{review.block_id}.{review.task_name}" in tidset:

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -865,7 +865,6 @@ def render_doc_view(
                 raise RouteException(f"Area {m.area} not found")
         elif m.b and m.size == 1:
             if not areas:
-                # FIXME: get_document_areas returns empty in translations
                 areas = get_document_areas(doc_info)
                 for a in areas:
                     if a[0] <= view_range.b and a[1] >= view_range.e:

--- a/timApp/velp/annotation.py
+++ b/timApp/velp/annotation.py
@@ -29,7 +29,6 @@ from timApp.document.viewcontext import default_view_ctx
 from timApp.peerreview.util.peerreview_utils import (
     has_review_access,
     get_reviews_targeting_user,
-    get_reviews_where_user_is_reviewer,
     get_all_reviews,
     get_reviews_related_to_user,
 )

--- a/timApp/velp/annotation.py
+++ b/timApp/velp/annotation.py
@@ -287,16 +287,17 @@ def get_annotations(doc_id: int, only_own: bool = False) -> Response:
 
     current_user = get_current_user_object()
     results = get_annotations_with_comments_in_document(current_user, d, only_own)
+    orig_doc_info = d if d.is_original_translation else d.src_doc
     if not only_own:
         # TODO: check use cases (only_own == not in view tab)
         #  teachermode should be able to browse all prs when changing user in ab
         #  review tab needs probably only reviews where reviewer is current user
         if has_teacher_access(d):
-            peer_reviews = get_all_reviews(d)
+            peer_reviews = get_all_reviews(orig_doc_info)
         else:
-            peer_reviews = get_reviews_related_to_user(d, current_user)
+            peer_reviews = get_reviews_related_to_user(orig_doc_info, current_user)
     else:
-        peer_reviews = get_reviews_targeting_user(d, current_user)
+        peer_reviews = get_reviews_targeting_user(orig_doc_info, current_user)
 
     # TODO: Fully anonymize peer_reviews if doc setting requires it
     if should_anonymize_annotations(d, current_user):

--- a/timApp/velp/velp.py
+++ b/timApp/velp/velp.py
@@ -121,7 +121,7 @@ def get_default_velp_group(doc_id: int) -> Response:
     user = get_current_user_object()
 
     doc = get_doc_or_abort(doc_id)
-    full_path = doc.path
+    full_path = doc.path_without_lang
     doc_path, doc_name = split_location(full_path)
     edit_access = False
     if has_edit_access(doc):
@@ -711,7 +711,7 @@ def create_velp_group_route(doc_id: int) -> Response:
         raise RouteException("Missing data: " + e.args[0])
 
     doc = get_doc_or_abort(doc_id)
-    full_path = doc.path
+    full_path = doc.path_without_lang
     doc_path, doc_name = split_location(full_path)
 
     # valid_until = json_data.get('valid_until')
@@ -912,7 +912,7 @@ def get_velp_groups_from_tree(doc: DocInfo) -> list[DocInfo]:
 
     """
 
-    full_path = doc.path
+    full_path = doc.path_without_lang
     doc_path, doc_name = split_location(full_path)
     velp_group_folder = "velp-groups"
 

--- a/timApp/velp/velpgroups.py
+++ b/timApp/velp/velpgroups.py
@@ -9,9 +9,9 @@ selections from the database.
 :version: 1.0.0
 
 """
-import copy
 from dataclasses import dataclass, field
 from typing import Union
+
 from timApp.auth.accesstype import AccessType
 from timApp.document.docentry import DocEntry
 from timApp.document.docinfo import DocInfo
@@ -29,7 +29,6 @@ from timApp.velp.velp_models import (
     VelpGroupsInDocument,
     VelpGroupSelection,
     VelpGroupDefaults,
-    VelpInGroup,
 )
 
 
@@ -127,7 +126,7 @@ def get_document_default_velp_group_info(doc_info: DocInfo) -> tuple[str, str]:
     """
     Returns path and name for a document's default group
     """
-    full_path = doc_info.path
+    full_path = doc_info.path_without_lang
     doc_path, doc_name = split_location(full_path)
     user_group = doc_info.block.owners[0]
     velps_folder_path = check_velp_group_folder_path(doc_path, user_group, doc_name)


### PR DESCRIPTION
Korjaa tilanteen jossa vertaisarvioinnin käynnistäminen käännetyssä dokumentissa ei lisännyt vertaisarviointirivejä, sillä aiemmin käännetyissä kappaleissa ei osattu katsoa kunnolla mitä lohkoa tai aluetta käännöskappeleen osa vastaa alkuperäisessä dokumentissa.

https://timdevs01-3.it.jyu.fi/view/pr_translated/en

Lisäksi muuttaa velppien oletusryhmän tarkistamista niin että käännösdokumenteilla ja alkuperäisillä dokumenteilla on sama default velp group. Aiemmin käännösversiossa ei voinut edes luoda uutta velppipohjaa jos käännöksen default velp group oli valittuna, sillä se yritti luoda käännösdokumentille erillisen default velp groupin ja epäonnistui.

Vertaa uuden velppipohjan tekoa esim

https://timdevs01-3.it.jyu.fi/view/pr_translated/en ja https://tim.jyu.fi/teacher/users/sijualle/kokeiluja/kaannos/en-GB