### PR TITLE
jsrunner: Add gtools.sendGradesToSisu

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -974,6 +974,7 @@ def post_answer_impl(
             pr_data=pr_data,
             overwrite_opts=overwrite_opts,
             view_ctx=view_ctx,
+            saver_plugin=plugin,
         )
 
         # TODO: Could report the result to other plugins too.

--- a/timApp/modules/jsrunner/server/routes/answer.ts
+++ b/timApp/modules/jsrunner/server/routes/answer.ts
@@ -23,7 +23,12 @@ import type {
 } from "../servertypes";
 import {JsrunnerAnswer} from "../servertypes";
 import {ivmRequest} from "../util/request";
-import type {IToolsResult, NewUserData, ToolsBase} from "./tools";
+import type {
+    IToolsResult,
+    NewUserData,
+    SendGradesToSisuData,
+    ToolsBase,
+} from "./tools";
 import {GTools, numberLines, Tools} from "./tools";
 
 console.log("answer");
@@ -70,6 +75,7 @@ type RunnerResult =
           itemRightActions: IItemRightActionData[];
           newUsers: NewUserData[];
           mailToSend: IMailSendData[];
+          sendSisuAssessments?: SendGradesToSisuData;
       }
     | {output: string; fatalError: IError; errorprg: string};
 
@@ -219,6 +225,7 @@ function runner(d: IRunnerData): RunnerResult {
             itemRightActions: gtools.itemRightActions,
             newUsers: gtools.newUsers,
             mailToSend: gtools.mailToSend,
+            sendSisuAssessments: gtools.sendToSisu,
         };
     } catch (e) {
         const err = e as Error;
@@ -341,6 +348,7 @@ router.put("/", async (req, res, next) => {
                 itemRightActions: result.itemRightActions,
                 newUsers: result.newUsers,
                 mailToSend: result.mailToSend,
+                sendSisuAssessments: result.sendSisuAssessments,
                 web: {
                     output: result.output,
                     errors: result.errors,

--- a/timApp/modules/jsrunner/shared/jsrunnertypes.ts
+++ b/timApp/modules/jsrunner/shared/jsrunnertypes.ts
@@ -9,6 +9,7 @@ import type {
     ItemRightActionT,
     IToolsResult,
     NewUserData,
+    SendGradesToSisuData,
 } from "../server/routes/tools";
 
 export {IncludeUsersOption} from "tim/plugin/attributes";
@@ -41,6 +42,8 @@ export const JsrunnerMarkup = t.intersection([
         confirmText: t.string,
         nextRunner: t.string,
         timeZoneDiff: t.number,
+        destCourse: t.string,
+        destCourseName: t.string,
     }),
     GenericPluginMarkup,
     t.type({
@@ -111,6 +114,7 @@ interface AnswerReturnSuccess {
     itemRightActions: IItemRightActionData[];
     newUsers: NewUserData[];
     mailToSend: IMailSendData[];
+    sendSisuAssessments?: SendGradesToSisuData;
 }
 
 interface AnswerReturnError {

--- a/timApp/plugin/jsrunner/jsrunner.py
+++ b/timApp/plugin/jsrunner/jsrunner.py
@@ -79,6 +79,8 @@ class JsRunnerMarkupModel(GenericMarkupModel):
     nextRunner: str | Missing = missing
     timeZoneDiff: int | Missing = missing
     peerReview: bool | Missing = missing
+    destCourse: str | Missing = missing
+    destCourseName: str | Missing = missing
 
     @validates_schema(skip_on_field_errors=True)
     def validate_schema(self, data: dict, **_: dict) -> None:


### PR DESCRIPTION
Testi: <https://timdevs02.it.jyu.fi/view/users/dezhidki/test-s2s-jsrunner> (testaa omalla tuotannon admin-tunnuksella)

Adds a JSRunner function `gtools.sendGradesToSisu(opts)` function. When called, the function triggers sending students' grades to Sisu after the script finishes executing.

To send grades to Sisu, the following must apply:
  - destCourse must be set in the JSRunner's markup
  - The student must have a value in the `grade` (course grade) field.
  - The student must have a value in the `credit` (course credits) field.
  - The student must have a value in the `completionDate` (course completion date) field.

By default, grades for all students specified in the `group` markup field will be sent to Sisu. If `group` is the wildcard "*", then the `group` option in the document settings will be used. The `users` option can be used to specify the specific users for which to send grades. Default fields used by Sisu Assessments API (`sentGrade`, `sentCredits`) can be used to determine if the assessment has already been sent.

The function also supports sending automated emails when the grades have been sent to Sisu.