### PR TITLE
ParMenu location as user setting

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8642,6 +8642,46 @@
           <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="4524940619580662231" datatype="html">
+        <source>Paragraph menu position</source>
+        <target state="translated">Kappalevalikon paikka</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">358,359</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5246819740476460403" datatype="html">
+        <source>Left</source>
+        <target state="translated">Vasen</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">363</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4808834755787530462" datatype="html">
+        <source>Right</source>
+        <target state="translated">Oikea</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">367</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3024375068220163416" datatype="html">
+        <source> Left of the active paragraph, marked with a vertical blue bar.</source>
+        <target state="translated"> Sininen pystypalkki aktiivisen kappaleen vasemmalla puolella.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">373</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="219841344342795336" datatype="html">
+        <source> Right of the active paragraph, marked with a pencil icon.</source>
+        <target state="translated"> Kynäikoni aktiivisen kappaleen oikealla puolella.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">375</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -8241,8 +8241,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="4215858884470188361" datatype="html">
-        <source>This gate can&apos;t be edited</source>
-        <target state="new">This gate can&apos;t be edited</target>
+        <source>This gate can't be edited</source>
+        <target state="new">This gate can't be edited</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-toolbox.component.ts</context>
           <context context-type="linenumber">18</context>
@@ -8265,8 +8265,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="3583886527803327688" datatype="html">
-        <source>Answer doesn&apos;t satisfy condition:</source>
-        <target state="new">Answer doesn&apos;t satisfy condition:</target>
+        <source>Answer doesn't satisfy condition:</source>
+        <target state="new">Answer doesn't satisfy condition:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
           <context context-type="linenumber">9</context>
@@ -8393,8 +8393,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="151222451665123813" datatype="html">
-        <source>Couldn&apos;t simulate circuit because there were too many qubits</source>
-        <target state="new">Couldn&apos;t simulate circuit because there were too many qubits</target>
+        <source>Couldn't simulate circuit because there were too many qubits</source>
+        <target state="new">Couldn't simulate circuit because there were too many qubits</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
           <context context-type="linenumber">39</context>
@@ -8417,8 +8417,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="9063698038582773958" datatype="html">
-        <source>Too many qubits for browser simulator. Try changing simulate attribute to &quot;server&quot;.</source>
-        <target state="new">Too many qubits for browser simulator. Try changing simulate attribute to &quot;server&quot;.</target>
+        <source>Too many qubits for browser simulator. Try changing simulate attribute to "server".</source>
+        <target state="new">Too many qubits for browser simulator. Try changing simulate attribute to "server".</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-simulation.ts</context>
           <context context-type="linenumber">451</context>
@@ -8457,8 +8457,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="6193475728133614712" datatype="html">
-        <source>Using browser simulator because user isn&apos;t logged in: <x id="PH" equiv-text="Users.getCurrent().name"/></source>
-        <target state="new">Using browser simulator because user isn&apos;t logged in: <x id="PH" equiv-text="Users.getCurrent().name"/></target>
+        <source>Using browser simulator because user isn't logged in: <x id="PH" equiv-text="Users.getCurrent().name"/></source>
+        <target state="new">Using browser simulator because user isn't logged in: <x id="PH" equiv-text="Users.getCurrent().name"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts</context>
           <context context-type="linenumber">1089,1088</context>
@@ -8473,16 +8473,16 @@
         </context-group>
       </trans-unit>
       <trans-unit id="2503761822693065589" datatype="html">
-        <source>Couldn&apos;t interpret circuits</source>
-        <target state="new">Couldn&apos;t interpret circuits</target>
+        <source>Couldn't interpret circuits</source>
+        <target state="new">Couldn't interpret circuits</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
           <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6585102904443570717" datatype="html">
-        <source>Couldn&apos;t simulate circuit because there were too many moments</source>
-        <target state="new">Couldn&apos;t simulate circuit because there were too many moments</target>
+        <source>Couldn't simulate circuit because there were too many moments</source>
+        <target state="new">Couldn't simulate circuit because there were too many moments</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-error.component.ts</context>
           <context context-type="linenumber">69</context>
@@ -8542,6 +8542,46 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/quantumcircuit/quantum-circuit-board.component.ts</context>
           <context context-type="linenumber">71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4524940619580662231" datatype="html">
+        <source>Paragraph menu position</source>
+        <target state="translated">Plats för paragraph meny</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">358,359</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5246819740476460403" datatype="html">
+        <source>Left</source>
+        <target state="translated">vänster</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">363</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4808834755787530462" datatype="html">
+        <source>Right</source>
+        <target state="translated">höger</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">367</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3024375068220163416" datatype="html">
+        <source> Left of the active paragraph, marked with a vertical blue bar.</source>
+        <target state="translated"> Vänster om det aktiva stycket, markerat med ett vertikalt blått fält.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">373</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="219841344342795336" datatype="html">
+        <source> Right of the active paragraph, marked with a pencil icon.</source>
+        <target state="translated">Till höger om det aktiva stycket, markerat med en pennikon.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">375</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/static/scripts/tim/document/editing/editing.ts
+++ b/timApp/static/scripts/tim/document/editing/editing.ts
@@ -89,6 +89,11 @@ export enum SelectionUpdateType {
     DontAllowShrink,
 }
 
+export enum ParMenuHandlePosition {
+    Left = 0,
+    Right = 1,
+}
+
 function prepareOptions(
     $this: HTMLElement,
     saveTag: string
@@ -970,6 +975,7 @@ auto_number_headings: 0${CURSOR}
         fns.push({
             func: (e) => {
                 this.viewctrl.editMenuOnLeft = !this.viewctrl.editMenuOnLeft;
+                this.saveEditMenuPos(this.viewctrl.editMenuOnLeft);
                 this.updateEditBarState();
                 this.viewctrl.notesHandler.updateBadgeState();
             },
@@ -981,6 +987,13 @@ auto_number_headings: 0${CURSOR}
             spacingBefore: 5,
         });
         return fns;
+    }
+
+    async saveEditMenuPos(value: boolean) {
+        const pos = value
+            ? ParMenuHandlePosition.Right
+            : ParMenuHandlePosition.Left;
+        await to($http.post(`/settings/save/parmenupos/${pos}`, {}));
     }
 
     updateEditBarState() {

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -59,11 +59,14 @@ import {initCssPrint} from "tim/printing/cssPrint";
 import type {IUser, IUserListEntry} from "tim/user/IUser";
 import {Users} from "tim/user/userService";
 import {widenFields} from "tim/util/common";
-import {documentglobals} from "tim/util/globals";
+import {documentglobals, genericglobals} from "tim/util/globals";
 import {$compile, $http, $interval, $timeout} from "tim/util/ngimport";
 import type {AnnotationComponent} from "tim/velp/annotation.component";
 import {ReviewController} from "tim/velp/reviewController";
-import {EditingHandler} from "tim/document/editing/editing";
+import {
+    EditingHandler,
+    ParMenuHandlePosition,
+} from "tim/document/editing/editing";
 import type {PendingCollection} from "tim/document/editing/edittypes";
 import {onClick} from "tim/document/eventhandlers";
 import type {IDocSettings} from "tim/document/IDocSettings";
@@ -235,10 +238,6 @@ export class ViewCtrl implements IController {
     public users: IUserListEntry[];
     public teacherMode: boolean;
     public velpMode: boolean;
-    private editMenuOnLeftStorage = new TimStorage(
-        "editMenu_openOnLeft",
-        t.boolean
-    );
     public instantUpdateTasks = false;
     public syncAnswerBrowsers = false;
 
@@ -446,12 +445,17 @@ export class ViewCtrl implements IController {
         this.editingHandler.updateEditBarState();
     }
 
-    get editMenuOnLeft() {
-        return this.editMenuOnLeftStorage.get() ?? false;
+    get editMenuOnLeft(): boolean {
+        return (
+            genericglobals().userPrefs.parmenu_position ==
+            ParMenuHandlePosition.Left
+        );
     }
 
     set editMenuOnLeft(value: boolean) {
-        this.editMenuOnLeftStorage.set(value);
+        genericglobals().userPrefs.parmenu_position = value
+            ? ParMenuHandlePosition.Right
+            : ParMenuHandlePosition.Left;
     }
 
     getDefaultAction(par: ParContext): IMenuFunctionEntry | undefined {

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -454,8 +454,8 @@ export class ViewCtrl implements IController {
 
     set editMenuOnLeft(value: boolean) {
         genericglobals().userPrefs.parmenu_position = value
-            ? ParMenuHandlePosition.Right
-            : ParMenuHandlePosition.Left;
+            ? ParMenuHandlePosition.Left
+            : ParMenuHandlePosition.Right;
     }
 
     getDefaultAction(par: ParContext): IMenuFunctionEntry | undefined {

--- a/timApp/static/scripts/tim/user/settings.component.scss
+++ b/timApp/static/scripts/tim/user/settings.component.scss
@@ -259,3 +259,7 @@ textarea#custom_css {
     margin: 0 5px;
     min-width: 20%
 }
+
+.select-option {
+  display: flex;
+}

--- a/timApp/static/scripts/tim/user/settings.component.ts
+++ b/timApp/static/scripts/tim/user/settings.component.ts
@@ -43,6 +43,7 @@ import {
     TimTableComponent,
     TimTableModule,
 } from "tim/plugin/timTable/tim-table.component";
+import {ParMenuHandlePosition} from "tim/document/editing/editing";
 
 @Component({
     selector: "settings-button-panel",
@@ -353,6 +354,26 @@ type StyleDocumentInfoAll = Required<StyleDocumentInfo>;
                                 <ng-container i18n>Side bar menu: remember the last open state</ng-container>
                             </label>
                         </div>
+                    </div>
+                    <label for="par-menu-position" i18n>Paragraph menu position</label>
+                    <div class="select-option" id="par-menu-pos-option">
+                        <div>
+                            <select [(ngModel)]="settings.parmenu_position" id="par-menu-position">
+                                <option [ngValue]="ParMenuHandlePosition.Left">
+                                    <ng-container i18n>Left</ng-container>
+                                </option>
+                                <!-- Current default setting is on the right of the paragraph -->
+                                <option [ngValue]="ParMenuHandlePosition.Right">
+                                    <ng-container i18n>Right</ng-container>
+                                </option>
+                            </select>
+                        </div>
+                        <span style="padding-left: 1em;" [ngSwitch]="settings.parmenu_position">
+                            <ng-container *ngSwitchCase="ParMenuHandlePosition.Left" i18n>
+                                Left of the active paragraph, marked with a vertical blue bar.</ng-container> 
+                            <ng-container *ngSwitchCase="ParMenuHandlePosition.Right" i18n>
+                                Right of the active paragraph, marked with a pencil icon.</ng-container>
+                        </span>
                     </div>
                 </div>
                 <settings-button-panel [saved]="submit"></settings-button-panel>
@@ -1247,6 +1268,8 @@ export class SettingsComponent implements DoCheck, AfterViewInit {
             await showMessageDialog(r.result.error.error);
         }
     }
+
+    protected readonly ParMenuHandlePosition = ParMenuHandlePosition;
 }
 
 @NgModule({

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -185,6 +185,7 @@ export interface ISettings {
     auto_mark_all_read: boolean;
     max_uncollapsed_toc_items: number | null;
     style_doc_ids: number[];
+    parmenu_position: number;
 }
 
 export interface ILectureInfoGlobals extends IDocumentGlobals {

--- a/timApp/tests/browser/browsertest.py
+++ b/timApp/tests/browser/browsertest.py
@@ -330,7 +330,7 @@ class BrowserTest(LiveServerTestCase, TimRouteTestBase):
 
     def use_left_menu(self):
         # TODO: remove once tests have been updated to use the new edit menu format
-        self.drv.execute_script("localStorage.setItem('editMenu_openOnLeft', 'true');")
+        self.post("/settings/save/parmenupos/0")
         self.drv.implicitly_wait(0.5)
         self.drv.refresh()
         self.drv.implicitly_wait(5)

--- a/timApp/tests/browser/test_questions.py
+++ b/timApp/tests/browser/test_questions.py
@@ -272,11 +272,11 @@ class QuestionTest(BrowserTest):
         answer_type_choice=None,
         adjust_matrix=None,
     ):
+        self.use_left_menu()
         if adjust_matrix is None:
             adjust_matrix = []
         d = self.create_doc(initial_par="test")
         self.goto_document(d, view="lecture")
-        self.use_left_menu()
         # self.find_element('.glyphicon-option-horizontal').click()
         self.wait_until_present("#HELP_PAR")
         par = self.drv.find_elements(By.CSS_SELECTOR, ".editline")[1]

--- a/timApp/tests/browser/test_questions.py
+++ b/timApp/tests/browser/test_questions.py
@@ -79,6 +79,7 @@ class QuestionTest(BrowserTest):
         """Create document questions and answer them."""
         self.login_browser_quick_test1()
         self.login_test1()
+        self.use_left_menu()
 
         points = ["3", "1", "", "0"]
         choices = [
@@ -272,7 +273,6 @@ class QuestionTest(BrowserTest):
         answer_type_choice=None,
         adjust_matrix=None,
     ):
-        self.use_left_menu()
         if adjust_matrix is None:
             adjust_matrix = []
         d = self.create_doc(initial_par="test")

--- a/timApp/tests/server/test_settings.py
+++ b/timApp/tests/server/test_settings.py
@@ -104,7 +104,8 @@ class SettingsTest(TimRouteTest):
                     '"style_doc_ids": [], "last_answer_fetch": {}, '
                     '"auto_mark_all_read": false, "bookmarks": [{"Last edited": '
                     '[{"document 2": "/view/users/test-user-1/doc1"}]}], '
-                    '"max_uncollapsed_toc_items": null}',
+                    '"max_uncollapsed_toc_items": null, '
+                    '"parmenu_position": 1}',
                     "real_name": "Test user 1",
                 },
                 "velps": [],
@@ -215,6 +216,7 @@ type: python
                 "style_doc_ids": [],
                 "use_document_word_list": False,
                 "word_list": "",
+                "parmenu_position": 1,
             },
         )
         self.json_post(
@@ -231,6 +233,7 @@ type: python
                 "remember_last_sidebar_menu_state": True,
                 "remember_last_sidebar_menu_tab": True,
                 "auto_mark_all_read": True,
+                "parmenu_position": 0,
             },
         )
         self.get(
@@ -249,6 +252,7 @@ type: python
                 "remember_last_sidebar_menu_tab": True,
                 "auto_mark_all_read": True,
                 "bookmarks": None,
+                "parmenu_position": 0,
             },
         )
         self.json_post(
@@ -264,6 +268,7 @@ type: python
                 "remember_last_sidebar_menu_state": False,
                 "remember_last_sidebar_menu_tab": True,
                 "auto_mark_all_read": False,
+                "parmenu_position": 1,
             },
         )
         self.get(
@@ -282,6 +287,7 @@ type: python
                 "auto_mark_all_read": False,
                 "max_uncollapsed_toc_items": None,
                 "bookmarks": None,
+                "parmenu_position": 1,
             },
         )
 

--- a/timApp/user/preferences.py
+++ b/timApp/user/preferences.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import re
 import sre_constants
 from functools import cached_property
@@ -19,6 +20,11 @@ BookmarkFolder = dict[str, BookmarkEntryList]
 BookmarkCollection = list[BookmarkFolder]
 
 
+class ParMenuPosition(Enum):
+    Left = 0
+    Right = 1
+
+
 @attr.s(auto_attribs=True)
 class Preferences:
     custom_css: str = ""
@@ -34,6 +40,7 @@ class Preferences:
     auto_mark_all_read: bool = False
     bookmarks: BookmarkCollection | None = None
     max_uncollapsed_toc_items: int | None = None
+    parmenu_position: int = ParMenuPosition.Right
 
     @staticmethod
     def from_json(j: dict) -> "Preferences":

--- a/timApp/user/settings/settings.py
+++ b/timApp/user/settings/settings.py
@@ -112,6 +112,17 @@ def save_language_route(lang: str) -> Response:
     return r
 
 
+@settings_page.post("/save/parmenupos/<int:pos>")
+def save_parmenu_position_route(pos: int) -> Response:
+    u = get_current_user_object()
+    prefs = u.get_prefs()
+    prefs.parmenu_position = pos
+    u.set_prefs(prefs)
+    db.session.commit()
+    r = ok_response()
+    return r
+
+
 @settings_page.get("/get/<name>")
 def get_setting(name: str) -> Response:
     prefs = get_current_user_object().get_prefs()


### PR DESCRIPTION
Use persistent user setting for storing ParMenu position, instead of using browser's LocalStorage.
- resolves #3467 
- adds setting controls under 'Menus' preferences in TIM settings.
- ParMenu function 'Move menu to left/right' now uses the user setting as well
- removes localstorage setting