### PR TITLE
Skip nested area processing if within hidden area

### DIFF
--- a/timApp/document/post_process.py
+++ b/timApp/document/post_process.py
@@ -290,6 +290,19 @@ def process_areas(
         cur_area = None
         area_start = p.get_attr("area")
         area_end = p.get_attr("area_end")
+        if len(current_areas) > 0:
+            if area_end != current_areas[-1].name:
+                assert current_areas[-1].visible is not None
+                if not current_areas[-1].visible:
+                    continue
+                # Timed paragraph, is there time limitation in area where par is included
+                st = current_areas[-1].attrs.get("starttime")
+                et = current_areas[-1].attrs.get("endtime")
+                if st or et:
+                    starttime = getdatetime(st, default_val=min_time)
+                    endtime = getdatetime(et, default_val=max_time)
+                    if starttime > now or endtime <= now:
+                        continue
         if area_start is not None:
             cur_area = Area(area_start, p.get_attrs())
             current_areas.append(cur_area)
@@ -392,21 +405,6 @@ def process_areas(
                 vis = get_boolean(vis, True)
                 if not vis:  #  TODO: if in preview, put this always True
                     access = False  # TODO: this should be added as some kind of small par that is visible in edit-mode
-                # Timed paragraph
-            if access:  # par itself is visible, is it in some area that is not visible
-                for a in current_areas:
-                    assert a.visible is not None
-                    if not a.visible:
-                        access = False
-                        break
-                    if access:  # is there time limitation in area where par is included
-                        st = a.attrs.get("starttime")
-                        et = a.attrs.get("endtime")
-                        if st or et:
-                            starttime = getdatetime(st, default_val=min_time)
-                            endtime = getdatetime(et, default_val=max_time)
-                            access &= starttime <= now < endtime
-
             if access:
                 new_pars.append(html_par)
 

--- a/timApp/tests/server/test_par_visibility.py
+++ b/timApp/tests/server/test_par_visibility.py
@@ -98,6 +98,12 @@ a title
 #-
 2
 
+#- {area=b collapse=true nocache=true}
+b title
+#-
+2.5
+#- {area_end=b}
+
 #- {area_end=a}
 
 #-
@@ -108,13 +114,7 @@ a title
         db.session.commit()
         self.assert_content(
             self.get(d.url, as_tree=True),
-            [
-                "1",
-                "a title",
-                "2",
-                "",
-                "3",
-            ],
+            ["1", "a title", "2", "2.5", "", "", "3"],
         )
         self.login_test2()
         self.assert_content(


### PR DESCRIPTION
Muuttaa piilotettujen alueiden käsittelyä niin että sisäkkäisiä alueita ei prosessoida, mikäli ulompi alue on piilossa. Etenkin piilotettujen alueiden sisällä olevat collapsible-alueet eivät enää näytä tyhjää otsikkoa.

Aiemmin piilotettujen alueiden sisällä olevien alueiden alku- ja loppukohdat näkyivät, mutta itse kappaleiden sisältö ei näkynyt. En ollut varma oliko ne tarkoituksella vai ei (esim rikkinäisten alueiden helpompaa huomaamista varten). Laitoin kuitenkin nyt niin etteivät ne näy, mutta sen saa kohtuu nopeasti muutettua myös toisinpäin jos näin halutaan

https://timdevs01-3.it.jyu.fi/view/areabugi