### PR TITLE
Add translation warning styles to default TeX print template

### DIFF
--- a/timApp/static/tim_docs/initial/print_base.md
+++ b/timApp/static/tim_docs/initial/print_base.md
@@ -353,6 +353,8 @@ macros
 \newcommand{\runo}[1]{\begin{center}\it{#1}\end{center}}
 \newcommand{\kuvavasen}[1]{#1}
 \newcommand{\timButton}[1]{\bgtim{\white{{#1}}}}
+\newcommand{\troutofdate}[1]{#1}
+\newcommand{\checktr}[1]{#1}
 
 \newenvironment{huomautus}{\begin{tcolorbox}}{\end{tcolorbox}}
 

--- a/timApp/tests/server/expected/printing/hello_1_2.tex
+++ b/timApp/tests/server/expected/printing/hello_1_2.tex
@@ -160,6 +160,8 @@
 \newcommand{\runo}[1]{\begin{center}\it{#1}\end{center}}
 \newcommand{\kuvavasen}[1]{#1}
 \newcommand{\timButton}[1]{\bgtim{\white{{#1}}}}
+\newcommand{\troutofdate}[1]{#1}
+\newcommand{\checktr}[1]{#1}
 
 \newenvironment{huomautus}{\begin{tcolorbox}}{\end{tcolorbox}}
 


### PR DESCRIPTION
Closes #1278.

Adds the (S)CSS styles `.troutofdate` and `.checktr` to the default TeX print template base. Previously, the in-built print functionality using TeX/LaTeX would fail because of missing style declarations.
Note that this change only affects new instances, since the default print template is created only once from the base file. Subsequent modifications need to be made by hand in a running instance by modifying the template file found in the 'TIM path' `[host]/view/templates/printing`.