### PR TITLE
Simplify admin quick login GUI

### DIFF
--- a/timApp/auth/sessioninfo.py
+++ b/timApp/auth/sessioninfo.py
@@ -141,3 +141,16 @@ def logged_in() -> bool:
 
 def save_last_page() -> None:
     session["last_doc"] = request.full_path
+
+
+def get_restored_context_user() -> User:
+    from timApp.auth.login import RESTORE_CONTEXT_KEY
+
+    # Look up in the restore context if the original user is an admin
+    if RESTORE_CONTEXT_KEY in session:
+        user_id = session[RESTORE_CONTEXT_KEY]["user_id"]
+        curr_user = User.get_by_id(user_id)
+    else:
+        curr_user = get_current_user_object()
+
+    return curr_user

--- a/timApp/document/docviewparams.py
+++ b/timApp/document/docviewparams.py
@@ -22,6 +22,7 @@ class DocViewParams:
     preamble: bool = False
     size: int | None = None
     valid_answers_only: bool | None = None
+    as_user: str | None = None
 
     def __post_init__(self) -> None:
         if self.b and self.e:

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8832,6 +8832,14 @@
           <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1836342875578532611" datatype="html">
+        <source>Switch to '<x id="INTERPOLATION" equiv-text="{{ restoreContextUser }}"/>'</source>
+        <target state="translated">Vaihda käyttäjään '<x id="INTERPOLATION" equiv-text="{{ restoreContextUser }}"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">79,80</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8840,6 +8840,62 @@
           <context context-type="linenumber">79,80</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2399597003780692851" datatype="html">
+        <source>Admin: Switch user</source>
+        <target state="translated">Admin: Vaihda käyttäjä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">78,79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1353298902710654370" datatype="html">
+        <source>User name (or email) to log in as</source>
+        <target state="translated">Käyttäjätunnus (tai sähköpostiosoite), jolla kirjaudutaan sisään</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">203,200</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9066185122374865739" datatype="html">
+        <source>Quick login</source>
+        <target state="translated">Nopea kirjautuminen</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">204,200</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7013428076523553580" datatype="html">
+        <source>Please enter a user name</source>
+        <target state="translated">Anna käyttäjätunnus</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">210</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4273028666363374378" datatype="html">
+        <source>Could not find users matching '<x id="PH" equiv-text="input"/>'</source>
+        <target state="translated">Ei löydetty käyttäjiä tunnuksella '<x id="PH" equiv-text="input"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">224</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="610626701105554971" datatype="html">
+        <source>No user found matching '<x id="PH" equiv-text="input"/>'</source>
+        <target state="translated">Ei löydetty käyttäjiä tunnuksella '<x id="PH" equiv-text="input"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">232</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8734603768376564175" datatype="html">
+        <source>Could not log in as '<x id="PH" equiv-text="quickLoginUser"/>': <x id="PH_1" equiv-text="loginResult.result.error"/></source>
+        <target state="translated">Nopea kirjautuminen käyttäjällä '<x id="PH" equiv-text="quickLoginUser"/>' ei onnistunut: <x id="PH_1" equiv-text="loginResult.result.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">250,249</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -8742,6 +8742,62 @@
           <context context-type="linenumber">79,80</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="2399597003780692851" datatype="html">
+        <source>Admin: Switch user</source>
+        <target state="translated">Admin: Växla användare</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">78,79</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1353298902710654370" datatype="html">
+        <source>User name (or email) to log in as</source>
+        <target state="translated">Användarnamn (eller e-postadress) att logga in som</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">203,200</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9066185122374865739" datatype="html">
+        <source>Quick login</source>
+        <target state="translated">Snabb inloggning</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">204,200</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7013428076523553580" datatype="html">
+        <source>Please enter a user name</source>
+        <target state="translated">Ange ett användarnamn</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">210</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4273028666363374378" datatype="html">
+        <source>Could not find users matching '<x id="PH" equiv-text="input"/>'</source>
+        <target state="translated">Kunde inte hitta användare som matchar '<x id="PH" equiv-text="input"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">224</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="610626701105554971" datatype="html">
+        <source>No user found matching '<x id="PH" equiv-text="input"/>'</source>
+        <target state="translated">Ingen användare hittades som matchade '<x id="PH" equiv-text="input"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">232</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8734603768376564175" datatype="html">
+        <source>Could not log in as '<x id="PH" equiv-text="quickLoginUser"/>': <x id="PH_1" equiv-text="loginResult.result.error"/></source>
+        <target state="translated">Kunde inte logga in som '<x id="PH" equiv-text="quickLoginUser"/>': <x id="PH_1" equiv-text="loginResult.result.error"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">250,249</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -8734,6 +8734,14 @@
           <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1836342875578532611" datatype="html">
+        <source>Switch to '<x id="INTERPOLATION" equiv-text="{{ restoreContextUser }}"/>'</source>
+        <target state="translated">Byt till '<x id="INTERPOLATION" equiv-text="{{ restoreContextUser }}"/>'</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/user-menu.component.ts</context>
+          <context context-type="linenumber">79,80</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -33,6 +33,7 @@ from timApp.auth.accesshelper import (
     ItemLockedException,
     verify_edit_access,
     verify_route_access,
+    verify_admin,
 )
 from timApp.auth.auth_models import BlockAccess
 from timApp.auth.get_user_rights_for_item import get_user_rights_for_item
@@ -572,6 +573,11 @@ def view(item_path: str, route: ViewRoute, render_doc: bool = True) -> FlaskView
     view_ctx = view_ctx_with_urlmacros(
         route, hide_names_requested=should_hide_names or is_hide_names()
     )
+
+    if m.as_user and verify_admin(require=False, user=current_user):
+        u = User.get_by_name(m.as_user)
+        if u:
+            current_user = u
 
     if render_doc:
         cr = check_doc_cache(doc_info, current_user, view_ctx, m, vp.nocache)

--- a/timApp/static/scripts/tim/user/user-menu.component.ts
+++ b/timApp/static/scripts/tim/user/user-menu.component.ts
@@ -11,9 +11,12 @@ import {
 } from "tim/item/access-role.service";
 import {showMessageDialog} from "tim/ui/showMessageDialog";
 import {showGroupLockDialog} from "tim/item/active-group-lock-dialog/showGroupLockDialog";
-import {to2} from "tim/util/utils";
+import {to2, toPromise} from "tim/util/utils";
 import type {IUser} from "tim/user/IUser";
-import {Users} from "tim/user/userService";
+import {isAdmin, Users} from "tim/user/userService";
+import {showInputDialog} from "tim/ui/showInputDialog";
+import {InputDialogKind} from "tim/ui/input-dialog.kind";
+import {HttpClient} from "@angular/common/http";
 
 /**
  * Displays the current user name and the number of additional
@@ -70,6 +73,10 @@ import {Users} from "tim/user/userService";
                     <li role="menuitem">
                         <a (click)="openGroupDialog()" i18n>Change active groups</a>
                     </li>
+                    
+                    <li role="menuitem" *ngIf="isAdmin() || restoreContextUser">
+                        <a (click)="beginQuickLogin()" i18n>Admin: Switch user</a>
+                    </li>
 
                     <li class="divider"></li>
                 </ng-container>
@@ -108,7 +115,7 @@ export class UserMenuComponent implements OnInit {
     private groupSwitchOpened = false;
     restoreContextUser: string | null = null;
 
-    constructor(private access: AccessRoleService) {}
+    constructor(private access: AccessRoleService, private http: HttpClient) {}
 
     ngOnInit(): void {
         if (!this.isLoggedIn()) {
@@ -151,6 +158,8 @@ export class UserMenuComponent implements OnInit {
     getCurrentUser = () => Users.getCurrent();
     getSessionUsers = () => Users.getSessionUsers();
 
+    isAdmin = () => isAdmin();
+
     numSession() {
         return Users.getSessionUsers().length;
     }
@@ -184,5 +193,66 @@ export class UserMenuComponent implements OnInit {
         this.groupSwitchOpened = true;
         await to2(showGroupLockDialog());
         this.groupSwitchOpened = false;
+    }
+
+    async beginQuickLogin() {
+        try {
+            const quickLoginUser = await showInputDialog({
+                isInput: InputDialogKind.InputAndValidator,
+                defaultValue: "",
+                text: $localize`User name (or email) to log in as`,
+                title: $localize`Quick login`,
+                okText: $localize`Log in`,
+                validator: async (input) => {
+                    if (!input || input.trim().length == 0) {
+                        return {
+                            ok: false,
+                            result: $localize`Please enter a user name`,
+                        };
+                    }
+                    const r = await toPromise(
+                        this.http.get<IUser[]>(`/users/search/${input}`, {
+                            params: {
+                                exact_match: true,
+                            },
+                        })
+                    );
+
+                    if (!r.ok) {
+                        return {
+                            ok: false,
+                            result: $localize`Could not find users matching '${input}'`,
+                        };
+                    }
+
+                    const result = r.result;
+                    if (result.length == 0) {
+                        return {
+                            ok: false,
+                            result: $localize`No user found matching '${input}'`,
+                        };
+                    }
+
+                    return {ok: true, result: result[0].name};
+                },
+            });
+
+            const loginResult = await toPromise(
+                this.http.get(`/quickLogin/${quickLoginUser}`, {
+                    params: {
+                        redirect: false,
+                    },
+                })
+            );
+
+            if (!loginResult.ok) {
+                await showMessageDialog(
+                    $localize`Could not log in as '${quickLoginUser}': ${loginResult.result.error}`
+                );
+                return;
+            }
+
+            window.location.reload();
+        } catch (e) {}
     }
 }

--- a/timApp/static/scripts/tim/user/user-menu.component.ts
+++ b/timApp/static/scripts/tim/user/user-menu.component.ts
@@ -74,9 +74,14 @@ import {Users} from "tim/user/userService";
                     <li class="divider"></li>
                 </ng-container>
                 <li *ngIf="!isLoggingOut" role="menuitem">
-                    <a (click)="beginLogout($event)" role="button" [ngSwitch]="numSession() > 0">
-                        <ng-container *ngSwitchCase="true" i18n>Log everyone out</ng-container>
-                        <ng-container *ngSwitchCase="false" i18n>Log out</ng-container>
+                    <a (click)="beginLogout($event)" role="button">
+                        <ng-container *ngIf="restoreContextUser; else normalContext">
+                            <ng-container i18n>Switch to '{{ restoreContextUser }}'</ng-container>
+                        </ng-container>
+                        <ng-template #normalContext [ngSwitch]="numSession() > 0">
+                            <ng-container *ngSwitchCase="true" i18n>Log everyone out</ng-container>
+                            <ng-container *ngSwitchCase="false" i18n>Log out</ng-container>    
+                        </ng-template>
                     </a>
                 </li>
                 <li role="menuitem" *ngFor="let u of getSessionUsers()">
@@ -101,6 +106,7 @@ export class UserMenuComponent implements OnInit {
     accessTypePrefix?: string;
     buttonTitle = $localize`You're logged in`;
     private groupSwitchOpened = false;
+    restoreContextUser: string | null = null;
 
     constructor(private access: AccessRoleService) {}
 
@@ -136,6 +142,8 @@ export class UserMenuComponent implements OnInit {
                 this.buttonTitle = $localize`${this.buttonTitle} (group access locked)`;
             }
         }
+
+        this.restoreContextUser = Users.restoreUser;
     }
 
     isLoggedIn = () => Users.isRealUser();

--- a/timApp/static/scripts/tim/user/userService.ts
+++ b/timApp/static/scripts/tim/user/userService.ts
@@ -15,14 +15,24 @@ export interface ILoginResponse {
 export class UserService {
     private current: ICurrentUser; // currently logged in user
     private group: IUser[]; // any additional users that have been added in the session - this does not include the main user
+    private restoreContextUser: string | null; // user to restore context to if the user is logged in as someone else
 
-    constructor(current: ICurrentUser, group: IUser[]) {
+    constructor(
+        current: ICurrentUser,
+        group: IUser[],
+        restoreContextUser: string | null = null
+    ) {
         this.current = current;
         this.group = group;
+        this.restoreContextUser = restoreContextUser;
     }
 
     public getCurrent(): ICurrentUser {
         return this.current;
+    }
+
+    public get restoreUser() {
+        return this.restoreContextUser;
     }
 
     public getCurrentPersonalFolderPath() {
@@ -44,7 +54,7 @@ export class UserService {
         const response = r.result;
         this.group = response.data.other_users;
         this.current = response.data.current_user;
-        if (!this.isLoggedIn()) {
+        if (!this.isLoggedIn() || this.restoreContextUser) {
             window.location.reload();
         }
     }
@@ -123,7 +133,8 @@ export class UserService {
 
 export const Users = new UserService(
     genericglobals().current_user,
-    genericglobals().other_users
+    genericglobals().other_users,
+    genericglobals().restoreContextUser
 );
 
 export function isAdmin() {

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -78,6 +78,7 @@ export interface IGenericGlobals {
     current_user: ICurrentUser;
     locale: Locale;
     other_users: IUser[];
+    restoreContextUser: string | null;
     bookmarks: IBookmarkGroup[] | null;
     ANGULARMODULES: unknown[];
     JSMODULES: string[];

--- a/timApp/templates/base.jinja2
+++ b/timApp/templates/base.jinja2
@@ -50,6 +50,7 @@
 
             var userPrefs = {{ prefs|tojson }};
             var current_user = {{ current_user.to_json(full=True)|tojson }};
+            var restoreContextUser = {{ (session.restore_context.user_name if session.restore_context else None)|tojson }};
             var other_users = {{ other_users|tojson }};
             var bookmarks = {{ bookmarks|tojson }};
             var locale = {{locale|tojson}};


### PR DESCRIPTION
Closes #3515 

Testaus: <https://timdevs02.it.jyu.fi/> (testaa omalla admin-tunnuksella)

Helpottaa admin-tunnuksella käyttäjätunnuksen vaihtamista ja palauttamista. Toteuttaa kolme uutta ominaisuutta:

1. Quick Login GUI

   Adminille näkyy nyt ylävalikossa "Admin: Vaihda käyttäjä" -painike:

     ![image](https://github.com/TIM-JYU/TIM/assets/5202606/39955b54-3d01-4f2d-89af-4a383276f354)

   Tämä avaa yksinkertaisen dialogin, jolla voi hakea ja nopeasti kirjautua sisään toisena käyttäjänä.
    
    ![image](https://github.com/TIM-JYU/TIM/assets/5202606/3bf713f6-0ea5-40b8-aec0-d42d57e78ebd)

2. Lisätty "Vaihda käyttäjään" -painike, kun on Quick Login päällä.

    Kun on kirjautunut toisella käyttäjällä quick loginissa, ylävalikossa näkyy uloskirjautumisen sijaan "Vaihda käyttäjä" -painike:
 
    ![image](https://github.com/TIM-JYU/TIM/assets/5202606/99329f2a-88c6-4dfc-b859-93ddb19f17e7)

   Painikkeella voi palata takaisin omaksi käyttäjäksi ilman sitä, että tarvitsee kirjautua kokonaan ulos.

3. Lisätty `as_user=` URL-parametri

    Kyseisellä URL-parametrilla voi esikatsella yksittäistä sivua jollain käyttäjällä. Esimerkiksi <https://timdevs02.it.jyu.fi/view/kurssit/tie/ohj1/2023s/eteneminen?as_user=akankka> lataa yksittäisen sivun Aku Ankan näkökulmasta. Kyseistä asetusta käytetään vain sivun avaamiseksi, eli kentät ja tehtävien vastaukset näkyvät mahdollisesti omina, mutta makrot näkyvät käyttäjän näkökulmasta. Tämä niin, koska muute kyseistä parametria pitäisi integroita syvemmällä TIMiin, mikä on paljon suurempi homma nykyisellä TIMin koodikannalla.

    
Kaikki nämä asetukset toimivat vain admineille. Jatkon kannalta voi toki miettiä, voisiko joku peruskäyttäjä tehdä rajoitetusti samaa.