### PR TITLE
Add links to a document's translations to the Manage-page

### DIFF
--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -764,6 +764,14 @@ export class PermCtrl implements IController {
     loggedIn() {
         return Users.isLoggedIn();
     }
+
+    /**
+     * Returns the path to a document specified by doc_id
+     * @param doc_id
+     */
+    getTranslationPath(doc_id: number) {
+        return this.translations.find((tr) => tr.id == doc_id)?.path ?? "";
+    }
 }
 
 timApp.component("timManage", {

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -770,7 +770,10 @@ export class PermCtrl implements IController {
      * @param doc_id
      */
     getTranslationPath(doc_id: number) {
-        return this.translations.find((tr) => tr.id == doc_id)?.path ?? this.item.path;
+        return (
+            this.translations.find((tr) => tr.id == doc_id)?.path ??
+            this.item.path
+        );
     }
 }
 

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -770,7 +770,7 @@ export class PermCtrl implements IController {
      * @param doc_id
      */
     getTranslationPath(doc_id: number) {
-        return this.translations.find((tr) => tr.id == doc_id)?.path ?? "";
+        return this.translations.find((tr) => tr.id == doc_id)?.path ?? this.item.path;
     }
 }
 

--- a/timApp/static/templates/manage.html
+++ b/timApp/static/templates/manage.html
@@ -189,7 +189,11 @@
                         <input type="text" class="form-control" ng-model="tr.title" placeholder="Title"/>
                     </td>
                     <td>{{tr.owner.name}}</td>
-                    <td>{{tr.id}}</td>
+                    <td>{{tr.id}}
+                        <a href="/view/{{$ctrl.getTranslationPath(tr.id)}}">
+                            <i class="glyphicon glyphicon-link"></i>
+                        </a>
+                    </td>
                     <td>
                         <button class="timButton" ng-click="$ctrl.updateTranslation(tr)"
                                 ng-disabled="!$ctrl.trChanged(tr)">Update


### PR DESCRIPTION
A small QOL improvement to the Translations-section of the Manage-page, adds direct links to a document's translations.

Closes #3441. 