### PR TITLE
Fix word count for csplugin textarea (via countboard component)

### DIFF
--- a/timApp/modules/cs/js/util/util.ts
+++ b/timApp/modules/cs/js/util/util.ts
@@ -15,7 +15,7 @@ export function countWords(str: string): number {
     }
     // ignore punctuation characters that appear on their own, as the grammar/syntax in some languages (notably, French)
     // dictates whitespace before some punctuation, like question/exclamation marks etc.
-    const ans = s.filter((e) => e.match(/\p{P}?\w/u));
+    const ans = s.filter((e) => e.match(/\w/u));
 
     // return s.length;
     return ans.length;

--- a/timApp/modules/cs/js/util/util.ts
+++ b/timApp/modules/cs/js/util/util.ts
@@ -13,7 +13,12 @@ export function countWords(str: string): number {
     if (s.length === 1 && s[0].length === 0) {
         return 0;
     }
-    return s.length;
+    // ignore punctuation characters that appear on their own, as the grammar/syntax in some languages (notably, French)
+    // dictates whitespace before some punctuation, like question/exclamation marks etc.
+    const ans = s.filter((e: string) => !e.match(/^\p{P}/gu));
+
+    // return s.length;
+    return ans.length;
 }
 
 export function getInt(s: string | number) {

--- a/timApp/modules/cs/js/util/util.ts
+++ b/timApp/modules/cs/js/util/util.ts
@@ -15,7 +15,7 @@ export function countWords(str: string): number {
     }
     // ignore punctuation characters that appear on their own, as the grammar/syntax in some languages (notably, French)
     // dictates whitespace before some punctuation, like question/exclamation marks etc.
-    const ans = s.filter((e: string) => !e.match(/^\p{P}/gu));
+    const ans = s.filter((e) => e.match(/\p{P}?\w/u));
 
     // return s.length;
     return ans.length;


### PR DESCRIPTION
Ignore solitary punctuation characters in input, since some languages' syntax dictates whitespace before e.g. exclamation/question marks etc.