### PR TITLE
Add integration between videos and JSRunner, add refresh support for JSRunner

### DIFF
--- a/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
+++ b/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
@@ -15,6 +15,7 @@ import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {PurifyModule} from "tim/util/purify.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
+import {showConfirm} from "tim/ui/showConfirmDialog";
 import type {
     AnswerReturnBrowser,
     ErrorList,
@@ -169,7 +170,11 @@ export class JsRunnerPluginComponent
             return;
         }
         if (this.attrsall.markup.confirmText) {
-            if (!window.confirm(this.attrsall.markup.confirmText)) {
+            const res = await showConfirm(
+                $localize`Confirm`,
+                this.attrsall.markup.confirmText
+            );
+            if (!res) {
                 return;
             }
         }

--- a/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
+++ b/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
@@ -242,6 +242,29 @@ export class JsRunnerPluginComponent
                 }
                 this.processExportData(tempd.outdata.exportdata);
                 this.vctrl.processAreaVisibility(tempd.outdata.areaVisibility);
+
+                if (tempd.outdata.refresh) {
+                    if (tempd.outdata.refreshRunJSRunners) {
+                        const urlParams = new URLSearchParams(
+                            window.location.search
+                        );
+                        urlParams.set(
+                            "run_jsrunners",
+                            tempd.outdata.refreshRunJSRunners.join(",")
+                        );
+                        const currentUrl = window.location.href;
+                        const url = new URL(window.location.href);
+                        url.search = urlParams.toString();
+                        const newUrl = url.toString();
+                        if (newUrl != currentUrl) {
+                            window.location.href = newUrl;
+                        } else {
+                            location.reload();
+                        }
+                    } else {
+                        location.reload();
+                    }
+                }
             }
         } else {
             this.error = {

--- a/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
+++ b/timApp/modules/jsrunner/client/javascripts/jsrunner-plugin.component.ts
@@ -241,7 +241,10 @@ export class JsRunnerPluginComponent
                     return;
                 }
                 this.processExportData(tempd.outdata.exportdata);
-                this.vctrl.processAreaVisibility(tempd.outdata.areaVisibility);
+                this.vctrl.processAreaVisibility(
+                    tempd.outdata.areaVisibility,
+                    tempd.outdata.saveAreaVisibility ?? true
+                );
 
                 if (tempd.outdata.refresh) {
                     if (tempd.outdata.refreshRunJSRunners) {

--- a/timApp/modules/jsrunner/shared/jsrunnertypes.ts
+++ b/timApp/modules/jsrunner/shared/jsrunnertypes.ts
@@ -93,6 +93,7 @@ interface AnswerReturnSuccess {
         outdata?: {
             exportdata?: ExportData;
             areaVisibility?: Record<string, boolean>;
+            saveAreaVisibility?: boolean;
             refresh?: boolean;
             refreshRunJSRunners?: string[];
             md?: string;

--- a/timApp/modules/jsrunner/shared/jsrunnertypes.ts
+++ b/timApp/modules/jsrunner/shared/jsrunnertypes.ts
@@ -93,6 +93,8 @@ interface AnswerReturnSuccess {
         outdata?: {
             exportdata?: ExportData;
             areaVisibility?: Record<string, boolean>;
+            refresh?: boolean;
+            refreshRunJSRunners?: string[];
             md?: string;
             html?: string;
         };

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -531,12 +531,18 @@ export class ViewCtrl implements IController {
         });
     }
 
-    public processAreaVisibility(newVisibility?: Record<string, boolean>) {
+    public processAreaVisibility(
+        newVisibility?: Record<string, boolean>,
+        saveState: boolean = true
+    ) {
         const d = new TimStorage(
             "areaVisibility",
             t.record(t.string, t.record(t.string, t.boolean))
         );
-        const currentVisibilities = d.get() ?? {};
+        let currentVisibilities = d.get() ?? {};
+        if (!saveState) {
+            currentVisibilities = {};
+        }
         // io-ts doesn't automatically convert number keys to strings so we use docId as string directly
         const docId = `${this.docId}`;
         let currentDoc = currentVisibilities[docId] ?? {};
@@ -564,7 +570,9 @@ export class ViewCtrl implements IController {
         if (hasAreas) {
             currentVisibilities[docId] = currentDoc;
         }
-        d.set(currentVisibilities);
+        if (saveState) {
+            d.set(currentVisibilities);
+        }
     }
 
     public findUserByName(userName: string) {


### PR DESCRIPTION
Toteutetaan ominaisuuksia, joita tarvitaan kurssille "Julkisten hankintojen perusteet":

- Videoiden loppuessa voi suorittaa JSRunner
- JSRunnerilla on mahdollisuus virkistää sivu ajon lopuksi
  - Lisäksi virkistyessä voidaan ajaa toinen JSRunner
- Pieni ominaisuus: JSRunnereiden alueiden piilotusta/näyttämistä voi tehdä nyt väliaikaisesti ilman, että tila tallentuisi localStorageen

Testit/esimerkit:

- JSRunnerin ajaminen videon loppuessa: <https://timdevs01-5.it.jyu.fi/view/users/test-user-1/test-video-jsrunner>
- JSRunner ja sivujen virkistäminen: <https://timdevs01-5.it.jyu.fi/view/users/test-user-1/test-jsrunner-refresh>