### PR TITLE
Add optional arguments for translation sessions

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -465,6 +465,21 @@ MACHINE_TRANSLATORS = [
     # ),
 ]
 
+# FuturesSession options for machine translators,
+# used to control the number of parallel translation requests,
+# and how many times a failed request will be re-sent
+TRANSLATION_SESSION_OPTIONS = {
+    "DeepL Free": {
+        "max_workers": 4,
+        "max_retries": 4,
+    },
+    "DeepL Pro": {
+        "max_workers": 4,
+        "max_retries": 4,
+    },
+}
+
+
 # Options related to session management
 
 SESSIONS_ENABLE = False

--- a/timApp/document/translation/deepl.py
+++ b/timApp/document/translation/deepl.py
@@ -321,8 +321,8 @@ class DeeplTranslationService(RegisteredTranslationService):
         source_lang: Language | None,
         target_lang: Language,
         tag_handling: str = "xml",
-        max_workers: Optional[int] = None,
-        max_retries: Optional[int] = None,
+        max_workers: int | None = None,
+        max_retries: int | None = None,
     ) -> list[str]:
         """
         Use the DeepL API to translate text between languages.

--- a/timApp/document/translation/reversingtranslator.py
+++ b/timApp/document/translation/reversingtranslator.py
@@ -51,8 +51,8 @@ class ReversingTranslationService(TranslationService):
         target_lang: Language,
         *,
         tag_handling: str = "",
-        max_workers: Optional[int] = None,
-        max_retries: Optional[int] = None,
+        max_workers: int | None = None,
+        max_retries: int | None = None,
     ) -> list[str]:
         """
         Reverse the translatable text given.

--- a/timApp/document/translation/reversingtranslator.py
+++ b/timApp/document/translation/reversingtranslator.py
@@ -13,6 +13,8 @@ __authors__ = [
 __license__ = "MIT"
 __date__ = "25.4.2022"
 
+from typing import Optional
+
 import langcodes
 
 from timApp.document.translation.language import Language
@@ -49,6 +51,8 @@ class ReversingTranslationService(TranslationService):
         target_lang: Language,
         *,
         tag_handling: str = "",
+        max_workers: Optional[int] = None,
+        max_retries: Optional[int] = None,
     ) -> list[str]:
         """
         Reverse the translatable text given.
@@ -63,6 +67,8 @@ class ReversingTranslationService(TranslationService):
         :param target_lang: Only REVERSE_LANG["lang_code"] is supported.
         :param tag_handling: tags to intelligently handle during translation
          TODO XML-handling.
+        :param max_workers: Maximum number of workers to use for sending translation requests
+        :param max_retries: Maximum number of retries on a failed translation request
         :return: Texts where translatable ones have been reversed.
         """
 

--- a/timApp/document/translation/routes.py
+++ b/timApp/document/translation/routes.py
@@ -253,6 +253,11 @@ def create_translation_route(
     # Run automatic translation if requested
     if translator != "Manual":
         session_opts = current_app.config["TRANSLATION_SESSION_OPTIONS"].get(translator)
+        mw, mr = None, None
+        if session_opts:
+            mw = session_opts.get("max_workers")
+            mr = session_opts.get("max_retries")
+
         # If src_doc id does not match tr_doc_id, the translation process was initiated
         # from an existing translation. We should use that translation as the basis
         # for the new one, instead of forcing the source to be the original document.
@@ -262,8 +267,8 @@ def create_translation_route(
                 doc.document,
                 language,
                 translator,
-                session_opts["max_workers"] if session_opts else None,
-                session_opts["max_retries"] if session_opts else None,
+                max_workers=mw,
+                max_retries=mr,
             )
         else:
             translate_full_document(
@@ -271,8 +276,8 @@ def create_translation_route(
                 src_doc,
                 language,
                 translator,
-                session_opts["max_workers"] if session_opts else None,
-                session_opts["max_retries"] if session_opts else None,
+                max_workers=mw,
+                max_retries=mr,
             )
 
     # Copy source document search relevance value to translation

--- a/timApp/document/translation/routes.py
+++ b/timApp/document/translation/routes.py
@@ -252,7 +252,7 @@ def create_translation_route(
 
     # Run automatic translation if requested
     if translator != "Manual":
-        session_opts = current_app.config["TRANSLATION_SESSION_OPTIONS"][translator]
+        session_opts = current_app.config["TRANSLATION_SESSION_OPTIONS"].get(translator)
         # If src_doc id does not match tr_doc_id, the translation process was initiated
         # from an existing translation. We should use that translation as the basis
         # for the new one, instead of forcing the source to be the original document.
@@ -262,8 +262,8 @@ def create_translation_route(
                 doc.document,
                 language,
                 translator,
-                session_opts["max_workers"],
-                session_opts["max_retries"],
+                session_opts["max_workers"] if session_opts else None,
+                session_opts["max_retries"] if session_opts else None,
             )
         else:
             translate_full_document(
@@ -271,8 +271,8 @@ def create_translation_route(
                 src_doc,
                 language,
                 translator,
-                session_opts["max_workers"],
-                session_opts["max_retries"],
+                session_opts["max_workers"] if session_opts else None,
+                session_opts["max_retries"] if session_opts else None,
             )
 
     # Copy source document search relevance value to translation

--- a/timApp/document/translation/routes.py
+++ b/timApp/document/translation/routes.py
@@ -78,8 +78,8 @@ def translate_full_document(
     src_doc: Document,
     target_language: Language,
     translator_code: str,
-    max_workers: Optional[int] = None,
-    max_retries: Optional[int] = None,
+    max_workers: int | None = None,
+    max_retries: int | None = None,
 ) -> None:
     """
     Translate matching paragraphs of document based on an original source

--- a/timApp/document/translation/translator.py
+++ b/timApp/document/translation/translator.py
@@ -89,6 +89,8 @@ class TranslationService(db.Model):
         target_lang: Language,
         *,
         tag_handling: str = "",
+        max_workers: Optional[int] = None,
+        max_retries: Optional[int] = None,
     ) -> list[str]:
         """
         Translate texts from source to target language.
@@ -105,6 +107,8 @@ class TranslationService(db.Model):
         :param tag_handling: Tag representing a way to separate or otherwise
          control translated text with the translation service. A HACKY way to
          handle special case with translating (html) tables.
+        :param max_workers: Maximum number of workers to use for sending translation requests
+        :param max_retries: Maximum number of retries on a failed translation request
         :return: List of strings found inside the items of `texts`-parameter,
          in the same order and translated.
         """
@@ -284,6 +288,8 @@ class TranslateProcessor:
         s_lang: str,
         t_lang: str,
         user_group: UserGroup | None,
+        max_workers: Optional[int] = None,
+        max_retries: Optional[int] = None,
     ):
         """
         Based on a name, get the correct TranslationService from database and
@@ -296,6 +302,8 @@ class TranslateProcessor:
         :param user_group: Identification of user, that can be allowed to use
          some TranslationServices (for example DeepL requires an API-key that
          the user sets to their account).
+        :param max_workers: Maximum number of workers to use for sending translation requests
+        :param max_retries: Maximum number of retries on a failed translation request
         """
 
         translator = (
@@ -326,6 +334,8 @@ class TranslateProcessor:
         self.parser = TranslationParser()
         self.source_lang = source_lang_
         self.target_lang = target_lang_
+        self.max_workers = max_workers
+        self.max_retries = max_retries
 
     def _translate_raw_texts(self, mds: list[str]) -> list[str]:
         """

--- a/timApp/document/translation/translator.py
+++ b/timApp/document/translation/translator.py
@@ -288,8 +288,8 @@ class TranslateProcessor:
         s_lang: str,
         t_lang: str,
         user_group: UserGroup | None,
-        max_workers: Optional[int] = None,
-        max_retries: Optional[int] = None,
+        max_workers: int | None = None,
+        max_retries: int | None = None,
     ):
         """
         Based on a name, get the correct TranslationService from database and

--- a/timApp/document/translation/translator.py
+++ b/timApp/document/translation/translator.py
@@ -89,8 +89,8 @@ class TranslationService(db.Model):
         target_lang: Language,
         *,
         tag_handling: str = "",
-        max_workers: Optional[int] = None,
-        max_retries: Optional[int] = None,
+        max_workers: int | None = None,
+        max_retries: int | None = None,
     ) -> list[str]:
         """
         Translate texts from source to target language.

--- a/tim_common/vendor/requests_futures.py
+++ b/tim_common/vendor/requests_futures.py
@@ -49,12 +49,15 @@ PICKLE_ERROR = (
     "github.com/ross/requests-futures/#using-processpoolexecutor"
 )
 
+DEFAULT_MAX_WORKERS = 8
+DEFAULT_MAX_RETRIES = 3
+
 
 class FuturesSession(Session):
     def __init__(
         self,
         executor=None,
-        max_workers=8,
+        max_workers=DEFAULT_MAX_WORKERS,
         session_factory=Session,
         adapter_kwargs=None,
         *args,

--- a/tim_common/vendor/requests_futures.py
+++ b/tim_common/vendor/requests_futures.py
@@ -50,7 +50,6 @@ PICKLE_ERROR = (
 )
 
 DEFAULT_MAX_WORKERS = 8
-DEFAULT_MAX_RETRIES = 3
 
 
 class FuturesSession(Session):


### PR DESCRIPTION
Alleviates translation errors resulting from too many requests being sent to the translation service url.

Adds optional arguments `max_workers` and `max_retries` that are passed to the FuturesSession objects performing the translation requests. Both can be controlled in `defaultconfig.py` via the variable `TRANSLATION_SESSION_OPTIONS`.

`max_workers` defaults to 8 (FuturesSession default, moved to `requests_futures.DEFAULT_MAX_WORKERS`) if not set.
`max_retries` defaults to `requests.adapter.DEFAULT_RETRIES`, which should be 0.

Current proposed default is 4 for both, which is set in `defaultconfig.py` by this PR.