### PR TITLE
Display user's groups in user search with URL param

### DIFF
--- a/timApp/admin/routes.py
+++ b/timApp/admin/routes.py
@@ -1,8 +1,6 @@
-import logging
 import os
 from dataclasses import dataclass
 
-import requests
 from flask import flash, url_for, Blueprint, Response, request
 
 from timApp.auth.accesshelper import verify_admin
@@ -11,7 +9,6 @@ from timApp.user.user import User
 from timApp.user.usergroup import UserGroup
 from timApp.util.flask.requesthelper import use_model
 from timApp.util.flask.responsehelper import safe_redirect, json_response
-from cli.util.logging import log_info
 
 admin_bp = Blueprint("admin", __name__, url_prefix="")
 

--- a/timApp/admin/routes.py
+++ b/timApp/admin/routes.py
@@ -1,28 +1,21 @@
 import os
-from dataclasses import dataclass
 
-from flask import flash, url_for, Blueprint, Response, request
+from flask import flash, url_for, Response
 
 from timApp.auth.accesshelper import verify_admin
 from timApp.timdb.sqa import db
 from timApp.user.user import User
 from timApp.user.usergroup import UserGroup
-from timApp.util.flask.requesthelper import use_model
 from timApp.util.flask.responsehelper import safe_redirect, json_response
+from timApp.util.flask.typedblueprint import TypedBlueprint
 
-admin_bp = Blueprint("admin", __name__, url_prefix="")
-
-
-@dataclass
-class ExceptionRouteModel:
-    db_error: bool = False
+admin_bp = TypedBlueprint("admin", __name__, url_prefix="")
 
 
 @admin_bp.route("/exception", methods=["GET", "POST", "PUT", "DELETE"])
-@use_model(ExceptionRouteModel)
-def throw_ex(m: ExceptionRouteModel) -> Response:
+def throw_ex(db_error: bool = False) -> Response:
     verify_admin()
-    if m.db_error:
+    if db_error:
         db.session.add(UserGroup(name="test"))
         db.session.add(UserGroup(name="test"))
         db.session.flush()
@@ -50,7 +43,7 @@ def restart_server() -> Response:
 
 
 @admin_bp.get("/users/search/<term>")
-def search_users(term: str) -> Response:
+def search_users(term: str, full: bool = False) -> Response:
     verify_admin()
     result = (
         User.query.filter(
@@ -61,9 +54,4 @@ def search_users(term: str) -> Response:
         .order_by(User.id)
         .all()
     )
-    show_groups = request.args.get("show_groups")
-    if not (show_groups == "True" or show_groups == "true"):
-        show_groups = False
-    return json_response(
-        [u.to_json(contacts=True, show_groups=show_groups) for u in result]
-    )
+    return json_response([u.to_json(contacts=True, full=full) for u in result])

--- a/timApp/admin/routes.py
+++ b/timApp/admin/routes.py
@@ -62,7 +62,7 @@ def search_users(term: str) -> Response:
         .all()
     )
     show_groups = request.args.get("show_groups")
-    if not show_groups == "True" or show_groups == "true":
+    if not (show_groups == "True" or show_groups == "true"):
         show_groups = False
     return json_response(
         [u.to_json(contacts=True, show_groups=show_groups) for u in result]

--- a/timApp/admin/routes.py
+++ b/timApp/admin/routes.py
@@ -1,7 +1,9 @@
+import logging
 import os
 from dataclasses import dataclass
 
-from flask import flash, url_for, Blueprint, Response
+import requests
+from flask import flash, url_for, Blueprint, Response, request
 
 from timApp.auth.accesshelper import verify_admin
 from timApp.timdb.sqa import db
@@ -9,6 +11,7 @@ from timApp.user.user import User
 from timApp.user.usergroup import UserGroup
 from timApp.util.flask.requesthelper import use_model
 from timApp.util.flask.responsehelper import safe_redirect, json_response
+from cli.util.logging import log_info
 
 admin_bp = Blueprint("admin", __name__, url_prefix="")
 
@@ -61,4 +64,9 @@ def search_users(term: str) -> Response:
         .order_by(User.id)
         .all()
     )
-    return json_response([u.to_json(contacts=True) for u in result])
+    show_groups = request.args.get("show_groups")
+    if not show_groups == "True" or show_groups == "true":
+        show_groups = False
+    return json_response(
+        [u.to_json(contacts=True, show_groups=show_groups) for u in result]
+    )

--- a/timApp/tests/server/test_admin.py
+++ b/timApp/tests/server/test_admin.py
@@ -12,7 +12,7 @@ from timApp.timdb.sqa import db
 from timApp.user.special_group_names import SPECIAL_USERNAMES
 from timApp.user.user import User, UserInfo
 from timApp.user.usercontact import ContactOrigin
-from timApp.user.usergroup import UserGroup
+from timApp.user.usergroup import UserGroup, get_admin_group_id
 from timApp.util.flask.requesthelper import RouteException, NotExist
 
 
@@ -68,6 +68,185 @@ class SearchTest(TimRouteTest):
                             "verified": True,
                         }
                     ],
+                },
+            ],
+        )
+
+        self.get(
+            "/users/search/test?full=true",
+            expect_content=[
+                {
+                    "consent": None,
+                    "contacts": [
+                        {
+                            "channel": "email",
+                            "contact": "test1@example.com",
+                            "origin": 1,
+                            "primary": True,
+                            "verified": True,
+                        }
+                    ],
+                    "email": "test1@example.com",
+                    "folder": {
+                        "id": self.test_user_1.get_personal_folder().id,
+                        "isFolder": True,
+                        "location": "users",
+                        "modified": "just now",
+                        "name": "test-user-1",
+                        "owners": [
+                            {
+                                "id": self.test_user_1.get_personal_group().id,
+                                "name": "testuser1",
+                            }
+                        ],
+                        "path": "users/test-user-1",
+                        "public": True,
+                        "rights": {
+                            "browse_own_answers": True,
+                            "can_comment": True,
+                            "can_mark_as_read": True,
+                            "copy": True,
+                            "editable": True,
+                            "manage": True,
+                            "owner": True,
+                            "see_answers": True,
+                            "teacher": True,
+                        },
+                        "title": "Test user 1",
+                        "unpublished": True,
+                    },
+                    "group": {
+                        "id": self.test_user_1.get_personal_group().id,
+                        "name": "testuser1",
+                    },
+                    "groups": [
+                        {
+                            "external_id": None,
+                            "id": self.test_user_1.get_personal_group().id,
+                            "name": "testuser1",
+                        },
+                        {
+                            "external_id": None,
+                            "id": get_admin_group_id(),
+                            "name": "Administrators",
+                        },
+                    ],
+                    "id": TEST_USER_1_ID,
+                    "last_name": None,
+                    "name": "testuser1",
+                    "real_name": "Test user 1",
+                },
+                {
+                    "consent": None,
+                    "contacts": [
+                        {
+                            "channel": "email",
+                            "contact": "test2@example.com",
+                            "origin": 1,
+                            "primary": True,
+                            "verified": True,
+                        }
+                    ],
+                    "email": "test2@example.com",
+                    "folder": {
+                        "id": self.test_user_2.get_personal_folder().id,
+                        "isFolder": True,
+                        "location": "users",
+                        "modified": "just now",
+                        "name": "test-user-2",
+                        "owners": [
+                            {
+                                "id": self.test_user_2.get_personal_group().id,
+                                "name": "testuser2",
+                            }
+                        ],
+                        "path": "users/test-user-2",
+                        "public": True,
+                        "rights": {
+                            "browse_own_answers": True,
+                            "can_comment": True,
+                            "can_mark_as_read": True,
+                            "copy": True,
+                            "editable": True,
+                            "manage": True,
+                            "owner": True,
+                            "see_answers": True,
+                            "teacher": True,
+                        },
+                        "title": "Test user 2",
+                        "unpublished": True,
+                    },
+                    "group": {
+                        "id": self.test_user_2.get_personal_group().id,
+                        "name": "testuser2",
+                    },
+                    "groups": [
+                        {
+                            "external_id": None,
+                            "id": self.test_user_2.get_personal_group().id,
+                            "name": "testuser2",
+                        }
+                    ],
+                    "id": TEST_USER_2_ID,
+                    "last_name": None,
+                    "name": "testuser2",
+                    "real_name": "Test user 2",
+                },
+                {
+                    "consent": None,
+                    "contacts": [
+                        {
+                            "channel": "email",
+                            "contact": "test3@example.com",
+                            "origin": 1,
+                            "primary": True,
+                            "verified": True,
+                        }
+                    ],
+                    "email": "test3@example.com",
+                    "folder": {
+                        "id": self.test_user_3.get_personal_folder().id,
+                        "isFolder": True,
+                        "location": "users",
+                        "modified": "just now",
+                        "name": "test-user-3",
+                        "owners": [
+                            {
+                                "id": self.test_user_3.get_personal_group().id,
+                                "name": "testuser3",
+                            }
+                        ],
+                        "path": "users/test-user-3",
+                        "public": True,
+                        "rights": {
+                            "browse_own_answers": True,
+                            "can_comment": True,
+                            "can_mark_as_read": True,
+                            "copy": True,
+                            "editable": True,
+                            "manage": True,
+                            "owner": True,
+                            "see_answers": True,
+                            "teacher": True,
+                        },
+                        "title": "Test user 3",
+                        "unpublished": True,
+                    },
+                    "group": {
+                        "id": self.test_user_3.get_personal_group().id,
+                        "name": "testuser3",
+                    },
+                    "groups": [
+                        {
+                            "external_id": None,
+                            "id": self.test_user_3.get_personal_group().id,
+                            "name": "testuser3",
+                        }
+                    ],
+                    "id": TEST_USER_3_ID,
+                    "last_name": None,
+                    "name": "testuser3",
+                    "real_name": "Test user 3",
                 },
             ],
         )

--- a/timApp/user/user.py
+++ b/timApp/user/user.py
@@ -1452,9 +1452,7 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
 
         return info_dict
 
-    def to_json(
-        self, full: bool = False, contacts: bool = False, show_groups: bool = False
-    ) -> dict:
+    def to_json(self, full: bool = False, contacts: bool = False) -> dict:
         external_ids: dict[int, str] = (
             {
                 s.group_id: s.external_id
@@ -1462,7 +1460,7 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
                     ScimUserGroup.group_id.in_([g.id for g in self.groups])
                 ).all()
             }
-            if full or show_groups
+            if full
             else []
         )
 
@@ -1489,21 +1487,6 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
 
         if contacts:
             result |= {"contacts": self.contacts}
-
-        if show_groups:
-            groups = self.groups
-            if (
-                self.logged_in
-                and self.is_current_user
-                and get_locked_active_groups() is not None
-            ):
-                groups = self.effective_groups
-            result |= {
-                "groups": [
-                    {**g.to_json(), "external_id": external_ids.get(g.id, None)}
-                    for g in groups
-                ]
-            }
 
         if self.logged_in and self.is_current_user:
             if locked_access := get_locked_access_type():

--- a/timApp/user/user.py
+++ b/timApp/user/user.py
@@ -1452,7 +1452,9 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
 
         return info_dict
 
-    def to_json(self, full: bool = False, contacts: bool = False) -> dict:
+    def to_json(
+        self, full: bool = False, contacts: bool = False, show_groups: bool = False
+    ) -> dict:
         external_ids: dict[int, str] = (
             {
                 s.group_id: s.external_id
@@ -1460,7 +1462,7 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
                     ScimUserGroup.group_id.in_([g.id for g in self.groups])
                 ).all()
             }
-            if full
+            if full or show_groups
             else []
         )
 
@@ -1487,6 +1489,21 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
 
         if contacts:
             result |= {"contacts": self.contacts}
+
+        if show_groups:
+            groups = self.groups
+            if (
+                self.logged_in
+                and self.is_current_user
+                and get_locked_active_groups() is not None
+            ):
+                groups = self.effective_groups
+            result |= {
+                "groups": [
+                    {**g.to_json(), "external_id": external_ids.get(g.id, None)}
+                    for g in groups
+                ]
+            }
 
         if self.logged_in and self.is_current_user:
             if locked_access := get_locked_access_type():


### PR DESCRIPTION
Allows displaying user's group memberships in user search results with the `show_groups` URL parameter.
Accepted values are 'true' and 'True', all else is considered False.