### PR TITLE
Add ability to send welcome message to new group users

### DIFF
--- a/timApp/notification/group_notification.py
+++ b/timApp/notification/group_notification.py
@@ -1,0 +1,90 @@
+from sqlalchemy import select
+
+from timApp.answer.answer import Answer
+from timApp.answer.answers import get_all_answer_initial_query
+from timApp.document.docentry import DocEntry
+from timApp.item.block import Block
+from timApp.notification.send_email import send_email
+from timApp.timdb.sqa import run_sql
+from timApp.user.user import User
+from timApp.user.usergroup import UserGroup
+
+JOIN_MESSAGE_TASKID = "GLO_join_message"
+
+
+def parse_message(message: str) -> tuple[str, str]:
+    """
+    Parses message by separating the Subject header from the message body.
+
+    :param message: The message to parse
+    :return: A tuple containing the subject and the message body
+    """
+    # First, try to read the headers
+    # Then, try to read the body
+
+    message = message.strip()
+    headers = {}
+    body = []
+    read_line = 0
+
+    for li, line in enumerate(message.splitlines()):
+        line = line.strip()
+        read_line = li
+        if not line:
+            break
+        if ":" not in line:
+            break
+        key, value = line.split(":", 1)
+        headers[key.strip()] = value.strip()
+
+    for line in message.splitlines()[read_line:]:
+        body.append(line)
+
+    # TODO: Return other headers as well if needed
+    return headers.get("Subject", ""), "\n".join(body).strip()
+
+
+def send_group_join_message(u: User, ug: UserGroup) -> None:
+    """
+    Sends a group join message to the user.
+
+    :param u: User to send the message to
+    :param ug: UserGroup the user joined
+    """
+    admin_doc: Block | None = ug.admin_doc
+    if not admin_doc:
+        return
+    docs: list[DocEntry] = admin_doc.docentries
+    if not docs:
+        return
+
+    doc = docs[0]
+
+    ans: Answer | None = (
+        run_sql(
+            select(Answer)
+            .where(Answer.task_id == f"{doc.id}.{JOIN_MESSAGE_TASKID}")
+            .order_by(Answer.id.desc())
+            .limit(1)
+        )
+        .scalars()
+        .first()
+    )
+
+    if not ans:
+        return
+
+    content = ans.content_as_json.get("c", None) or ans.content_as_json.get(
+        "usercode", None
+    )
+    if not content or not isinstance(content, str):
+        return
+
+    subject, body = parse_message(content)
+    if not body:
+        return
+
+    if not subject:
+        subject = f"TIM: You were added to group '{ug.name}'"
+
+    send_email(u.email, subject, body)

--- a/timApp/sisu/scim.py
+++ b/timApp/sisu/scim.py
@@ -16,6 +16,7 @@ from timApp.messaging.messagelist.messagelist_utils import (
     sync_message_list_on_add,
     sync_message_list_on_expire,
 )
+from timApp.notification.group_notification import send_group_join_message
 from timApp.sisu.parse_display_name import (
     parse_sisu_group_display_name,
     SisuDisplayName,
@@ -508,6 +509,7 @@ def update_users(ug: UserGroup, args: SCIMGroupModel) -> None:
         update_mailing_list_address(old, new)
 
     for added_user in added_users:
+        send_group_join_message(added_user, ug)
         sync_message_list_on_add(added_user, ug)
 
     for expired_membership in expired_memberships:

--- a/timApp/static/tim_docs/initial/group_preamble.md
+++ b/timApp/static/tim_docs/initial/group_preamble.md
@@ -1,5 +1,6 @@
 ``` {settings=""}
 form_mode: true
+disable_answer: view
 macros:
   fields:
     - info
@@ -65,3 +66,27 @@ emailUsersButtonText: "Lähetä sähköpostia"
 
 #- {.hidden-print}
 Ryhmiä ei voi poistaa.
+
+## Muita asetuksia {.hidden-print}
+
+``` {#GLO_join_message plugin="csPlugin" .hidden-print}
+type: text
+stem: |!!
+md:
+**Tervetuloviesti**
+
+Alla oleva viesti lähetetään automaattisesti kaikille ryhmään lisätyille käyttäjille.
+
+Voit määritellä viestin otsikon lisäämällä alkuun `Subject:`.\
+Malli:
+
+~~~
+Subject: Viestin otsikko
+
+Tervetuloa!
+~~~
+
+!!
+button: Tallenna
+rows: 10
+```


### PR DESCRIPTION
Esimerkki: <https://timdevs01-5.it.jyu.fi/view/groups/testgroup1>
  - testuser1 omistaa ryhmän
  - Huom: Testiä varten kannattaa tehdä oma tunnus toimivalla sähköpostilla, niin voi kokeilla viestin saapumista

This feature allows to set an automatic welcome message to be sent to the users that are added to a user group. To specify the message, save it as a global answer to the user group management document with task name "GLO_join_message". The contents of this global answer are used as the message contents.

