### PR TITLE
Fix translation source

### DIFF
--- a/timApp/admin/translationservice_cli.py
+++ b/timApp/admin/translationservice_cli.py
@@ -17,6 +17,7 @@ from flask.cli import AppGroup
 from sqlalchemy import select
 
 from timApp.document.translation.translator import TranslationService
+from timApp.document.translation.deepl import purge_languages_cache
 from timApp.tim_app import app
 from timApp.timdb.sqa import db, run_sql
 
@@ -70,3 +71,19 @@ def add_all_tr_services_to_session(log: bool = False) -> None:
             if log:
                 click.echo(f"Adding new translation service '{service_name}'")
             db.session.add(service)
+
+
+@tr_service_cli.command()
+def purge_deepl_lang_cache(log: bool = False) -> None:
+    """
+    Purge supported languages cache.
+
+    Purge supported LanguagePairings cache for DeeplTranslationService,
+    so that it will be refreshed as soon as supported languages are checked.
+
+    :return: None.
+    """
+    purge_languages_cache()
+
+    if log:
+        click.echo(f"Purged cache for supported languages in DeeplTranslationService")

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -383,7 +383,7 @@ VERIFICATION_REACTED_CLEANUP_INTERVAL = 30 * 24 * 60 * 60
 # Database entries for languages are created when TIM is started/re-started.
 # Pre-existing entries are skipped.
 # Default list includes languages supported by the translation service
-# DeepL: https://https://www.deepl.com/docs-api/translating-text/
+# DeepL: https://www.deepl.com/docs-api/translating-text/
 # Custom language syntax is the following:
 # {
 #   "lang_code": "<standardized tag>",
@@ -401,6 +401,7 @@ LANGUAGES = [
     "American English",
     "British English",
     "Spanish",
+    "English",
     "Estonian",
     "Finnish",
     "French",

--- a/timApp/document/translation/deepl.py
+++ b/timApp/document/translation/deepl.py
@@ -516,3 +516,12 @@ class DeeplProTranslationService(DeeplTranslationService):
 
     # TODO Make the value an enum like with Verification?
     __mapper_args__ = {"polymorphic_identity": "DeepL Pro"}
+
+
+def purge_languages_cache() -> None:
+    """
+    Purges the cached LanguagePairings from the DeeplTranslationService.
+    Mostly needed when new languages are added, but the cache has not refreshed yet.
+    :return: None
+    """
+    cache.delete_memoized(DeeplTranslationService.languages)

--- a/timApp/document/translation/routes.py
+++ b/timApp/document/translation/routes.py
@@ -102,7 +102,10 @@ def translate_full_document(
     source_paragraphs = list(
         filter(
             lambda x: not x.is_setting(),
-            tr.document.get_source_document().get_paragraphs(),
+            # tr.document.get_source_document().get_paragraphs(),
+            # Instead of fetching the original document's pars,
+            # get the pars from the document specified by src_doc parameter
+            src_doc.get_paragraphs(),
         ),
     )
 

--- a/timApp/document/translation/routes.py
+++ b/timApp/document/translation/routes.py
@@ -238,7 +238,13 @@ def create_translation_route(
 
     # Run automatic translation if requested
     if translator != "Manual":
-        translate_full_document(tr, src_doc, language, translator)
+        # If src_doc id does not match tr_doc_id, the translation process was initiated
+        # from an existing translation. We should use that translation as the basis
+        # for the new one, instead of forcing the source to be the original document.
+        if tr_doc_id != src_doc.doc_id:
+            translate_full_document(tr, doc.document, language, translator)
+        else:
+            translate_full_document(tr, src_doc, language, translator)
 
     # Copy source document search relevance value to translation
     set_relevance(tr.id, get_document_relevance(doc))

--- a/timApp/document/translation/translator.py
+++ b/timApp/document/translation/translator.py
@@ -184,6 +184,8 @@ class TranslationService(db.Model):
             if lang_code in ["pt-BR", "pt-PT"]:
                 return "pt"
 
+        return lang_code
+
     # Polymorphism allows querying multiple objects by their class e.g.
     # `TranslationService.query`.
     __mapper_args__ = {"polymorphic_on": "service_name"}

--- a/timApp/document/translation/translator.py
+++ b/timApp/document/translation/translator.py
@@ -166,6 +166,24 @@ class TranslationService(db.Model):
         """
         raise NotImplementedError
 
+    def ensure_compatible_source_lang_variant(self, lang_code: str) -> str:
+        """
+        Return compatible source language code for this translation service.
+        This is a workaround for translation services that do not accept certain
+        language variants as the source (such as en-GB, en-US, etc.).
+        :param lang_code: Language code to check and possibly modify
+        :return: compatible language code
+        """
+        # TODO fetch up-to-date supported source languages from DeepL API, and
+        #      do the conversion on the fly instead of hard-coded values
+        if "DeepL" in self.service_name:
+            # Variants for English
+            if lang_code in ["en-GB", "en-US"]:
+                return "en"
+            # Variants for Portuguese
+            if lang_code in ["pt-BR", "pt-PT"]:
+                return "pt"
+
     # Polymorphism allows querying multiple objects by their class e.g.
     # `TranslationService.query`.
     __mapper_args__ = {"polymorphic_on": "service_name"}
@@ -293,7 +311,8 @@ class TranslateProcessor:
         ):
             translator.register(user_group)
 
-        source_lang_ = Language.query_by_code(s_lang)
+        source_language = translator.ensure_compatible_source_lang_variant(s_lang)
+        source_lang_ = Language.query_by_code(source_language)
         target_lang_ = Language.query_by_code(t_lang)
 
         if not translator.supports(source_lang_, target_lang_):

--- a/timApp/tests/server/timroutetest.py
+++ b/timApp/tests/server/timroutetest.py
@@ -145,7 +145,8 @@ class TimRouteTestBase(TimDbTest):
         with app.app_context():
             # Default language on create_translation NOTE not same as british or
             # american english.
-            cls.add_language("english")
+            # NOTE: going forward, generic English will be added automatically via the config list LANGUAGES
+            # cls.add_language("english")
             db.session.commit()
             db.session.expire_all()
 


### PR DESCRIPTION
Fixes an issue with translation source document always being the original 'parent' document, even when initiating the translation process from an existing translation.
Translation source will now be the currently open document, when creating a new translation from its Manage-page. Paragraph references will still point to the original.

TODO
<s>- [ ] Reference paragraph ids when matching paragraphs to enable partial translations (when creating a new translation from an existing, partial translation, for example)</s> (Move to its own PR/issue, if this does not turn out to be critical)
- [x] Make certain language variants use the generic language code, since variants are generally not accepted as source languages by DeepL. For example, ('en-GB', 'en-US') -> 'en'.


After merging, run the following:

1. `./tim run flask language update`
2. `./tim run flask trservice purge-deepl-lang-cache`

The latter clears the memoized cache for supported language pairings, since the timeout for it is fairly long normally.