### PR TITLE
Fix page links on doc lang change

### DIFF
--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -273,6 +273,7 @@ export class PermCtrl implements IController {
                 this.syncTitle(tr.title);
                 // syncTitle does not update the current document path,
                 // force an alias update on the current document to fix this
+                // TODO: check that this works as expected!
                 this.getAliases();
             }
         } else {

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -273,8 +273,11 @@ export class PermCtrl implements IController {
                 this.syncTitle(tr.title);
                 // syncTitle does not update the current document path,
                 // force page reload manually with the new translation path
+                const sep = tr.old_langid == "" ? "/" : "";
+                const idx = tr.path.lastIndexOf(tr.old_langid);
                 const new_path = tr.path
-                    .substring(0, tr.path.lastIndexOf(tr.old_langid))
+                    .substring(0, idx)
+                    .concat(sep)
                     .concat(tr.lang_id);
                 window.location.replace("/manage/" + new_path);
             }

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -273,7 +273,7 @@ export class PermCtrl implements IController {
                 this.syncTitle(tr.title);
                 // syncTitle does not update the current document path,
                 // force page reload manually with the new translation path
-                let new_path = tr.path
+                const new_path = tr.path
                     .substring(0, tr.path.lastIndexOf(tr.old_langid))
                     .concat(tr.lang_id);
                 window.location.replace("/manage/" + new_path);

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -270,7 +270,6 @@ export class PermCtrl implements IController {
         if (r.ok) {
             await this.getTranslations();
             if (tr.id === this.item.id) {
-                this.syncTitle(tr.title);
                 // syncTitle does not update the current document path,
                 // force page reload manually with the new translation path
                 const sep = tr.old_langid == "" ? "/" : "";

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -271,6 +271,9 @@ export class PermCtrl implements IController {
             await this.getTranslations();
             if (tr.id === this.item.id) {
                 this.syncTitle(tr.title);
+                // syncTitle does not update the current document path,
+                // force an alias update on the current document to fix this
+                this.getAliases();
             }
         } else {
             tr.lang_id = old_lang;

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -272,9 +272,11 @@ export class PermCtrl implements IController {
             if (tr.id === this.item.id) {
                 this.syncTitle(tr.title);
                 // syncTitle does not update the current document path,
-                // force an alias update on the current document to fix this
-                // TODO: check that this works as expected!
-                this.getAliases();
+                // force page reload manually with the new translation path
+                let new_path = tr.path.substring(0, 
+                    tr.path.lastIndexOf(tr.old_langid))
+                    .concat(tr.lang_id);
+                window.location.replace("/manage/" + new_path);
             }
         } else {
             tr.lang_id = old_lang;

--- a/timApp/static/scripts/tim/item/manageCtrl.ts
+++ b/timApp/static/scripts/tim/item/manageCtrl.ts
@@ -273,8 +273,8 @@ export class PermCtrl implements IController {
                 this.syncTitle(tr.title);
                 // syncTitle does not update the current document path,
                 // force page reload manually with the new translation path
-                let new_path = tr.path.substring(0, 
-                    tr.path.lastIndexOf(tr.old_langid))
+                let new_path = tr.path
+                    .substring(0, tr.path.lastIndexOf(tr.old_langid))
                     .concat(tr.lang_id);
                 window.location.replace("/manage/" + new_path);
             }


### PR DESCRIPTION
Force a documents aliases/page update when changing current document's language on the Manage page.

Resolves #3437.