### PR TITLE
Fix validate_points to accept values with comma as decimal separator

### DIFF
--- a/timApp/plugin/plugin.py
+++ b/timApp/plugin/plugin.py
@@ -328,6 +328,14 @@ class Plugin:
 
     def validate_points(self, points: str | float | None):
         try:
+            if isinstance(points, str) and points.rfind(",") >= 0:
+                # Convert decimal comma to decimal point since float conversion doesn't handle commas.
+                # If there are more than one comma, treat them as thousands separators and remove all
+                # of them before conversion.
+                ipart, sep, dpart = points.rpartition(",")
+                if ipart.rfind(","):
+                    ipart = ipart.replace(",", "")
+                points = f"{ipart}.{dpart}"
             points = float(points)
         except (ValueError, TypeError):
             raise PluginException("Invalid points format.")

--- a/timApp/plugin/plugin.py
+++ b/timApp/plugin/plugin.py
@@ -328,14 +328,20 @@ class Plugin:
 
     def validate_points(self, points: str | float | None):
         try:
+            # Convert decimal comma to decimal point since float conversion doesn't handle commas.
+            # If there are more than one comma, treat them as thousands separators and remove all
+            # of them before conversion.
             if isinstance(points, str) and points.rfind(",") >= 0:
-                # Convert decimal comma to decimal point since float conversion doesn't handle commas.
-                # If there are more than one comma, treat them as thousands separators and remove all
-                # of them before conversion.
-                ipart, sep, dpart = points.rpartition(",")
-                if ipart.rfind(","):
-                    ipart = ipart.replace(",", "")
-                points = f"{ipart}.{dpart}"
+                if not points.rfind("."):
+                    ipart, sep, dpart = points.rpartition(",")
+                    sep = "."
+                    if ipart.rfind(","):
+                        ipart = ipart.replace(",", "")
+                        # More than one comma, so these are thousands separators
+                        sep = ""
+                    points = f"{ipart}{sep}{dpart}"
+                else:
+                    points = points.replace(",", "")
             points = float(points)
         except (ValueError, TypeError):
             raise PluginException("Invalid points format.")


### PR DESCRIPTION
Korjaa käyttäjän itse pisteyttämien tehtävien pisteiden validoinnin:
- muuntaa desimaalierottimen pilkkumuotoisesta pistemuotoiseen, jonka Python osaa muuntaa floatiksi
- ottaa huomioon tuhaterottimet siltä varalta, että joku niitä yrittää tarjota (tuskin on tarpeen, mutta estetään rikkoutuminen)

Testattavana: <https://timdevs01-6.it.jyu.fi/view/users/test-user-1/plugin-userpoints/a>