### PR TITLE
Show qst explanations without reload

### DIFF
--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -231,8 +231,10 @@ def qst_answer_jso(m: QstAnswerModel):
     result = False
     if (
         info
-        and info.max_answers
-        and info.max_answers <= info.earlier_answers + 1
+        and (
+            (info.max_answers and info.max_answers <= info.earlier_answers + 1)
+            or not info.max_answers
+        )
         and prev_state != answers
     ):
         result = True

--- a/timApp/tests/server/test_question.py
+++ b/timApp/tests/server/test_question.py
@@ -152,7 +152,8 @@ points: '2:1'</code></pre>
             )
             self.get(d.url)
 
-        def test_hidden_points(self):
+    def test_hidden_points(self):
+        with self.internal_container_ctx():
             self.login_test1()
             d = self.create_doc(
                 initial_par="""
@@ -160,7 +161,9 @@ points: '2:1'</code></pre>
 answerFieldType: radio
 answerLimit: 1
 defaultPoints: -0.5
-expl: {}
+expl:
+  '1': def
+  '2': def
 headers:
 - a
 - b
@@ -205,6 +208,11 @@ rows:
             self.assertTrue("error" not in r)
             answers = self.get_task_answers(f"{d.id}.t", self.current_user)
             self.assertEqual(0.5, answers[0]["points"])
+            r = self.get(d.url, as_tree=True)
+            # TODO: showPoints: false hides explanations and points from teachers too
+            plugjson = self.get_plugin_json(r.cssselect(".parContent tim-qst")[0])
+            self.assertIsNone(plugjson["markup"].get("points"))
+            self.assertIsNone(plugjson["markup"].get("expl"))
             self.login_test2()
             r = self.post_answer(
                 "qst", f"{d.id}.t", user_input={"answers": [["2"], ["1"]]}
@@ -231,6 +239,10 @@ rows:
             self.assertTrue("error" not in r)
             answers = self.get_task_answers(f"{d.id}.t", self.current_user)
             self.assertEqual(None, answers[0]["points"])  # Should be hidden.
+            r = self.get(d.url, as_tree=True)
+            plugjson = self.get_plugin_json(r.cssselect(".parContent tim-qst")[0])
+            self.assertIsNone(plugjson["markup"].get("points"))
+            self.assertIsNone(plugjson["markup"].get("expl"))
 
     def test_question_shuffle(self):
         """

--- a/timApp/tests/server/test_question.py
+++ b/timApp/tests/server/test_question.py
@@ -450,3 +450,35 @@ rows:
             },
             r,
         )
+
+    def test_question_explanation_visibility(self):
+        with self.internal_container_ctx():
+            self.login_test1()
+            d = self.create_doc(
+                initial_par="""
+``` {#t plugin="qst"}
+answerFieldType: radio
+expl:
+ 1: wrong
+ 2: right
+headers:
+ - False
+ - True
+points: '2:1'
+questionText: test
+questionTitle: test
+questionType: matrix
+matrixType: radiobutton-horizontal
+rows:
+- 'A'
+- 'B'
+```"""
+            )
+            r = self.post_answer(
+                "qst", f"{d.id}.t", user_input={"answers": [["2"], []]}
+            )
+            self.assertEqual({"1": "wrong", "2": "right"}, r["web"]["markup"]["expl"])
+            r = self.get(d.url_relative, as_tree=True)
+            plugjson = self.get_plugin_json(r.cssselect(".parContent tim-qst")[0])
+            self.assertTrue(plugjson["show_result"])
+            self.assertEqual({"1": "wrong", "2": "right"}, plugjson["markup"]["expl"])


### PR DESCRIPTION
Näyttää qst-tehtävän kysmysvaihtoehtojen selitykset heti vastauksen jälkeen jos answerLimit ei ole käytössä. Tällä hetkellä käyttäjä joutuu päivittämään sivun että vaihtoehdot näkyy

https://timdevs01-3.it.jyu.fi/view/qst vs https://tim.jyu.fi/view/users/sijualle/kokeiluja/qstinfo