### PR TITLE
Qst: enforce expl as dict or None

### DIFF
--- a/timApp/lecture/question_utils.py
+++ b/timApp/lecture/question_utils.py
@@ -212,7 +212,7 @@ def qst_handle_randomization(jso: dict) -> None:
             )
     if rand_arr is not None:  # specific order found in prev.ans or markup
         markup["rows"] = qst_set_array_order(rows, rand_arr)
-        markup["expl"] = qst_pick_expls(markup["expl"], rand_arr)
+        markup["expl"] = qst_pick_expls(markup.get("expl"), rand_arr)
         points = markup.get("points")
         if points:
             question_type = markup.get("questionType")

--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -121,7 +121,7 @@ class QstMarkupModel(GenericMarkupModel):
     maxpoints: float | Missing = missing
     # TODO: Set proper types
     answerFieldType: str | None | Missing = missing
-    expl: Any | Missing = missing
+    expl: dict[Any, Any] | None | Missing = missing
     headers: Any | Missing = missing
     matrixType: str | None | Missing = missing
     questionText: str | None | Missing = missing
@@ -226,7 +226,8 @@ def qst_answer_jso(m: QstAnswerModel):
         # TODO: Schema?
         answers = {"c": answers, "order": rand_arr}
         m.markup.rows = qst_set_array_order(m.markup.rows, rand_arr)
-        m.markup.expl = qst_pick_expls(m.markup.expl, rand_arr)
+        if m.markup.expl is not missing:
+            m.markup.expl = qst_pick_expls(m.markup.expl, rand_arr)
 
     result = False
     if (


### PR DESCRIPTION
Pakottaa qst-tehtävissä expl-attribuutin dictiksi/tyhjäksi/puuttuvaksi

Noissa satunnaistusfunktioissa oletetaan että expl joko puuttuu tai on objekti. Tuosta on tullut jonkin verran wuffeja jos se on ollut esim pelkkä merkkijono ja satunnaistus on ollut käytössä

Laitoin haaran devs02:een timdevs02.it.jyu.fi
Nopeasti testattuna nykyiset qst-tehtävät ja luentokysymykset toimii. Koitin haulla katsoa onko jossain aktiivisessa dokumentissa käytetty väärää muotoa, mutta niitä ei näyttänyt olevan