### PR TITLE
distribute_rights: Add relayed right distribution

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -297,6 +297,43 @@ SYNC_USER_GROUPS_RECEIVE_SECRET = None
 # }
 DIST_RIGHTS_HOSTS = {}
 
+# A description of the right distribution network.
+# The setting defines all machines that are part of the network, how they are grouped and the specific rules
+# for distributing rights
+#
+# Example:
+# {
+#     "hosts": {
+#       "host1": "https://machine1.example.com",
+#       "host2": "https://machine2.example.com",
+#       "host3": "https://machine3.example.com",
+#     },
+#     "distribution_groups": {
+#         "group1": ["host1", "host2"],
+#         "group2": ["host3"],
+#     },
+#     "distribute_targets": {
+#         "some_exam": [
+#             {
+#                 "target": "host1",
+#                 "distribute_group": "group1",
+#             },
+#             {
+#                 "target": "host3",
+#                 "distribute_group": "group2",
+#             },
+#         ],
+#     },
+# }
+DIST_RIGHTS_NETWORK = {
+    "hosts": {},
+    "distribute_groups": {},
+    "distribute_targets": {},
+}
+
+# Current host identifier in the distribution network.
+DIST_RIGHTS_HOST_ID = None
+
 # When registering a right that is going to be distributed, make sure that the given secret matches this one.
 DIST_RIGHTS_REGISTER_SECRET = None
 

--- a/timApp/plugin/userselect/userselect.py
+++ b/timApp/plugin/userselect/userselect.py
@@ -169,6 +169,7 @@ class UserSelectMarkupModel(GenericMarkupModel):
     selectOnce: bool = False
     maxMatches: int = 10
     useActionQueues: bool = False
+    synchronizedGroupActions: bool = True
     scanner: ScannerOptions = field(default_factory=ScannerOptions)
     groups: list[str] = field(default_factory=list)
     fields: list[str] = field(default_factory=list)
@@ -897,6 +898,8 @@ def needs_verify(username: str, par: GlobalParId) -> Response:
 def get_group_action_locks(
     model: UserSelectMarkupModel,
 ) -> list[filelock.BaseFileLock]:
+    if not model.synchronizedGroupActions:
+        return []
     if model.useActionQueues:
         return []
     if not model.actions:

--- a/timApp/tim_celery.py
+++ b/timApp/tim_celery.py
@@ -19,7 +19,6 @@ from sqlalchemy import delete
 from timApp.answer.routes import post_answer_impl, AnswerRouteResult
 from timApp.document.usercontext import UserContext
 from timApp.document.viewcontext import default_view_ctx
-from timApp.item.distribute_rights import UnlockOp, register_op_to_hosts
 from timApp.notification.notify import process_pending_notifications
 from timApp.plugin.containerLink import call_plugin_generic
 from timApp.plugin.exportdata import WithOutData, WithOutDataSchema
@@ -214,6 +213,9 @@ def send_unlock_op(
     email: str,
     target: list[str],
 ):
+    from timApp.item.distribute_rights import UnlockOp
+    from timApp.item.distribute_rights import register_op_to_hosts
+
     op = UnlockOp(type="unlock", email=email, timestamp=get_current_time())
     return register_op_to_hosts(op, target, is_receiving_backup=False)
 
@@ -289,3 +291,10 @@ def apply_pending_userselect_actions() -> None:
     from timApp.plugin.userselect.action_queue import apply_pending_actions_impl
 
     apply_pending_actions_impl()
+
+
+@celery.task(ignore_result=True)
+def relay_dist_rights(dist_json: str, dist_hosts: list[str]) -> None:
+    from timApp.item.distribute_rights import relay_dist_rights_impl
+
+    relay_dist_rights_impl(dist_json, dist_hosts)


### PR DESCRIPTION
(Aikatestit ja esimerkit alla)

Fixes #3423

## Description

This commit adds support for distributing rights using all available machines to improve distribution times.

The commit adds a new configuration option DIST_RIGHTS_NETWORK that allows to specify right distribution hosts and network as follows:

```py
{
    # All TIM instances that can send and receive rights
    "hosts": {
        "machine1": "https://machine1.tim.education",
        "machine2": "https://machine2.tim.education",
        "machine3": "https://machine3.tim.education",
        "machine4": "https://machine4.tim.education",
    },
    # Describes how machines are linked together. The machines in the same group
    # can relay right distribution requests between each other.
    # Ideally, each group contains machines in the same network.
    "distribute_groups": {
        # Machines 1 and 2 are in the same network, thus they can share
        # rights with each other.
        "group1": [
            "machine1",
            "machine2"
        ],
        # Machines 3 and 4 are in the same network, but in a
        # different network than group1's machines.
        "group2": [
            "machine3",
            "machine4",
        ],
    },
    # Defines the machines that will be the first to receive the rights
    # Different users can be assigned different targets to ensure that
    # the first rights will land to correct machines-
    "distribute_targets": {
        "target1": [
            # Send right to machine1 and ask it to relay the request to group1's machines
            { "target": "machine1", "distribute_group": "group1"},
            # Also send the right to machine 3 and ask it to relay the request to group2's machines
            { "target": "machine3", "distribute_group": "group2"},
        ],
    },
}
```

Further, UserSelect now supports two new options

```yml
# If set to false, actions are applied without locking
# This speeds up right setting, but it can cause consistency problems
# if actions are applied to the same user multiple times
synchronizedGroupActions: false
actions:
    distributeRight:
        # Defines the TIM field from which to check what distribute_target to send the request to
        distNetworkTargetField: "93.networkTarget"
```

## Testit

Sisäänkirjaus on testattavissa: <https://aalto10.tim.education/view/dist_right_test/skannaus/sisaan?paikka=JY&sali=maa212> (oma admin-tunnus).
Sisäänkirjauksen oikeudet voi tarkistaa: <https://aalto01.tim.education/view/dist_right_test/koe> (sama dokumentti on koneissa `aalto{01..09}` ja `korona{01..07}` ).
Testisivu on simulaatio viime vuoden tilanteesta.

Tein lisäksi simuloidun aikatestauksen käytten viime vuoden hakijamääriä sekä salijakoja.
Testausmenetelmä:

- Generoitu 1015 käyttäjätunnusta (sama kuin k23 TKT-kokeen lopullinen osallistujamäärä)
- Tunnukset on jaettu paikkakunnittain ja koneittain seuraten [vuoden 2023 jakoa](https://tim.jyu.fi/view/tim/TIMin-kehitys/valintakokeet/kevat-2023#tietotekniikan-valintakoe-tktvalintakoeyhteisty%C3%B6-ma-29.5.2023-1400-1800)
- Tunnukset on lisäksi jaettu saleittain käyttäen vuoden 2023 lopullista salijakoa
- Jokaiselle salille allokoitu "virtuaalisia valvojia" s.e. jokaista 100 hakijaa kohden on yksi sisäänkirjaava valvoja
   - Yhteensä  22 valvojaa, jotka kirjaavat hakijoita samaan aikaan sisään
- Asetelma
  - Kaikki valvojat alkavat kirjaamaan hakijoita samaan aikaan sisään noin 0-10 sekunnin sisällä -> vastaa k23 tilannetta, jossa sisäänkirjaus on aloitettu suunnilleen samaan aikaan
  - Jokaisen sisäänkirjauksen jälkeen valvoja "odottaa" 2-4 sekuntia ennen seuraavaa sisäänkirjausta -> vastaa keskimäärin k23 tilannetta, jossa yksittäinen valvoja kirjaa sisään nopeudella 2-5 s/hakija
 
Testattu kaksi kirjaustapaa:
- **kevään 2023 tapa**: "piippaus" valmistuu heti, mutta kaikki oikeudet levitetään taustalla yhdeltä koneelta
- **kevään 2024 tapa**: tämän PR:n tapa, jossa
   - hakijan nimestä ja paikkakunnasta päätellään, mihin koneeseen pitää levittää oikeus
   - "piippaus" valmistuu vasta, kun oikeus on onnistuneesti lisätty hakijan nimea ja paikkakuntaa vastaavalle pääkoneelle ja varakoneelle
   - pääkone ja varakone levittävät oikeudet muihin koneisiin taustalla

Mittaus:
- kevään 2023 tapa: otettu kellonaika, kun piippaus on aloitettu ja kellonaika, kun oikeus on levitetty loppuun
- kevään 2024 tapa: otettu kellonaika, kun piippaus aloitettu ja kellonaika, kun piippaus on valmis (= oikeus levitetty hakijan pääkoneelle ja varakoneelle)

### Tulokset

**Piippauksen kesto histogrammina**

Alla olevat histogrammit kuvaavat, kuinka kauan keskimäärin kesti yksittäiselle hakijalle saada oikeus kokeeseen.

![histo_k23](https://github.com/TIM-JYU/TIM/assets/5202606/aa6c208c-a62d-4283-954a-ce64163381d7)

![histo_k24](https://github.com/TIM-JYU/TIM/assets/5202606/9304e8eb-a497-4c07-bcae-2e7d75b74588)

Huomiot:

- kevään 2023 tavassa suurin osa pyynnöistä valmistui vasta yli 30 min päästä piippauksesta
- kevään 2024 tavassa histogrammi kertoo, kuinka kauan piippaus kestää valvojan kannalta (eli kauanko valvoja joutuu odottaa ennen seuraavaa piippausta)
  - kevään 2023 tavassa piippaus valmistuu heti (noin 400 ms), sillä oikeuden levitys käsitellään erillisessä jonossa
- kevään 2024 tavassa muutaman hakijan kohdalla piippaus kesti yli 2 sekuntia; tämä kuitenkin vaikuttaa vain yksittäistapaukselta, joka tulee suurimman ruuhkan aikana

**Levitettyjen oikeuksien lukumäärä sisäänkirjauksen aloittamiesta**

Alla olevat kuvaajat esittävät, kuinka monella hakijalle on onnistuneesti annettu oikeus siitä hetkestä, kun sisäänkirjaus aloitetaan. Kuvaaja siis kertoo, kuinka kauan kestää kirjata kaikki hakijat  sisään.

![cumul_k23](https://github.com/TIM-JYU/TIM/assets/5202606/0164396b-c438-4183-9d14-6657c55a02c4)
![cumul_k24](https://github.com/TIM-JYU/TIM/assets/5202606/33c371ce-c881-43f7-b999-603ce93e18e4)

Huomiot:

- kevään 2024 tavan kuvaaja kertoo vain, kuinka kauan kesti antaa oikeus hakijan pääkoneeseen ja varakoneeseen
  - **omien havaintojen perusteella** kaikki oikeudet levittyivät kaikkiin koneisiin lopullisesti noin 30 sekuntia viimeisen sisäänkirjauksen jälkeen
  - yllä oleva johtuu varmasti siitä, että nyt oikeuksia on levittämässä kaikki 18 konetta eikä vain 1 kone, ja että yksi kone saa vain keskimäärin 100-200 oikeutta levittäväkseen 1000 sijaan

**Kaikkiaan siis** päivitetty tapa vaikuttaa olevan varmempi ja nopeampi ylipäätään väliaikaisen eheyden hinnalla sekä suuremman piippausviiveen takia.

 



