### PR TITLE
Restrict indexing and archiving by search provider crawler bots

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -504,9 +504,9 @@ GLOBAL_DOCUMENT_CACHING = False
 Global default value for document caching. The value allows globally enabling or disabling document cache.
 """
 
-RESTRICT_ROBOTS = True
+RESTRICT_ROBOTS = False
 RESTRICT_ROBOTS_METHODS = {
-    "restrict_global": False,
+    "restrict_global": True,
     "global_unavailable_date": "2023-10-20",
     "global": ["noindex", "nofollow", "noarchive"],
     "bots": {

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -507,14 +507,16 @@ Global default value for document caching. The value allows globally enabling or
 RESTRICT_ROBOTS = True
 RESTRICT_ROBOTS_METHODS = {
     "restrict_global": True,
-    "global": ["noindex", "nofollow", "noarchive"],
     "global_unavailable_date": "2023-10-20",
-    "googlebot": [],  # Google
-    "bingbot": [],  # Microsoft
-    "facebot": [],  # Facebook/Meta
-    "duckduckbot": [],  # Duck-Duck Go
-    "slurp": [],  # Yahoo
-    "baiduspider": [],  # Baidu
-    "yandexbot": [],  # Yandex
-    "otherbot": [],
+    "global": ["noindex", "nofollow", "noarchive"],
+    "bots": {
+        "googlebot": [],  # Google
+        "bingbot": [],  # Microsoft
+        "facebot": [],  # Facebook/Meta
+        "duckduckbot": [],  # Duck-Duck Go
+        "slurp": [],  # Yahoo
+        "baiduspider": [],  # Baidu
+        "yandexbot": [],  # Yandex
+        "otherbot": [],
+    },
 }

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -508,6 +508,7 @@ RESTRICT_ROBOTS = True
 RESTRICT_ROBOTS_METHODS = {
     "restrict_global": True,
     "global": ["noindex", "nofollow", "noarchive"],
+    "global_unavaílable_date": "2023-10-20",
     "googlebot": [],  # Google
     "bingbot": [],  # Microsoft
     "facebot": [],  # Facebook/Meta

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -503,3 +503,17 @@ GLOBAL_DOCUMENT_CACHING = False
 """
 Global default value for document caching. The value allows globally enabling or disabling document cache.
 """
+
+RESTRICT_ROBOTS = True
+RESTRICT_ROBOTS_METHODS = {
+    "restrict_global": True,
+    "global": ["noindex", "nofollow", "noarchive"],
+    "googlebot": [],  # Google
+    "bingbot": [],  # Microsoft
+    "facebot": [],  # Facebook/Meta
+    "duckduckbot": [],  # Duck-Duck Go
+    "slurp": [],  # Yahoo
+    "baiduspider": [],  # Baidu
+    "yandexbot": [],  # Yandex
+    "otherbot": [],
+}

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -508,7 +508,7 @@ RESTRICT_ROBOTS = True
 RESTRICT_ROBOTS_METHODS = {
     "restrict_global": True,
     "global": ["noindex", "nofollow", "noarchive"],
-    "global_unavaílable_date": "2023-10-20",
+    "global_unavailable_date": "2023-10-20",
     "googlebot": [],  # Google
     "bingbot": [],  # Microsoft
     "facebot": [],  # Facebook/Meta

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -506,7 +506,7 @@ Global default value for document caching. The value allows globally enabling or
 
 RESTRICT_ROBOTS = True
 RESTRICT_ROBOTS_METHODS = {
-    "restrict_global": True,
+    "restrict_global": False,
     "global_unavailable_date": "2023-10-20",
     "global": ["noindex", "nofollow", "noarchive"],
     "bots": {

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -360,6 +360,24 @@ def log_request(response):
 
 
 @app.after_request
+def robots_request(response: Response):
+    if app.config["RESTRICT_ROBOTS"] and request.method == "GET":
+        if app.config["RESTRICT_ROBOTS_METHODS"].get("restrict_global"):
+            response.headers.add_header(
+                "X-Robots-Tag",
+                ", ".join(app.config["RESTRICT_ROBOTS_METHODS"].get("global")),
+            )
+        else:
+            for bot in app.config["RESTRICT_ROBOTS_METHODS"].keys:
+                if bot not in ["restrict_global", "global"]:
+                    response.headers.add_header(
+                        "X-Robots-Tag",
+                        f"{bot}: {', '.join(app.config['RESTRICT_ROBOTS_METHODS'].get(bot))}",
+                    )
+    return response
+
+
+@app.after_request
 def after_request(resp: Response):
     token = generate_csrf()
     resp.set_cookie(

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -368,7 +368,7 @@ def robots_request(response: Response):
                 ", ".join(app.config["RESTRICT_ROBOTS_METHODS"].get("global")),
             )
         else:
-            for bot in app.config["RESTRICT_ROBOTS_METHODS"].keys:
+            for bot in app.config["RESTRICT_ROBOTS_METHODS"].keys():
                 if bot not in ["restrict_global", "global"]:
                     response.headers.add_header(
                         "X-Robots-Tag",

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -368,11 +368,13 @@ def robots_request(response: Response):
                 ", ".join(app.config["RESTRICT_ROBOTS_METHODS"].get("global")),
             )
         else:
-            for bot in app.config["RESTRICT_ROBOTS_METHODS"].keys():
-                if bot not in ["restrict_global", "global"]:
+            for bot in app.config["RESTRICT_ROBOTS_METHODS"]["bots"].keys():
+                restricted_methods = f"{', '.join(app.config['RESTRICT_ROBOTS_METHODS']['bots'].get(bot))}"
+                if restricted_methods:
+                    value = f"{bot}: {restricted_methods}"
                     response.headers.add_header(
                         "X-Robots-Tag",
-                        f"{bot}: {', '.join(app.config['RESTRICT_ROBOTS_METHODS'].get(bot))}",
+                        value,
                     )
 
         response.headers.add_header(

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -374,6 +374,11 @@ def robots_request(response: Response):
                         "X-Robots-Tag",
                         f"{bot}: {', '.join(app.config['RESTRICT_ROBOTS_METHODS'].get(bot))}",
                     )
+
+        response.headers.add_header(
+            "X-Robots-Tag",
+            f"unavailable_after: {app.config['RESTRICT_ROBOTS_METHODS'].get('global_unavailable_date')}",
+        )
     return response
 
 


### PR DESCRIPTION
Rajoittaa hakukoneiden indeksointeja TIM-palvelimilla. Asettaa GET-pyyntöjen vastauksiin headerin `X-Robots-Tag` joko globaalisti tai hakukoneittain riippuen `defaultconfig.py`ssä annetuista arvoista (muuttujat `RESTRICT_ROBOTS`, `RESTRICT_ROBOTS_METHODS`).

Katso myös: <https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag>.