### PR TITLE
CLI: Add cli command to init babel translation catalogs

### DIFF
--- a/cli/commands/i18n/extract.py
+++ b/cli/commands/i18n/extract.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser
-from typing import List
+from subprocess import CompletedProcess
+from typing import List, Optional
 
 from cli.docker.run import run_compose
 from cli.npm.run import run_npm
@@ -14,8 +15,10 @@ class Arguments:
     pass
 
 
-def run_pybabel(cmds: List[str]) -> None:
-    run_compose(
+def run_pybabel(
+    cmds: List[str], capture_output: Optional[bool] = None
+) -> CompletedProcess:
+    return run_compose(
         [
             "run",
             "--rm",
@@ -25,7 +28,8 @@ def run_pybabel(cmds: List[str]) -> None:
             "tim",
             "pybabel",
             *cmds,
-        ]
+        ],
+        capture_output=capture_output if capture_output else None,
     )
 
 

--- a/cli/commands/i18n/init_lang.py
+++ b/cli/commands/i18n/init_lang.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 
 from cli.commands.i18n.extract import run_pybabel
 from cli.docker.run import run_compose
+from cli.util.errors import CLIError
 from cli.util.logging import log_info
 
 info = {
@@ -20,30 +21,21 @@ def init_catalog(lang: str) -> None:
 
 def run(args: Arguments) -> None:
     if not args.language:
-        log_info("No language specified.")
         log_info("Please provide a CLDR compliant language code.")
         log_info(
             "See https://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code for details."
         )
-        return
+        raise CLIError(f"No language specified.")
 
     if not check_locale(args.language):
-        log_info(f"Unknown language code: {args.language}")
-        return
+        raise CLIError(f"Unknown language code: {args.language}")
 
     init_catalog(args.language)
 
 
 def check_locale(lang: str) -> bool:
-    locales = run_compose(
+    locales = run_pybabel(
         [
-            "run",
-            "--rm",
-            "--workdir",
-            "/service/timApp",
-            "--no-deps",
-            "tim",
-            "pybabel",
             "--list-locales",
         ],
         capture_output=True,

--- a/cli/commands/i18n/init_lang.py
+++ b/cli/commands/i18n/init_lang.py
@@ -1,0 +1,60 @@
+from argparse import ArgumentParser
+
+from cli.commands.i18n.extract import run_pybabel
+from cli.docker.run import run_compose
+from cli.util.logging import log_info
+
+info = {
+    "help": "Initialize a new translation catalog for server messages",
+}
+
+
+class Arguments:
+    language: str
+
+
+def init_catalog(lang: str) -> None:
+    log_info("Initializing translation catalog")
+    run_pybabel(["init", "-i", "messages.pot", "-d", "i18n", "-l", f"{lang}"])
+
+
+def run(args: Arguments) -> None:
+    if not args.language:
+        log_info("No language specified.")
+        log_info("Please provide a CLDR compliant language code.")
+        log_info(
+            "See https://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code for details."
+        )
+        return
+
+    if not check_locale(args.language):
+        log_info(f"Unknown language code: {args.language}")
+        return
+
+    init_catalog(args.language)
+
+
+def check_locale(lang: str) -> bool:
+    locales = run_compose(
+        [
+            "run",
+            "--rm",
+            "--workdir",
+            "/service/timApp",
+            "--no-deps",
+            "tim",
+            "pybabel",
+            "--list-locales",
+        ],
+        capture_output=True,
+    ).stdout.decode("utf-8")
+    codes = list(map(lambda x: x.partition(" ")[0], locales.splitlines()))
+    return lang in codes
+
+
+def init(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "language",
+        help="The language for which to initialize a new translation catalog.",
+        nargs="?",
+    )

--- a/cli/docker/run.py
+++ b/cli/docker/run.py
@@ -80,12 +80,13 @@ def run_compose(
     with_compose_file: bool = True,
     override_profile: bool = True,
     extra_env: Optional[Dict[str, str]] = None,
+    capture_output: Optional[bool] = False,
 ) -> subprocess.CompletedProcess:
     compose_args = get_compose_cmd(args, profile, with_compose_file, override_profile)
     env = dict(os.environ)
     if extra_env:
         env.update(extra_env)
-    return run_cmd(compose_args, env=env)
+    return run_cmd(compose_args, capture_output=capture_output, env=env)
 
 
 def run_docker(args: List[str], **kwargs: Any) -> subprocess.CompletedProcess:

--- a/cli/docker/run.py
+++ b/cli/docker/run.py
@@ -80,7 +80,7 @@ def run_compose(
     with_compose_file: bool = True,
     override_profile: bool = True,
     extra_env: Optional[Dict[str, str]] = None,
-    capture_output: Optional[bool] = False,
+    capture_output: Optional[bool] = None,
 ) -> subprocess.CompletedProcess:
     compose_args = get_compose_cmd(args, profile, with_compose_file, override_profile)
     env = dict(os.environ)

--- a/cli/util/proc.py
+++ b/cli/util/proc.py
@@ -1,6 +1,6 @@
 import shlex
 import subprocess
-from typing import Any, List
+from typing import Any, List, Optional
 
 from cli.util.logging import log_debug
 
@@ -11,7 +11,15 @@ def sh_join(split_command: List[str]) -> str:
 
 
 def run_cmd(
-    args: List[str], check: bool = True, capture_output: bool = False, **kwargs: Any
+    args: List[str],
+    check: bool = True,
+    capture_output: Optional[bool] = None,
+    **kwargs: Any,
 ) -> subprocess.CompletedProcess:
     log_debug(f"cmd: {sh_join(args)}")
-    return subprocess.run(args, check=check, capture_output=capture_output, **kwargs)
+    return subprocess.run(
+        args,
+        check=check,
+        capture_output=capture_output if capture_output else False,
+        **kwargs,
+    )

--- a/cli/util/proc.py
+++ b/cli/util/proc.py
@@ -11,7 +11,7 @@ def sh_join(split_command: List[str]) -> str:
 
 
 def run_cmd(
-    args: List[str], check: bool = True, **kwargs: Any
+    args: List[str], check: bool = True, capture_output: bool = False, **kwargs: Any
 ) -> subprocess.CompletedProcess:
     log_debug(f"cmd: {sh_join(args)}")
-    return subprocess.run(args, check=check, **kwargs)
+    return subprocess.run(args, check=check, capture_output=capture_output, **kwargs)


### PR DESCRIPTION
Lisää CLI-komennon, jonka avulla on helpompi alustaa Babelin käännöskatalogi uusille kielille.

Käyttö: `./tim i18n init-lang <kielikoodi>`


Kielikoodi annettava Babelin tukemassa muodossa (ISO 639-3 ja BCP 47, kts. https://cldr.unicode.org/index/cldr-spec/picking-the-right-language-code).