### PR TITLE
csPlugin: use undefined parsons as default instead of {}

### DIFF
--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -725,7 +725,7 @@ const CsMarkupOptional = t.partial({
     mode: t.string,
     noeditor: t.boolean,
     normal: nullable(t.string),
-    parsons: withDefault(CsParsonsOptions, {}),
+    parsons: CsParsonsOptions,
     formulaEditor: t.boolean,
     path: t.string,
     placeholder: nullable(t.string),


### PR DESCRIPTION
https://timdevs01-3.it.jyu.fi/view/parsonsdef#aliohjelmatValmiina vs https://tim.jyu.fi/view/users/sijualle/kokeiluja/parsonsdef#aliohjelmatValmiina -> Näytä koko koodi