### PR TITLE
parmenu: Detect edit menu click on par side

### DIFF
--- a/timApp/static/scripts/tim/document/editing/editing.ts
+++ b/timApp/static/scripts/tim/document/editing/editing.ts
@@ -1010,10 +1010,15 @@ auto_number_headings: 0${CURSOR}
     }
 
     updateEditBarState() {
-        document.documentElement.style.setProperty(
-            "--editline-display",
-            this.viewctrl.editMenuOnLeft ? "block" : "none"
-        );
+        const body = document.body;
+
+        if (this.viewctrl.editMenuOnLeft) {
+            body.classList.add("editmenu-left");
+            body.classList.remove("editmenu-right");
+        } else {
+            body.classList.remove("editmenu-left");
+            body.classList.add("editmenu-right");
+        }
     }
 
     private getAddParagraphItem(pos: EditPosition) {

--- a/timApp/static/scripts/tim/document/parmenu.ts
+++ b/timApp/static/scripts/tim/document/parmenu.ts
@@ -63,9 +63,7 @@ export class ParmenuHandler {
                 }
                 const editMenuLeft = this.viewctrl.editMenuOnLeft;
                 if ((editMenuLeft && !par.preamble) || !editMenuLeft) {
-                    const parOffset = par.offset() ?? getEmptyCoords();
-                    const badgeY = e.pageY - parOffset.top;
-                    this.viewctrl.notesHandler.updateNoteBadge(par, badgeY);
+                    this.updateBadgePosition(par, e);
                 }
                 if (!par.isActionable()) {
                     return;
@@ -124,8 +122,26 @@ export class ParmenuHandler {
             true
         );
 
-        onClick(".editline", this.openParMenu, true);
+        onClick(".editline", this.handleLeftEditAreaClick, true);
     }
+
+    private updateBadgePosition(par: ParContext, e: OnClickArg) {
+        const parOffset = par.offset() ?? getEmptyCoords();
+        const badgeY = e.pageY - parOffset.top;
+        this.viewctrl.notesHandler.updateNoteBadge(par, badgeY);
+    }
+
+    handleLeftEditAreaClick = async (
+        $this: JQuery,
+        e: OnClickArg
+    ): Promise<boolean | void> => {
+        const par = createParContextOrHelp(findParentPar($this));
+        if (!this.viewctrl.editMenuOnLeft && !par.isHelp) {
+            this.updateBadgePosition(par, e);
+            return;
+        }
+        await this.openParMenu($this, e);
+    };
 
     openParMenu = async (
         $this: JQuery,

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -674,7 +674,7 @@ a.timButton {
     width: $editline-width;
     height: 100%;
     top: 0;
-    display: var(--editline-display, none);
+    display: block;
 
     @media (max-width: 870px) { /* for ipdas because of outend headings */
         left: -($editline-width / 2);
@@ -689,6 +689,38 @@ a.timButton {
     &:hover, &.menuopen {
         opacity: 0.5;
         background: $editline-bg-color;
+    }
+}
+
+.editmenu-right {
+    .editline {
+        --_overfill-width: #{$editline-width + $editline-extra};
+        width: var(--_overfill-width);
+        z-index: 1;
+
+        @media (max-width: 870px) { /* for ipdas because of outend headings */
+            --_overfill-width: #{$editline-width / 2};
+        }
+
+        @media (max-width: $screen-xs-max) {
+            --_overfill-width: #{$grid-gutter-width / 3 + $focus-bar-width};
+        }
+
+        &:hover, &.menuopen {
+            opacity: 0;
+        }
+
+        &:focus {
+            outline: none;
+        }
+    }
+
+    .parContent {
+        z-index: 2;
+    }
+
+    .edit-menu-button {
+        z-index: 3;
     }
 }
 


### PR DESCRIPTION
Testi: <https://timdevs02.it.jyu.fi/> (oma tunnus)

This commit improves detection of edit menu click when using the right-side menu. This uses the left-side menu to detect paragraph clicks on the side, fixing issues where iframes capture the click events.

[test.webm](https://github.com/TIM-JYU/TIM/assets/5202606/b26a8389-1230-4591-9871-5ba9b84db9f6)
