### PR TITLE
Quantum2

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8578,6 +8578,22 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6585102904443570717" datatype="html">
+        <source>Couldn't simulate circuit because there were too many moments</source>
+        <target state="translated">Ei pystytty simuloimaan piiriä, koska siinä oli liikaa ajanhetkiä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4633281565605788402" datatype="html">
+        <source>Circuit contains <x id="INTERPOLATION" equiv-text="{{error.moments}}"/> moments</source>
+        <target state="translated">Piiri sisältää <x id="INTERPOLATION" equiv-text="{{error.moments}}"/> ajanhetkeä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8602,6 +8602,38 @@
           <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1505321340021272471" datatype="html">
+        <source>Simulation time can be extended up to 25 seconds using maxRunTimeout attribute.</source>
+        <target state="translated">Simulointiaikaa pystyy pidentämään 25 sekuntiin asti käyttäen maxRunTimeout attribuuttia.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3834816620880979274" datatype="html">
+        <source>The value of maxRunTimeout is too large</source>
+        <target state="translated">maxRunTimeout:in arvo on liian suuri</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7385899603772624470" datatype="html">
+        <source>maxRunTimeout has value: <x id="INTERPOLATION" equiv-text="{{error.timeout}}"/></source>
+        <target state="translated">maxRunTimeout:lla on arvo: <x id="INTERPOLATION" equiv-text="{{error.timeout}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="562104592773648088" datatype="html">
+        <source>But maximum is: <x id="INTERPOLATION" equiv-text="{{error.maxTimeout}}"/></source>
+        <target state="translated">Mutta maksimi on: <x id="INTERPOLATION" equiv-text="{{error.maxTimeout}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8594,6 +8594,14 @@
           <context context-type="linenumber">70</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7408991640539151057" datatype="html">
+        <source>Show all rows</source>
+        <target state="translated">Näytä kaikki rivit</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -8480,6 +8480,22 @@
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6585102904443570717" datatype="html">
+        <source>Couldn&apos;t simulate circuit because there were too many moments</source>
+        <target state="new">Couldn&apos;t simulate circuit because there were too many moments</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4633281565605788402" datatype="html">
+        <source>Circuit contains <x id="INTERPOLATION" equiv-text="{{error.moments}}"/> moments</source>
+        <target state="new">Circuit contains <x id="INTERPOLATION" equiv-text="{{error.moments}}"/> moments</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">70</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -8504,6 +8504,38 @@
           <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1505321340021272471" datatype="html">
+        <source>Simulation time can be extended up to 25 seconds using maxRunTimeout attribute.</source>
+        <target state="new">Simulation time can be extended up to 25 seconds using maxRunTimeout attribute.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3834816620880979274" datatype="html">
+        <source>The value of maxRunTimeout is too large</source>
+        <target state="new">The value of maxRunTimeout is too large</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7385899603772624470" datatype="html">
+        <source>maxRunTimeout has value: <x id="INTERPOLATION" equiv-text="{{error.timeout}}"/></source>
+        <target state="new">maxRunTimeout has value: <x id="INTERPOLATION" equiv-text="{{error.timeout}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="562104592773648088" datatype="html">
+        <source>But maximum is: <x id="INTERPOLATION" equiv-text="{{error.maxTimeout}}"/></source>
+        <target state="new">But maximum is: <x id="INTERPOLATION" equiv-text="{{error.maxTimeout}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -8496,6 +8496,14 @@
           <context context-type="linenumber">70</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="7408991640539151057" datatype="html">
+        <source>Show all rows</source>
+        <target state="new">Show all rows</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit-board.component.scss
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit-board.component.scss
@@ -140,6 +140,7 @@ svg text::selection {
   justify-content: flex-start;
   align-items: center;
   border-left: 1px solid black;
+  width: max-content;
 }
 
 img {

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
@@ -344,9 +344,9 @@ export interface CircuitOptions {
                     </div>
                 </div>
 
+                <tim-loading *ngIf="isResultCheckingRunning"></tim-loading>
                 <tim-quantum-error *ngIf="error" [error]="error"></tim-quantum-error>
                 <pre class="circuit-error" *ngIf="errorString" [innerHTML]="errorString | purify"></pre>
-                <tim-loading *ngIf="isResultCheckingRunning"></tim-loading>
                 <pre *ngIf="result" [innerHTML]="result | purify"></pre>
             </ng-container>
             <p footer *ngIf="footer" [innerHTML]="footer | purify"></p>

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
@@ -1074,12 +1074,14 @@ export class QuantumCircuitComponent
                 probabilityText: "0",
             }));
 
-        const outputProbabilities = this.simulator.getOutputProbabilities();
-        if (outputProbabilities) {
-            for (let i = 0; i < outputProbabilities.length; i++) {
-                this.qubitOutputs[i].probability = outputProbabilities[i];
-                this.qubitOutputs[i].probabilityText =
-                    outputProbabilities[i].toFixed(2) + "%";
+        if (this.showOutputBits) {
+            const outputProbabilities = this.simulator.getOutputProbabilities();
+            if (outputProbabilities) {
+                for (let i = 0; i < outputProbabilities.length; i++) {
+                    this.qubitOutputs[i].probability = outputProbabilities[i];
+                    this.qubitOutputs[i].probabilityText =
+                        outputProbabilities[i].toFixed(2) + "%";
+                }
             }
         }
 

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
@@ -220,6 +220,11 @@ export const ServerError = t.union([
         errorType: t.literal("too-many-qubits"),
     }),
     t.type({
+        moments: t.number,
+        maxMoments: t.number,
+        errorType: t.literal("too-many-moments"),
+    }),
+    t.type({
         regex: t.string,
         errorType: t.literal("regex-invalid"),
     }),
@@ -618,14 +623,14 @@ export class QuantumCircuitComponent
             const error = res.result;
             if (typeof error === "string") {
                 this.showErrorMessage(error);
-            } else if (error.errorType === "too-many-qubits") {
+            } else {
                 this.error = error;
             }
             this.isSimulatorRunning = false;
             const endTime = new Date();
 
             const timeDiff = endTime.getTime() - startTime.getTime();
-            console.log(`simulation ended in error at: ${timeDiff}ms`);
+            console.error(`simulation ended in error at: ${timeDiff}ms`);
 
             return;
         }

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
@@ -155,6 +155,7 @@ const QuantumCircuitMarkup = t.intersection([
         modelConditions: nullable(t.array(t.string)),
         qubits: nullable(t.array(QubitInfo)),
         outputNames: nullable(t.array(t.string)),
+        maxRunTimeout: nullable(t.number),
     }),
     GenericPluginMarkup,
     t.type({
@@ -230,6 +231,11 @@ export const ServerError = t.union([
     }),
     t.type({
         errorType: t.literal("simulation-timed-out"),
+    }),
+    t.type({
+        timeout: t.number,
+        maxTimeout: t.number,
+        errorType: t.literal("too-long-timeout"),
     }),
     t.type({
         message: t.string,

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts
@@ -64,6 +64,12 @@ import {IServerError} from "tim/plugin/quantumcircuit/quantum-circuit.component"
                 <p i18n>Circuit contains {{error.qubits}} qubits</p>
                 <p i18n>But max is {{error.maxQubits}}</p>
             </div>
+            
+            <div *ngIf="error.errorType === 'too-many-moments'">
+                <p i18n>Couldn't simulate circuit because there were too many moments</p>
+                <p i18n>Circuit contains {{error.moments}} moments</p>
+                <p i18n>But max is {{error.maxMoments}}</p>
+            </div>
 
             <div *ngIf="error.errorType === 'regex-invalid'">
                 <p i18n>modelInput contains invalid regex pattern</p>

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts
@@ -39,7 +39,7 @@ interface AnswerIncorrectRow {
 
             <div *ngIf="error.errorType === 'answer-incorrect'">
                 <label>
-                    <ng-container i18n>Show all</ng-container>
+                    <ng-container i18n>Show all rows</ng-container>
                     <input type="checkbox" [(ngModel)]="answerIncorrectShowAll" (ngModelChange)="createAnswerDisplayData()">
                 </label>
                 

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts
@@ -90,6 +90,13 @@ interface AnswerIncorrectRow {
 
             <div *ngIf="error.errorType === 'simulation-timed-out'">
                 <p i18n>Simulator timed out</p>
+                <p i18n>Simulation time can be extended up to 25 seconds using maxRunTimeout attribute.</p>
+            </div>
+            
+            <div *ngIf="error.errorType === 'too-long-timeout'">
+                <p i18n>The value of maxRunTimeout is too large</p>
+                <p i18n>maxRunTimeout has value: {{error.timeout}}</p>
+                <p i18n>But maximum is: {{error.maxTimeout}}</p>
             </div>
 
             <div *ngIf="error.errorType === 'circuit-uninterpretable'">

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-simulation.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-simulation.ts
@@ -99,12 +99,7 @@ export abstract class QuantumCircuitSimulator {
             return undefined;
         }
 
-        const probabilities: number[] = [];
-        this.result.forEach((probability) => {
-            probabilities.push(probability);
-        });
-
-        const output = this.randomChoice(probabilities);
+        const output = this.randomChoice(this.result);
         if (output !== undefined) {
             return {
                 input: input,
@@ -126,10 +121,13 @@ export abstract class QuantumCircuitSimulator {
         const probabilities: number[] = Array(this.board.nQubits).fill(0);
         const data = this.getProbabilities();
 
+        // see where there are 1's and increase the respective probabilities
         for (let i = 0; i < data.probabilities.length; i++) {
-            for (let j = data.labels.length - 1; j >= 0; j--) {
-                if (data.labels[i].charAt(j) === "1") {
-                    probabilities[j] += data.probabilities[i];
+            const label = data.labels[i];
+            const probability = data.probabilities[i];
+            for (let j = 0; j < label.length; j++) {
+                if (label.charAt(j) === "1") {
+                    probabilities[j] += probability;
                 }
             }
         }
@@ -155,15 +153,10 @@ export abstract class QuantumCircuitSimulator {
         result: number[],
         sampleSize: number
     ) {
-        const probabilities: number[] = [];
-        result.forEach((probability) => {
-            probabilities.push(probability);
-        });
-
         // draw samples and keep track of how many times they occur
-        const counter = Array(probabilities.length).fill(0);
+        const counter = Array(result.length).fill(0);
         for (let i = 0; i < sampleSize; i++) {
-            const sample = this.randomChoice(probabilities);
+            const sample = this.randomChoice(result);
 
             if (sample !== undefined) {
                 counter[sample]++;
@@ -186,7 +179,9 @@ export abstract class QuantumCircuitSimulator {
             return {probabilities: [], labels: []};
         }
 
+        const N = this.result.length;
         let probabilities: number[] = [];
+        let dataIndex = 0;
         if (sampleSize !== undefined) {
             probabilities = this.computeProbabilitiesBySampling(
                 this.result,
@@ -199,13 +194,16 @@ export abstract class QuantumCircuitSimulator {
                 this.result.length
             );
         }
-        const labels: string[] = [];
+        if (probabilities.length === 0) {
+            probabilities = Array(N);
+        }
+        const labels: string[] = Array(N);
         this.result.forEach((value, i) => {
             if (sampleSize === undefined && measurements === undefined) {
-                probabilities.push(value * 100);
+                probabilities[dataIndex] = value * 100;
             }
-            const bitString: string = this.indexToBitstring(i);
-            labels.push(bitString);
+            labels[dataIndex] = this.indexToBitstring(i);
+            dataIndex++;
         });
         return {
             probabilities: probabilities,

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-stats.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-stats.component.ts
@@ -82,6 +82,8 @@ export interface QuantumChartData {
 })
 export class QuantumStatsComponent implements OnInit, AfterViewInit, OnChanges {
     hideZeroRows: boolean = false;
+    hideZeroRowsLimit: number = 2000;
+    hideZeroRowsHasChanged: boolean = false;
 
     @ViewChild("chartInnerElement")
     chartInner?: ElementRef<HTMLDivElement>;
@@ -188,6 +190,15 @@ export class QuantumStatsComponent implements OnInit, AfterViewInit, OnChanges {
         }
         let labels = this.quantumChartData.labels;
         let probabilities = this.quantumChartData.probabilities;
+
+        // hide zero rows by default when there is a lot of data
+        if (
+            !this.hideZeroRowsHasChanged &&
+            labels.length > this.hideZeroRowsLimit
+        ) {
+            this.hideZeroRows = true;
+            this.hideZeroRowsHasChanged = true;
+        }
 
         if (this.hideZeroRows) {
             labels = [];


### PR DESCRIPTION
- Nopeuttaa tilastojen laskentaa (getOutputProbabilities käydään vahingossa 2^n * 2^n silmukkaa vaikka pitäisi käydä 2^n * n) ja alustetaan valmiiksi oikean kokoiset taulukot sen sijaan että täytettäisiin ne dynaamisesti
- Poistetaan qulacs:in virheviesteistä c++ funktionimet
- hideZeroRows näytetään oletuksella vain osa riveistä, jolloin diagrammi latautuu paremmin
- maksimimäärä ajanhetkille (nMoments)
- Mahdollisuus näyttää vastauksen virheviestin todennäköisyyslistauksesta vain ne rivit jotka ovat väärin
- tallentaessa vastausta tim-loading siirretty html:ssä ylemmäs ennen virheviestejä niin se näkyy kun tallentaa uudestaan
- width: max-content; korjasin ongelman, jossa kun nMoments on suuri ja tulee horisontaalinen scrollbar niin pieni svg neliö output-value ei näy ollenkaan
- maxRunTimeout attribuutti, joka rajaa simulointiin käytettävää aikaa vastausta tarkistettaessa max 25 sekuntia ja  oletus 10 sekuntia


https://timdevs01-2.it.jyu.fi/view/users/test-user-1/kvantti/test-kvantti
