### PR TITLE
AnswerBrowser: Don't overwrite unsaved states on network errors

### DIFF
--- a/timApp/modules/drag/client/drag.ts
+++ b/timApp/modules/drag/client/drag.ts
@@ -149,6 +149,8 @@ export class DragComponent
     trash?: boolean;
     saveButton?: boolean;
     wordObjs: WordObject[] = [];
+    changes = false;
+    initialWords: string[] = [];
     type: string = " ";
     max!: number;
     copy?: string;
@@ -214,6 +216,7 @@ export class DragComponent
         if (this.attrsall.state?.styles && !this.markup.ignorestyles) {
             this.styles = parseStyles(this.attrsall.state.styles);
         }
+        this.initialWords = this.getContentArray();
     }
 
     ngOnDestroy() {
@@ -294,6 +297,8 @@ export class DragComponent
         } else {
             this.createWordobjs(words);
         }
+        this.initialWords = this.getContentArray();
+        this.changes = false;
     }
 
     resetField(): undefined {
@@ -304,6 +309,7 @@ export class DragComponent
 
     handleMove(index: number) {
         this.wordObjs.splice(index, 1);
+        this.changes = true;
         if (this.markup.autoSave && !this.trash) {
             void this.save();
         }
@@ -313,6 +319,7 @@ export class DragComponent
         const taskId = this.pluginMeta.getTaskId()?.docTask();
         const word = event.data as WordObject;
         this.wordObjs.splice(event.index ?? 0, 0, word);
+        this.changes = true;
         if (
             this.markup.autoSave &&
             !this.trash &&
@@ -353,6 +360,8 @@ export class DragComponent
             if (this.markup.clearstyles) {
                 this.styles = {};
             }
+            this.changes = false;
+            this.initialWords = this.getContentArray();
         } else {
             this.error =
                 r.result.error.error ??
@@ -364,7 +373,7 @@ export class DragComponent
     }
 
     isUnSaved() {
-        return false; // TODO
+        return this.changes;
     }
 }
 

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -1286,7 +1286,7 @@ export class ViewCtrl implements IController {
             );
         }
         for (const ab of regularAbMap.values()) {
-            ab.getAnswersAndUpdate();
+            ab.getAnswersAndUpdate(true);
             ab.loadInfo();
         }
     }

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -47,7 +47,7 @@
                             <select i18n-title class="form-control answer-select"
                                     title="List of answers"
                                     [(ngModel)]="selectedAnswer"
-                                    (ngModelChange)="changeAnswer()">
+                                    (ngModelChange)="changeAnswer(undefined,undefined, true)">
                                  <option *ngFor="let answer of filteredAnswers; let idx = index" [ngValue]="answer">{{((filteredAnswers.length - idx) + '. ' + (answer.answered_on |  date:'dd.MM.YYYY HH:mm:ss' ))}}</option>
                             </select>
                             <span class="input-group-btn">

--- a/timApp/tests/browser/browsertest.py
+++ b/timApp/tests/browser/browsertest.py
@@ -499,6 +499,17 @@ class BrowserTest(LiveServerTestCase, TimRouteTestBase):
         self.wait_until_present("pareditor")
         self.wait_until_hidden(".editor-loading")
 
+    def set_network_state(self, online: bool):
+        """
+        Blocks or allows all network activity
+        :param online: If false block everything, otherwise allow everything
+        """
+        self.drv.execute_cdp_cmd(
+            "Network.setBlockedURLs", {"urls": [] if online else ["*"]}
+        )
+        self.drv.execute_cdp_cmd("Network.enable", {})
+        pass
+
 
 def find_button_by_text(root: WebElement, text: str):
     return find_element_by_text(root, text, "button")

--- a/timApp/tests/browser/test_fields.py
+++ b/timApp/tests/browser/test_fields.py
@@ -134,8 +134,7 @@ copy: target
             self.wait_until_hidden(f"#{task} .alertFrame")
             self.wait_until_hidden(f"#{task} bs-tooltip-container")
 
-        self.drv.execute_cdp_cmd("Network.setBlockedURLs", {"urls": ["*"]})
-        self.drv.execute_cdp_cmd("Network.enable", {})
+        self.set_network_state(False)
 
         send_input("textfield", "Hello")
         send_input("numericfield", "400")
@@ -168,8 +167,7 @@ copy: target
         check_hover("dropdown")
         check_hover("dragtarget")
 
-        self.drv.execute_cdp_cmd("Network.setBlockedURLs", {"urls": []})
-        self.drv.execute_cdp_cmd("Network.enable", {})
+        self.set_network_state(True)
 
         answer_successfully("textfield")
         answer_successfully("numericfield")


### PR DESCRIPTION
Poistaa poikkeuksen joka heitetään jos /getAnswers-reitti epäonnistuu, mutta ei silti tyhjennä pluginin tilaa kun verkkoyhteys palaa

https://timdevs01-3.it.jyu.fi/view/csplug

Koitin aluksi tehdä tuota niin että taskInfo ladattaisiin ennen getAnswers-kutsuja, mutta käytännössä tuosta tuli paljon ongelmia muihin answerbrowserin osiin ja lopuksi joutui purkalla korjaamaan useampaa kohtaa (vrt https://github.com/TIM-JYU/TIM/compare/master...ab-no-state-clear). Tuo canSafelyChangeState-tarkistus, jota Denis käytti tuossa wip-haarassa toimii paljon yksinkertaisemmin