### PR TITLE
Improve partial document handling

### DIFF
--- a/timApp/document/editing/routes.py
+++ b/timApp/document/editing/routes.py
@@ -854,7 +854,10 @@ def add_paragraph_common(md: str, doc_id: int, par_next_id: str | None):
 
     pars = []
     for p in editor_pars:
-        par = doc.insert_paragraph_obj(p, insert_before_id=par_next_id)
+        if p.is_setting():
+            par = doc.insert_setting_paragraph_obj(p, insert_before_id=par_next_id)
+        else:
+            par = doc.insert_paragraph_obj(p, insert_before_id=par_next_id)
         pars.append(par)
         edit_result.added.append(par)
     if not edit_result.empty:

--- a/timApp/item/partitioning.py
+++ b/timApp/item/partitioning.py
@@ -152,6 +152,9 @@ def partition_texts(
         return texts
     started = False
     for text in texts:
+        if text.is_setting:
+            partitioned.append(text)
+            continue
         present = text.id in requested_pars
         if not present and started:
             break

--- a/timApp/item/partitioning.py
+++ b/timApp/item/partitioning.py
@@ -118,7 +118,7 @@ def partition_texts_with_index(
     for text in texts:
         if i >= e:
             break
-        if i < preamble_count or i >= b:
+        if i < preamble_count or i >= b or text.is_setting:
             partitioned.append(text)
         i += 1
     return partitioned

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -939,7 +939,7 @@ def render_doc_view(
     # If index was in cache, partitioning will be done earlier.
     if view_range.is_restricted and contents_have_changed:
         post_process_result.texts = partition_texts(
-            post_process_result.texts, view_range, preamble_count
+            xs, post_process_result.texts, view_range, preamble_count
         )
 
     if force_hide_names(current_user, doc_info) or view_ctx.hide_names_requested:

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -192,6 +192,19 @@ def get_partial_document(doc: Document, view_range: ViewRange) -> DocumentSlice:
             else actual_start_index + view_range.size
         )
     pars = all_pars[actual_start_index:actual_end_index]
+    # Ensure the settings are always included despite requested range not starting from 0
+    if actual_start_index > 0 and len(all_pars) > 0:
+        setting_pars = []
+        for i, p in enumerate(all_pars):
+            if i == actual_start_index:
+                break
+            if p.is_setting():
+                setting_pars.append(p)
+            # TODO: multiple setting pars seem to work if they're all in the start of the document,
+            #   but any non-setting par in between them breaks the rest
+            else:
+                break
+        pars = setting_pars + pars
     return pars, IndexedViewRange(
         b=actual_start_index, e=actual_end_index, par_count=len(all_pars)
     )

--- a/timApp/tests/server/test_doc_partition.py
+++ b/timApp/tests/server/test_doc_partition.py
@@ -1,3 +1,4 @@
+from timApp.document.caching import clear_doc_cache
 from timApp.item.partitioning import INCLUDE_IN_PARTS_CLASS_NAME
 from timApp.tests.server.timroutetest import TimRouteTest
 
@@ -519,3 +520,39 @@ Koira
         self.assert_content(tree, [])
         tree = self.get(d.url, query_string={"b": par_ids[1], "size": 10}, as_tree=True)
         self.assert_content(tree, ["2", "3", "4"])
+
+    def test_settings_with_area(self):
+        self.login_test1()
+        d = self.create_doc(
+            initial_par="""
+#-
+1
+
+#- {area="24"}
+
+#-
+2
+
+#- {visible="%% (False | isview) %%" nocache="true"}
+3
+
+#-
+4
+
+#- {area_end="24"}
+
+#-
+5
+        """
+        )
+        tree = self.get(d.url, query_string={"area": "24"}, as_tree=True)
+        # partitioning works normally right after document generation
+        self.assert_content(tree, ["", "2", "4", ""])
+        d.document.set_settings({"cache": "true"})
+        clear_doc_cache(d, None)
+        tree = self.get(d.url, query_string={"area": "24"}, as_tree=True)
+        # partitioning works normally right after document settings are edited
+        self.assert_content(tree, ["", "", "2", "4", ""])
+        # partitioning works normally when loading document from cache
+        tree = self.get(d.url, query_string={"area": "24"}, as_tree=True)
+        self.assert_content(tree, ["", "", "2", "4", ""])


### PR DESCRIPTION
Korjaa tilanteen jossa dokumentit cacheutuvat väärin jos avaa muutosten jälkeen vain osan dokumentista

Vrt https://timdevs01-3.it.jyu.fi/view/visible?area=35 vs https://tim.jyu.fi/view/users/sijualle/kokeiluja/visible?area=35 (muokkaa jompaa kumpaa kappaletta ja f5)


Lisäksi liittää dokumentin asetuskappaleet dokumenttiin mikäli dokumentti avataan osissa (esim vain jokin area), jotta "set settings"-valikosta pystyisi aina muokkaamaan dokumentin asetuksia vaikka dokumentti on avattu vain osissa.