### PR TITLE
docsettings: Add fieldmacros option

### DIFF
--- a/timApp/printing/documentprinter.py
+++ b/timApp/printing/documentprinter.py
@@ -812,7 +812,7 @@ class DocumentPrinter:
         macros.update(doc_settings.get_texmacroinfo(default_view_ctx).get_macros())
 
         out_pars = []
-        macroinfo = MacroInfo(default_view_ctx, macro_map=macros)
+        macroinfo = MacroInfo(default_view_ctx, macro_map=macros).with_field_macros()
         # go through doc pars to get all the template pars
         for par in pars:
             if par.get_attr("printing_template") is not None:

--- a/timApp/util/get_fields.py
+++ b/timApp/util/get_fields.py
@@ -138,7 +138,7 @@ class UserFieldObj(TypedDict):
     groupinfo: NotRequired[Any]
 
 
-@dataclass
+@dataclass(slots=True)
 class RequestedGroups:
     groups: list[UserGroup]
     include_all_answered: bool = False


### PR DESCRIPTION
Closes #3525 

Testisivu: <https://timdevs01-5.it.jyu.fi/view/users/test-user-1/test-fieldmacros> (testuser1)

The new `fieldmacros` setting allows to fetch user's current field values into macros. The syntax is the same as for JSRunner fields; that is:

```
fieldmacros:
  - field1
  - field1.points=f1p
```

and this approach supports the same field types (i.e. tallies, plugininfos, etc.).

At the moment, all user's fields can be used in fieldmacros, but only user's own latest valid answer is displayed. This means that a user can fetch their own answers from any document (just as they can do so by requesting the full personal GDPR-compliant data dump from TIM).

The setting displays fields only for the current user and does not switch the values in teacher mode. This will probably be an impossible task to implement without making major modifications to the rendering pipeline.
