### PR TITLE
Don't force show invalid answers because of modelAnswer in teacher mode

### DIFF
--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1744,9 +1744,11 @@ export class AnswerBrowserComponent
             ) {
                 this.hideModelAnswerPanel = true;
             }
-            this.onlyValid = false;
-            if (this.answers.length > 0) {
-                this.onOnlyValidChanged();
+            if (!this.viewctrl.teacherMode) {
+                this.onlyValid = false;
+                if (this.answers.length > 0) {
+                    this.onOnlyValidChanged();
+                }
             }
         }
         this.showNewTask = this.isAndSetShowNewTask();


### PR DESCRIPTION
Poistaa show valid only-ruksin pois päältä pakottamisen jos ollaan opettajanäkymässä ja tehtävässä on mallivastaus

Jos tehtävässä on mallivastaus, siihen pakotetaan answerbrowseriin show valid only aina pois päältä, muistaakseni siksi että mallivastausta saattoi rauhassa kokeilla ilman että plugin lataa vanhemman vastauksen tallentamisen jälkeen. Tämä tosin haittaa tehtävien arvostelua, sillä opettajanäkymässä show valid on oletuksena pois (tai dokumenttiasetuksilla säädetty)