### PR TITLE
Bump Poetry min version from 1.2.1 to 1.3.1

### DIFF
--- a/cli/commands/setup.py
+++ b/cli/commands/setup.py
@@ -32,7 +32,7 @@ This command is intended to be run once, but can be re-run to re-initialize the 
 }
 
 # Version of Poetry to install
-POETRY_MIN_VERSION = "1.2.1"
+POETRY_MIN_VERSION = "1.3.1"
 
 # Minimal Python version needed for development
 PYTHON_MIN_DEV_VERSION = [3, 7]


### PR DESCRIPTION
Bump minimum Poetry version from 1.2.1 to 1.3.1. Current `poetry.lock` file has been generated by Poetry version >1.3, so earlier Poetry version can't read it (see <https://github.com/python-poetry/poetry/issues/7211>).

This PR brings the Poetry version to parity with the Dockerfile, and resolves the above issue with new TIM installations.