### PR TITLE
Add sort options for sorting by answer submit date

### DIFF
--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -243,6 +243,8 @@ class NameOptions(Enum):
 class SortOptions(Enum):
     USERNAME = "username"
     TASK = "task"
+    DATE_ASCENDING = "date"
+    DATE_DESCENDING = "date_desc"
 
 
 class FormatOptions(Enum):
@@ -352,6 +354,11 @@ def get_all_answers(
             stmt = stmt.order_by(User.name, Answer.task_id, Answer.answered_on)
         case SortOptions.TASK:
             stmt = stmt.order_by(Answer.task_id, User.name, Answer.answered_on)
+        case SortOptions.DATE_ASCENDING:
+            stmt = stmt.order_by(Answer.answered_on, Answer.task_id, User.name)
+        case SortOptions.DATE_DESCENDING:
+            stmt = stmt.order_by(Answer.answered_on.desc(), Answer.task_id, User.name)
+
     stmt = stmt.with_only_columns(Answer, User, sub_stmt.c.count)
     result = []
     result_json = []

--- a/timApp/answer/answers.py
+++ b/timApp/answer/answers.py
@@ -33,8 +33,9 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.orm import defaultload, selectinload, contains_eager
+from sqlalchemy.orm.base import Mapped
 from sqlalchemy.sql import Select, Subquery
-from sqlalchemy.sql.elements import OperatorExpression
+from sqlalchemy.sql.elements import OperatorExpression, UnaryExpression
 
 from timApp.answer.answer import Answer
 from timApp.answer.answer_models import AnswerTag, UserAnswer
@@ -272,7 +273,7 @@ class AllAnswersOptions(AnswerPeriodOptions):
         default=ValidityOptions.VALID, metadata={"by_value": True}
     )
     name: NameOptions = field(default=NameOptions.BOTH, metadata={"by_value": True})
-    sort: str = field(default=SORT_OPTIONS_DEFAULT, metadata={"by_value": True})
+    sort: str = field(default=SORT_OPTIONS_DEFAULT)
     format: FormatOptions = field(
         default=FormatOptions.TEXT, metadata={"by_value": True}
     )
@@ -352,8 +353,6 @@ def get_all_answers(
         .join(User, Answer.users)
     )
     stmt = stmt.outerjoin(PluginType).options(contains_eager(Answer.plugin_type))
-    from sqlalchemy.sql.elements import UnaryExpression
-    from sqlalchemy.orm.base import Mapped
 
     sort_priority: list[Mapped[str] | Mapped[datetime] | UnaryExpression] = []
     for s_key in options.sort.split("-"):

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -5232,30 +5232,6 @@
           <context context-type="linenumber">168</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7699622144571229146" datatype="html">
-        <source>Sort by</source>
-        <target state="translated">Lajitteluperuste</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">175</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3309915655225296659" datatype="html">
-        <source>Task, then username</source>
-        <target state="translated">Ensin tehtävä, sitten nimi</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">181</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2384777388145535848" datatype="html">
-        <source>Username, then task</source>
-        <target state="translated">Ensin nimi, sitten tehtävä</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">187</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="7049887240439736400" datatype="html">
         <source>Print</source>
         <target state="translated">Tulosta</target>
@@ -9006,6 +8982,30 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/answer/answer-browser.component.ts</context>
           <context context-type="linenumber">1792</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5226253559895463240" datatype="html">
+        <source>Date (oldest first)</source>
+        <target state="translated">Tallennusaika (vanhin ensin)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">54,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6686635921104768748" datatype="html">
+        <source>Date (newest first)</source>
+        <target state="translated">Tallennusaika (uusin ensin)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">55,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7786524874819296811" datatype="html">
+        <source>Sort answers by</source>
+        <target state="translated">Järjestä vastaukset</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">280,281</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -414,30 +414,6 @@
           <context context-type="linenumber">186</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7699622144571229146" datatype="html">
-        <source>Sort by</source>
-        <target state="translated">Sortera efter</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">193</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3309915655225296659" datatype="html">
-        <source>Task, then username</source>
-        <target state="translated">Uppgift, sedan användarnamn</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">199</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2384777388145535848" datatype="html">
-        <source>Username, then task</source>
-        <target state="translated">Användarnamn, sedan uppgift</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
-          <context context-type="linenumber">205</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="7049887240439736400" datatype="html">
         <source>Print</source>
         <target state="translated">Skriva ut</target>
@@ -8908,6 +8884,30 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/answer/answer-browser.component.ts</context>
           <context context-type="linenumber">1792</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5226253559895463240" datatype="html">
+        <source>Date (oldest first)</source>
+        <target state="translated">Datum (äldsta först)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">54,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6686635921104768748" datatype="html">
+        <source>Date (newest first)</source>
+        <target state="translated">Datum (nyast först)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">55,51</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7786524874819296811" datatype="html">
+        <source>Sort answers by</source>
+        <target state="translated">Sortera svaren efter</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/answer/all-answers-dialog.component.ts</context>
+          <context context-type="linenumber">280,281</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/static/scripts/tim/answer/all-answers-dialog.component.scss
+++ b/timApp/static/scripts/tim/answer/all-answers-dialog.component.scss
@@ -10,3 +10,19 @@
 .pseudonym-input {
   margin-top: 0.5em;
 }
+
+.margin-bottom-4 {
+  margin-bottom: 4px;
+}
+
+.padding-top-0 {
+  padding-top: 0;
+}
+
+.padding-top-7 {
+  padding-top: 7px;
+}
+
+.fit-width {
+  width: fit-content;
+}

--- a/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
+++ b/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
@@ -14,7 +14,6 @@ import {documentglobals} from "tim/util/globals";
 import {$httpParamSerializer} from "tim/util/ngimport";
 import {TimStorage, toPromise} from "tim/util/utils";
 import {CommonModule} from "@angular/common";
-import {$localize} from "@angular/localize/init";
 
 const AnswersDialogOptions = t.intersection([
     t.type({
@@ -362,7 +361,6 @@ export class AllAnswersDialogComponent extends AngularDialogComponent<
     void
 > {
     protected dialogName = "AllAnswers";
-    // showSort: boolean = true;
     options!: IOptions;
     private storage = new TimStorage("allAnswersOptions", AnswersDialogOptions);
     lastFetch?: ReadonlyMoment;
@@ -388,7 +386,6 @@ export class AllAnswersDialogComponent extends AngularDialogComponent<
 
     ngOnInit() {
         const options = this.data;
-        // this.showSort = options.allTasks;
         this.activeGroups = documentglobals().groups;
 
         const defs = {

--- a/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
+++ b/timApp/static/scripts/tim/answer/all-answers-dialog.component.ts
@@ -395,7 +395,7 @@ export class AllAnswersDialogComponent extends AngularDialogComponent<
             age: "max",
             valid: "1",
             name: "both",
-            sort: "task-username-date",
+            sort: "username-task-date",
             periodFrom: undefined,
             periodTo: undefined,
             consent: "any",

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -697,12 +697,12 @@ type: upload
 \[true, false, false\]
 
 ----------------------------------------------------------------------------------
-{'Test user 2'}; {'testuser2'}; None; {re.escape(task_id)}; mmcq; {date_re}; 1; 2\.0
-\[true, true, true\]
-
-----------------------------------------------------------------------------------
 {TEST_USER_1_NAME}; {'testuser1'}; None; {re.escape(task_id2)}; mmcq; {date_re}; 1; 1\.0
 \[true, false\]
+
+----------------------------------------------------------------------------------
+{'Test user 2'}; {'testuser2'}; None; {re.escape(task_id)}; mmcq; {date_re}; 1; 2\.0
+\[true, true, true\]
 
 ----------------------------------------------------------------------------------
 {'Test user 2'}; {'testuser2'}; None; {re.escape(task_id2)}; mmcq; {date_re}; 1; 2\.0
@@ -764,8 +764,8 @@ type: upload
             self.assertEqual(1, r["count"])
         expected = [
             "[true, false, false]",
-            "[true, true, true]",
             "[true, false]",
+            "[true, true, true]",
             "[false, false]",
         ]
         self.assertEqual(expected, [r["answer"]["content"] for r in res])
@@ -783,12 +783,12 @@ user_e26b0683f5dde1cc06e2e90a0f20293e9ea8d55e91e4fd5b1871513660badf4f; None; {re
 \[true, false, false\]
 
 ----------------------------------------------------------------------------------
-user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re.escape(task_id)}; mmcq; {date_re}; 1; 2\.0
-\[true, true, true\]
-
-----------------------------------------------------------------------------------
 user_e26b0683f5dde1cc06e2e90a0f20293e9ea8d55e91e4fd5b1871513660badf4f; None; {re.escape(task_id2)}; mmcq; {date_re}; 1; 1\.0
 \[true, false\]
+
+----------------------------------------------------------------------------------
+user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re.escape(task_id)}; mmcq; {date_re}; 1; 2\.0
+\[true, true, true\]
 
 ----------------------------------------------------------------------------------
 user_99934f03a2c8a14eed17b3ab3e46180b4b96a8c552768f7c7781f9003b22ca70; None; {re.escape(task_id2)}; mmcq; {date_re}; 1; 2\.0


### PR DESCRIPTION
Adds two sort options, `date` and `date_desc` to `allAnswersPlain` route. These allow sorting the fetched answers by submission time in either ascending (oldest first, `sort=date`) or descending (newest first, `sort=date_desc`) order.

Enables answer sorting for single tasks in the UI and changes the sort priority selection to a dropdown to better accommodate the larger number of sorting options.