### PR TITLE
quantum: add stem classes

### DIFF
--- a/timApp/plugin/quantum_circuit/quantumCircuit.py
+++ b/timApp/plugin/quantum_circuit/quantumCircuit.py
@@ -272,7 +272,7 @@ def render_static_quantum_circuit(m: QuantumCircuitHtmlModel) -> str:
             </div>
             <div class="panel-body">
                 {% if stem %}
-                    <p>{{ stem }}</p>
+                    <p class="stem">{{ stem }}</p>
                 {% endif %}
 
                 <p class="alert alert-info">{{message}}</p>                

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
@@ -297,7 +297,7 @@ export interface CircuitOptions {
             <tim-plugin-header *ngIf="header" header>
                 <span [innerHTML]="header | purify"></span>
             </tim-plugin-header>
-            <p stem *ngIf="stem" [innerHTML]="stem | purify"></p>
+            <p stem class="stem" *ngIf="stem" [innerHTML]="stem | purify"></p>
             <ng-container body>
                 <div #qcContainer class="circuit-container" (window:resize)="handleResize()">
                     <div class="top-menu">


### PR DESCRIPTION
Latex lazynä ladattuna menee pluginin ulkopuolelle niin lisätään luokka ja sitten voi kurssin css:ssä siistiä sen.

![clip](https://github.com/TIM-JYU/TIM/assets/59937841/3f71a10c-7160-4ad4-a53e-c292cd0ba093)


math_type: svg
css: |!!
    .panel-body .stem {
        word-break: break-word;
        max-height: 50px;
        overflow-y: hidden;
    }
!!

``````
``` {#tehtava1 plugin="quantumCircuit" .tehtava}
header: "Tehtävä"
stem: |!!
md: Tee sellainen piiri, joka vastaa matriisimerkintää $(I \otimes B)(A\otimes C)$.
!!
nQubits: 3
nMoments: 4
simulate: browser
lazy: true
```
``````


