### PR TITLE
Add workaround for answer fetching performance

### DIFF
--- a/timApp/tests/server/test_answers.py
+++ b/timApp/tests/server/test_answers.py
@@ -32,6 +32,11 @@ class AnswerTest(TimRouteTest):
                     "total_points": total_points,
                     "velp_points": None,
                     "velped_task_count": 0,
+                    "answer_duration": None,
+                    "doc_id": "",
+                    "first_answer_on": None,
+                    "last_answer_on": None,
+                    "task_id": "",
                 }
             ],
             get_users_for_tasks(task_ids, [user.id]),

--- a/timApp/tests/server/test_hide_names.py
+++ b/timApp/tests/server/test_hide_names.py
@@ -3,7 +3,6 @@ from timApp.tests.db.timdbtest import TEST_USER_1_ID
 from timApp.tests.server.timroutetest import TimRouteTest
 from timApp.timdb.sqa import db
 from timApp.user.user import User, UserInfo
-from timApp.util.utils import get_current_time
 
 
 class HideNamesTest(TimRouteTest):
@@ -23,6 +22,11 @@ class HideNamesTest(TimRouteTest):
             "users",
             [
                 {
+                    "answer_duration": None,
+                    "doc_id": "",
+                    "first_answer_on": None,
+                    "last_answer_on": None,
+                    "task_id": "",
                     "task_count": 1,
                     "task_points": None,
                     "total_points": None,
@@ -36,6 +40,11 @@ class HideNamesTest(TimRouteTest):
                     "velped_task_count": 0,
                 },
                 {
+                    "answer_duration": None,
+                    "doc_id": "",
+                    "first_answer_on": None,
+                    "last_answer_on": None,
+                    "task_id": "",
                     "task_count": 1,
                     "task_points": None,
                     "total_points": None,

--- a/timApp/tests/server/test_teacher.py
+++ b/timApp/tests/server/test_teacher.py
@@ -1,6 +1,5 @@
 """Server tests for xxx."""
 import json
-
 import re
 
 from timApp.answer.answer import Answer
@@ -69,6 +68,11 @@ class TeacherTest(TimRouteTest):
             "users",
             [
                 {
+                    "answer_duration": None,
+                    "doc_id": "",
+                    "first_answer_on": None,
+                    "last_answer_on": None,
+                    "task_id": "",
                     "task_count": 1,
                     "task_points": None,
                     "total_points": None,

--- a/timApp/util/answerutil.py
+++ b/timApp/util/answerutil.py
@@ -12,8 +12,8 @@ from timApp.timdb.sqa import db
 from timApp.util.utils import get_current_time
 
 
-def task_ids_to_strlist(ids: list[TaskId]) -> list[str]:
-    return [t.doc_task for t in ids]
+def task_ids_to_strlist(ids: list[TaskId]) -> set[str]:
+    return set(t.doc_task for t in ids)
 
 
 GLOBAL_SINCE_LAST_KEY = "*"


### PR DESCRIPTION
Lisää workaroundin yhteispisteiden laskennalle joissain sivuissa. 

Nykyinen pistetilanteiden hakufunktio `answer.get_users_for_tasks` rakentaa yhden ison SQL-lausekkeen, joka hakee käyttäjien uusimmat vastaukset ja laskee niistä samalla yhteispisteet sekä tehtyjen tehtävien määrän.
SQL-lauseketta rakennettiin joskus silloin, kun datamäärä oli pieni, joten SQL-kyselyä ei silloin ajateltu optimoida, vaan sen sisään on lisätty vaan uusia laskuja. Nykyisellään kyseinen lauseke on niin hidas, että joissain dokumenteissa teacher-tilan lataamisessa voi mennä yli 30 sekuntia.

Tämä PR lisää (toivottavasti) väliaikaisen workaroundin, joka pilkkoo SQL-lausekkeen kolmeen osaan ja siirtää kaikki laskut Pythonin puolelle. Muutoksen ansiosta käsittelyaika putoaa muutamaan sekuntiin.

Esimerkki:
- <https://tim.jyu.fi/teacher/kurssit/tie/ohj1/2023k/omat-tiedot> (yksi SQL-kysely)
- <https://timdevs02.it.jyu.fi/teacher/kurssit/tie/ohj1/2023k/omat-tiedot>(muutama SQL-kysely + yhteenlasku Pythonissa)

Jätin koodiin alkuperäisen SQL-lausekkeella tehdyn version ja lisäsin samalla kommenteihin tapoja, jolla kysely tulisi korjata tulevaisuudessa. Tämän PR:n versio on nyt enemmän RAM-muistia käyttävä, mutta tämä on OK ottaen huomioon tuotanto-TIMin muistimäärään.