### PR TITLE
Inline comment block shortcut

### DIFF
--- a/timApp/static/scripts/tim/editor/AceParEditor.ts
+++ b/timApp/static/scripts/tim/editor/AceParEditor.ts
@@ -218,8 +218,8 @@ export class AceParEditor extends BaseParEditor implements IEditor {
         this.editor.commands.addCommand({
             name: "commentBlock",
             bindKey: {
-                win: "Ctrl-Y",
-                mac: "Command-Y",
+                win: "Ctrl-Shift-K",
+                mac: "Ctrl-Shift-K",
             },
             exec: () => {
                 this.commentClicked();


### PR DESCRIPTION
Closes #3560

Modifies the custom keymapping for inline comment block `{!!! !!!}`
from `CTRL+Y`/`CMD+Y` to `CTRL+SHIFT+K` to avoid conflicts with
[Windows](https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec), [macOS](https://support.apple.com/en-us/HT201236) and [ACE editor default](https://github.com/ajaxorg/ace/wiki/Default-Keyboard-Shortcuts) keyboard shortcuts.

The new shortcut only conflicts with ACE's mapping for the 'Find previous' search function, which does not seem very essential given that it is also provided in the editor's search UI.