### PR TITLE
Serve Angular JS files through Caddy

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -26,6 +26,22 @@
 			root /csgenerated
 		}
 	}
+
+	handle_path /js/* {
+		@has_lang {
+			file {
+				root /tim/timApp/static/scripts/build/{cookie.script_lang}
+				try_files {path}
+			}
+		}
+		file_server @has_lang {
+			root /tim/timApp/static/scripts/build/{cookie.script_lang}
+		}
+	    file_server {
+			root /tim/timApp/static/scripts/build
+		}
+	}
+
 	handle_path /csstatic/* {
         @is_global {
             file {

--- a/timApp/tests/server/test_tim.py
+++ b/timApp/tests/server/test_tim.py
@@ -1,5 +1,4 @@
 """Unit tests for TIM routes."""
-from unittest.mock import patch
 
 from flask import current_app
 from lxml.cssselect import CSSSelector
@@ -465,13 +464,3 @@ class TimTest(TimRouteTest):
 
         self.json_post(f"/settings/updateConsent", {"consent": 9999}, expect_status=422)
         self.json_post(f"/settings/updateConsent", {"consent": "x"}, expect_status=422)
-
-    def test_no_db_for_js(self):
-        """Database is not accessed during a JS file request."""
-        self.login_test1()
-        self.get("/")
-        with patch.object(
-            User, User.get_by_id.__name__, wraps=User.get_by_id
-        ) as m:  # type: Mock
-            self.get(f"/js/x.js", expect_status=404)
-        m.assert_not_called()

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 import bs4
 from bs4 import BeautifulSoup
-from flask import Response, send_from_directory
+from flask import Response
 from flask import g
 from flask import redirect
 from flask import render_template
@@ -13,7 +13,6 @@ from flask import session
 from flask_assets import Environment
 from flask_wtf.csrf import generate_csrf
 from sqlalchemy import event
-from werkzeug.exceptions import NotFound
 from werkzeug.middleware.profiler import ProfilerMiddleware
 
 from timApp.admin.cli import register_clis
@@ -88,7 +87,6 @@ from timApp.util.error_handlers import register_errorhandlers
 from timApp.util.flask.cache import cache
 from timApp.util.flask.requesthelper import (
     get_request_message,
-    NotExist,
     is_testing,
 )
 from timApp.util.flask.responsehelper import json_response, ok_response
@@ -239,14 +237,7 @@ def inject_user() -> dict:
 
 @app.get("/js/<path:path>")
 def get_js_file(path: str):
-    # Resolve any relative paths
-    locale = get_locale()
-    for d in (f"static/scripts/build/{locale}", f"static/scripts/build"):
-        try:
-            return send_from_directory(d, path)
-        except NotFound:
-            pass
-    raise NotExist("File not found")
+    raise Exception("Angular scripts should be served by Caddy, not Flask")
 
 
 @app.get("/empty")
@@ -401,8 +392,15 @@ def after_request(resp: Response):
         samesite=app.config["SESSION_COOKIE_SAMESITE"],
         secure=app.config["SESSION_COOKIE_SECURE"],
     )
+
+    locale = get_locale()
+    # lang is used to preserve the active language preference which may be either
+    # a specific language or "UseWebBrowser" which defaults to browser preference
     if not request.cookies.get("lang"):
-        resp.set_cookie("lang", get_locale())
+        resp.set_cookie("lang", locale)
+    # script_lang is used by Caddy to serve correct Angular scripts
+    # It always contains a specific valid language, never "UseWebBrowser"
+    resp.set_cookie("script_lang", locale)
     return resp
 
 


### PR DESCRIPTION
Siirtää kaikki Angularin JS-skriptien lähettämisen Caddy:lle. Tämä muutos

* yksinkertaistaa lokeja (JS-tiedostojen hakua ei lokiteta turhaan TIM-lokeissa vaan ainoastaan Caddyn lokeissa)
* vähentää hieman ylimääräisiä tietokantakutsuja JS-tiedostojen haun yhteydessä
* vähentää kuormaa TIM-kontilta (Caddyn ei tarvitse kysyä TIMin JS-tiedostoja TIM-kontilta, vaan se osaa lähettää ne suoraan).

Testi: <https://timdevs02.it.jyu.fi>