### PR TITLE
plugin: Add saveSingleAnswer option

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -144,6 +144,7 @@ def save_answer(
     max_content_len: int | None = None,
     origin: OriginInfo | None = None,
     answered_on: datetime | None = None,
+    overwrite_existing: bool = False,
 ) -> Answer | None:
     """Saves an answer to the database.
 
@@ -160,6 +161,7 @@ def save_answer(
     :param force_save: Whether to force to save the answer even if the latest existing answer has the same content.
     :param origin: If known, the document from which the answer was sent.
     :param answered_on: If specified, overrides the date when the answer was saved. If None, uses the current date.
+    :param overwrite_existing: If specified, overwrites the existing answer with the new content if it exists.
 
     """
     # Never save points with round-off errors (could be caused by any computation)
@@ -182,6 +184,14 @@ def save_answer(
             a = answerinfo.latest_answer
             a.points = points
             a.last_points_modifier = points_given_by
+        return None
+    if overwrite_existing and answerinfo.latest_answer:
+        a = answerinfo.latest_answer
+        a.content = content_str
+        a.points = points
+        a.last_points_modifier = points_given_by
+        a.valid = valid
+        a.answered_on = answered_on or datetime.now()
         return None
 
     a = Answer(

--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -1172,6 +1172,7 @@ def post_answer_impl(
                     plugintype=plugin.ptype,
                     max_content_len=current_app.config["MAX_ANSWER_CONTENT_SIZE"],
                     origin=origin,
+                    overwrite_existing=plugin.known.saveSingleAnswer,
                 )
                 result["savedNew"] = a.id if a else None
                 if a:
@@ -1220,6 +1221,7 @@ def post_answer_impl(
                 plugintype=plugin.ptype,
                 max_content_len=current_app.config["MAX_ANSWER_CONTENT_SIZE"],
                 origin=origin,
+                overwrite_existing=plugin.known.saveSingleAnswer,
             )
             # TODO: Could call backup here too, but first we'd need to add support for saver in export/import.
             result["savedNew"] = a.id if a else None

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -154,6 +154,7 @@ class KnownMarkupFields(HiddenFieldsMixin):
     texbeforeprint: str | None | Missing = missing
     texprint: str | None | Missing = missing
     readonly: bool | Missing | None = missing
+    saveSingleAnswer: bool | Missing | None = missing
 
     def show_points(self) -> bool:
         if isinstance(self.showPoints, bool):


### PR DESCRIPTION
Esimerkki: <https://timdevs01-5.it.jyu.fi/view/users/test-user-1/test-single-save> (testuser1)

The `saveSingleAnswer` plugin option allows to only store the latest save attempt for each user. If the user sends multiple answers for the plugin task, only the latest answer will be saved.

The option is primarily intended for use with automatically computed fields (e.g. learning analytics dashboards in courses or progress markers for use with `fieldmacros`). For such cases, storing only a single answer per user will reduce database usage and keep page loading performance the same over time.

The option can be used with any plugin, but the UI currently may not properly support it.