### PR TITLE
jsrunner: Add canOverwriteValidity option

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -99,7 +99,7 @@ from timApp.plugin.jsrunner.jsrunner import (
     JsRunnerAnswerModel,
     JsRunnerAnswerSchema,
 )
-from timApp.plugin.jsrunner.util import save_fields
+from timApp.plugin.jsrunner.util import save_fields, AllowedOverwriteOptions
 from timApp.plugin.plugin import (
     Plugin,
     PluginWrap,
@@ -958,8 +958,8 @@ def post_answer_impl(
 
     if "savedata" in jsonresp:
         siw = answer_call_data.get("markup", {}).get("showInView", False)
-        overwrite_points = answer_call_data.get("markup", {}).get(
-            "canOverwritePoints", False
+        overwrite_opts = AllowedOverwriteOptions.from_markup(
+            answer_call_data.get("markup", {})
         )
         add_group = None
         if plugin.type == "importData":
@@ -972,7 +972,7 @@ def post_answer_impl(
             allow_non_teacher=siw,
             add_users_to_group=add_group,
             pr_data=pr_data,
-            overwrite_previous_points=overwrite_points,
+            overwrite_opts=overwrite_opts,
             view_ctx=view_ctx,
         )
 

--- a/timApp/plugin/jsrunner/jsrunner.py
+++ b/timApp/plugin/jsrunner/jsrunner.py
@@ -72,6 +72,7 @@ class JsRunnerMarkupModel(GenericMarkupModel):
     overrideGrade: bool = False
     showInView: bool = False
     canOverwritePoints: bool = False
+    canOverwriteValidity: bool = False
     confirmText: str | Missing = missing
     timeout: int | Missing = missing
     updateFields: list[str] | Missing = missing


### PR DESCRIPTION
Tämä kortti on osana kurssin "Julkisten hankintojen perusteet" tarvittavia ominaisuuksia.

Adds JSRunner option to allow overwriting validity state of current answers. This allows to, for example, unlock/lock tasks with more ease.

Testi:

- <https://timdevs01-5.it.jyu.fi/view/users/test-user-1/test-invalid-reset>

