### PR TITLE
Modelanswer points attributes, hide points in userAnswersForTasks

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2007,17 +2007,17 @@ def get_model_answer(task_id: str, answer_id: int | None = None) -> Response:
                     f"You need to attempt at least {model_answer_info.count} times before viewing the model answer"
                 )
         if (
-            model_answer_info.points is not None
-            and model_answer_info.points is not missing
+            model_answer_info.minPoints is not None
+            and model_answer_info.minPoints is not missing
         ):
             prev_ans = current_user.get_answers_for_task(tid.doc_task).first()
             if (
                 not prev_ans
                 or prev_ans.points is None
-                or prev_ans.points < model_answer_info.points
+                or prev_ans.points < model_answer_info.minPoints
             ):
                 raise AccessDenied(
-                    f"You need at least {model_answer_info.points} points from this task to view the model answer"
+                    f"You need at least {model_answer_info.minPoints} points from this task to view the model answer"
                 )
         if model_answer_info.lock:
             b = TaskBlock.get_by_task(tid.doc_task)

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2004,7 +2004,19 @@ def get_model_answer(task_id: str) -> Response:
                 raise AccessDenied(
                     f"You need to attempt at least {model_answer_info.count} times before viewing the model answer"
                 )
-
+        if (
+            model_answer_info.points is not None
+            and model_answer_info.points is not missing
+        ):
+            prev_ans = current_user.get_answers_for_task(tid.doc_task).first()
+            if (
+                not prev_ans
+                or prev_ans.points is None
+                or prev_ans.points < model_answer_info.points
+            ):
+                raise AccessDenied(
+                    f"You need at least {model_answer_info.points} points from this task to view the model answer"
+                )
         if model_answer_info.lock:
             b = TaskBlock.get_by_task(tid.doc_task)
             if not b:

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -439,14 +439,15 @@ def get_useranswers_for_task(
         .group_by(Answer.task_id)
         .subquery()
     )
-    answs: list[Answer] = Answer.query.join(sub, Answer.id == sub.c.col).all()
+    answs: list[Answer] = (
+        Answer.query.join(sub, Answer.id == sub.c.col)
+        .options(joinedload(Answer.users_all))
+        .all()
+    )
     for answer in answs:
-        if len(answer.users_all) > 1:
-            answer_map[answer.task_id] = answer.to_json()
-        else:
-            asd = answer.to_json()
-            asd.pop("users")
-            answer_map[answer.task_id] = asd
+        asd = answer.to_json()
+        asd.pop("points", None)
+        answer_map[answer.task_id] = asd
     return answs
 
 

--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -247,6 +247,10 @@ def qst_answer_jso(m: QstAnswerModel):
         jsonmarkup.pop("points", None)
         jsonmarkup.pop("defaultPoints", None)
 
+    # TODO: Qst sends entire plugin markup for building the ui
+    #  -> Should send only attributes used by qst ui
+    jsonmarkup.pop("modelAnswer", None)
+
     savedText = "Saved"  # markup.savedText or "Saved"
 
     web = {

--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -707,7 +707,7 @@ def qst_try_hide_points(jso):
     limit_reached = get_num_value(info, "max_answers", 1) <= get_num_value(
         info, "earlier_answers", 0
     )
-    show_points = markup.get("showPoints", True)
+    show_points = info.get("show_points", True) if info is not None else True
     if not limit_reached or not show_points:
         markup.pop("points", None)
         markup.pop("expl", None)

--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -239,7 +239,10 @@ def qst_answer_jso(m: QstAnswerModel):
     jsonmarkup = m.markup.get_visible_data()
     convert_qst_md(jsonmarkup)  # TODO get mathtype from doc settings?
     save = answers
-    if not markup.show_points():
+    show_points = (
+        info.show_points if info is not None and info.show_points is not None else True
+    )
+    if not show_points:
         jsonmarkup.pop("expl", None)
         jsonmarkup.pop("points", None)
         jsonmarkup.pop("defaultPoints", None)

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1327,7 +1327,9 @@ export class AnswerBrowserComponent
         if (this.selectedAnswer) {
             this.points = r.result.data.points;
             this.selectedAnswer.points = r.result.data.points;
-            if (this.taskInfo) this.taskInfo.showPoints = true;
+            if (this.taskInfo) {
+                this.taskInfo.showPoints = true;
+            }
         }
         this.modelAnswerFetched = true;
         this.modelAnswerVisible = true;

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -338,6 +338,8 @@ export class AnswerBrowserComponent
         }
         this.showFeedback(args.topfeedback);
         this.loader.showFeedback(args.feedback);
+        console.log("sa", this.selectedAnswer);
+        console.log("la", this.loadedAnswer);
         this.cdr.detectChanges();
     }
 
@@ -1259,6 +1261,8 @@ export class AnswerBrowserComponent
     }
 
     async showModelAnswer() {
+        console.log("sa", this.selectedAnswer);
+        console.log("la", this.loadedAnswer);
         if (this.modelAnswerFetched) {
             this.modelAnswerVisible = !this.modelAnswerVisible;
             if (this.modelAnswerVisible && this.modelAnswerRef) {
@@ -1304,9 +1308,12 @@ export class AnswerBrowserComponent
         }
         this.loading++;
         const r = await to(
-            $http.get<{answer: string}>(this.getModelAnswerLink(), {
-                params: {...parParams},
-            })
+            $http.get<{answer: string; points?: number}>(
+                this.getModelAnswerLink(),
+                {
+                    params: {...parParams, answer_id: this.selectedAnswer?.id},
+                }
+            )
         );
         this.loading--;
         if (!r.ok) {
@@ -1316,6 +1323,11 @@ export class AnswerBrowserComponent
         if (this.modelAnswer?.lock) {
             this.modelAnswer.alreadyLocked = true;
             this.viewctrl.informAboutLock(this.taskId);
+        }
+        if (this.selectedAnswer) {
+            this.points = r.result.data.points;
+            this.selectedAnswer.points = r.result.data.points;
+            if (this.taskInfo) this.taskInfo.showPoints = true;
         }
         this.modelAnswerFetched = true;
         this.modelAnswerVisible = true;

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -338,8 +338,6 @@ export class AnswerBrowserComponent
         }
         this.showFeedback(args.topfeedback);
         this.loader.showFeedback(args.feedback);
-        console.log("sa", this.selectedAnswer);
-        console.log("la", this.loadedAnswer);
         this.cdr.detectChanges();
     }
 
@@ -1261,8 +1259,6 @@ export class AnswerBrowserComponent
     }
 
     async showModelAnswer() {
-        console.log("sa", this.selectedAnswer);
-        console.log("la", this.loadedAnswer);
         if (this.modelAnswerFetched) {
             this.modelAnswerVisible = !this.modelAnswerVisible;
             if (this.modelAnswerVisible && this.modelAnswerRef) {

--- a/timApp/tests/browser/test_model_answer.py
+++ b/timApp/tests/browser/test_model_answer.py
@@ -153,14 +153,14 @@ modelAnswer:
  lock: true
  answer: Hello
  count: 0
- points: 0
+ minPoints: 0
 ````
 ```` {#nonepoints plugin="textfield"}
 modelAnswer:
  lock: true
  answer: Hello
  count: 0
- points: 
+ minPoints: 
 ````
 ```` {#missingpoints plugin="textfield"}
 modelAnswer:

--- a/timApp/tests/browser/test_model_answer.py
+++ b/timApp/tests/browser/test_model_answer.py
@@ -1,7 +1,10 @@
 from selenium.webdriver.common.by import By
 
+from timApp.answer.answers import save_answer
 from timApp.auth.accesstype import AccessType
 from timApp.item.block import Block
+from timApp.item.taskblock import TaskBlock
+from timApp.plugin.taskid import TaskId
 from timApp.tests.browser.browsertest import (
     BrowserTest,
 )
@@ -139,3 +142,106 @@ hidden area
             By.CSS_SELECTOR, ".area_afterLock .parContent"
         )[1]
         self.assertEqual("hidden area", text_par.text)
+
+    def test_model_answer_points(self):
+        self.login_test1()
+        self.login_browser_quick_test1()
+        d = self.create_doc(
+            initial_par="""
+```` {#zeropoints plugin="textfield"}
+modelAnswer:
+ lock: true
+ answer: Hello
+ count: 0
+ points: 0
+````
+```` {#nonepoints plugin="textfield"}
+modelAnswer:
+ lock: true
+ answer: Hello
+ count: 0
+ points: 
+````
+```` {#missingpoints plugin="textfield"}
+modelAnswer:
+ lock: true
+ answer: Hello
+ count: 0
+````
+"""
+        )
+        self.test_user_2.grant_access(d, AccessType.view)
+        db.session.commit()
+        db.session.refresh(Block.query.get(d.block.id))
+        self.login_test2()
+        error_msg = "points from this task to view the model answer"
+        self.get(
+            f"/getModelAnswer/{d.id}.zeropoints",
+            expect_status=403,
+            expect_content="You need at least 0.0 points from this task to view the model answer",
+        )
+        save_answer(
+            [self.test_user_2],
+            TaskId.parse(f"{d.id}.zeropoints"),
+            content={"c": "input"},
+            points=-1,
+        )
+        db.session.commit()
+        self.get(
+            f"/getModelAnswer/{d.id}.zeropoints",
+            expect_status=403,
+            expect_content="You need at least 0.0 points from this task to view the model answer",
+        )
+        save_answer(
+            [self.test_user_2],
+            TaskId.parse(f"{d.id}.zeropoints"),
+            content={"c": "input"},
+            points=None,
+        )
+        db.session.commit()
+        self.get(
+            f"/getModelAnswer/{d.id}.zeropoints",
+            expect_status=403,
+            expect_content="You need at least 0.0 points from this task to view the model answer",
+        )
+        tb = TaskBlock.get_block_by_task(f"{d.id}.zeropoints")
+        self.assertIsNone(tb)
+        save_answer(
+            [self.test_user_2],
+            TaskId.parse(f"{d.id}.zeropoints"),
+            content={"c": "input"},
+            points=0,
+        )
+        db.session.commit()
+        self.get(f"/getModelAnswer/{d.id}.zeropoints", expect_status=200)
+        tb = TaskBlock.get_block_by_task(f"{d.id}.zeropoints")
+        self.assertIsNotNone(tb)
+        save_answer(
+            [self.test_user_2],
+            TaskId.parse(f"{d.id}.zeropoints"),
+            content={"c": "input"},
+            points=-2,
+        )
+        db.session.commit()
+        self.get(
+            f"/getModelAnswer/{d.id}.zeropoints",
+            expect_status=403,
+            expect_content="You need at least 0.0 points from this task to view the model answer",
+        )
+        save_answer(
+            [self.test_user_2],
+            TaskId.parse(f"{d.id}.nonepoints"),
+            content={"c": "input"},
+            points=-1,
+        )
+        db.session.commit()
+        self.get(f"/getModelAnswer/{d.id}.nonepoints")
+        save_answer(
+            [self.test_user_2],
+            TaskId.parse(f"{d.id}.nonepoints"),
+            content={"c": "input"},
+            points=None,
+        )
+        db.session.commit()
+        self.get(f"/getModelAnswer/{d.id}.nonepoints")
+        self.get(f"/getModelAnswer/{d.id}.missingpoints")

--- a/timApp/tests/server/test_inlineplugins.py
+++ b/timApp/tests/server/test_inlineplugins.py
@@ -74,6 +74,7 @@ Hi {#t3#} $x$
                 "max_answers": None,
                 "user_id": "testuser1",
                 "valid": True,
+                "show_points": True,
             },
             state=s,
         )

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -1780,6 +1780,7 @@ needed_len: 6
                     "max_answers": None,
                     "user_id": "testuser1",
                     "valid": True,
+                    "show_points": True,
                 },
             ),
         )
@@ -1891,6 +1892,7 @@ needed_len: 6
                 "max_answers": None,
                 "user_id": "testuser1",
                 "valid": True,
+                "show_points": True,
             },
         )
         self.assert_same_html(
@@ -1947,6 +1949,7 @@ needed_len: 6
                     "max_answers": None,
                     "user_id": "testuser1",
                     "valid": True,
+                    "show_points": True,
                 },
             ),
         )
@@ -2257,7 +2260,7 @@ a: b
                 "deadline": None,
                 "maxPoints": None,
                 "pointsText": "Points:",
-                "showPoints": {},
+                "showPoints": True,
                 "starttime": None,
                 "triesText": "Tries left:",
                 "userMax": 0.5,

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -95,6 +95,7 @@ class ModelAnswerInfo:
     lockConfirmation: str | None | Missing = missing
     lockedLinkText: str | None | Missing = missing
     points: float | None | Missing = missing
+    hidePoints: bool | None | Missing = missing
     revealDate: PluginDateTime | datetime | None | Missing = missing
 
 

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -94,6 +94,7 @@ class ModelAnswerInfo:
     lockedAnswerMessage: str | None | Missing = missing
     lockConfirmation: str | None | Missing = missing
     lockedLinkText: str | None | Missing = missing
+    points: float | None | Missing = missing
     revealDate: PluginDateTime | datetime | None | Missing = missing
 
 

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -94,7 +94,7 @@ class ModelAnswerInfo:
     lockedAnswerMessage: str | None | Missing = missing
     lockConfirmation: str | None | Missing = missing
     lockedLinkText: str | None | Missing = missing
-    points: float | None | Missing = missing
+    minPoints: float | None | Missing = missing
     hidePoints: bool | None | Missing = missing
     revealDate: PluginDateTime | datetime | None | Missing = missing
 

--- a/tim_common/pluginserver_flask.py
+++ b/tim_common/pluginserver_flask.py
@@ -90,7 +90,7 @@ class InfoModel:
     max_answers: int | None
     user_id: str
     valid: bool  # could be False e.g. if answering deadline has passed
-    show_points: bool
+    show_points: bool | None = None
 
     @property
     def primary_user(self) -> str:

--- a/tim_common/pluginserver_flask.py
+++ b/tim_common/pluginserver_flask.py
@@ -90,6 +90,7 @@ class InfoModel:
     max_answers: int | None
     user_id: str
     valid: bool  # could be False e.g. if answering deadline has passed
+    show_points: bool
 
     @property
     def primary_user(self) -> str:


### PR DESCRIPTION
Lisää modelAnswer-attribuuttiin kaksi uutta aliattribuuttia
- hidePoints: jos true niin pisteet piilotetaan kunnes mallivastaus on katsottu
- minPoints: Pitää saada x pistettä että mallivastauksen voi avata

https://timdevs01-3.it.jyu.fi/view/modelanswer-points

Lisäksi userAnswersForTasks-reitissä ollut pisteiden kurkistelumahdollisuus on nyt tukittu