### PR TITLE
Exclude db migrations from ci-typos checks

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -20,6 +20,7 @@ extend-exclude = [
     "embedded_sagecell.js",
     "processing.js",
     "codeHighlight.scss",
+    "timApp/migrations/versions/*.py",
 ]
 
 [default.extend-identifiers]


### PR DESCRIPTION
Revision hashes are a constant source for false positives, so exclude database migration files from typos check when running CI on PRs/pushes.