### PR TITLE
document: Add pollDocumentViewInfo and global messages

### DIFF
--- a/timApp/document/caching.py
+++ b/timApp/document/caching.py
@@ -10,6 +10,7 @@ from timApp.document.docrenderresult import DocRenderResult
 from timApp.document.document import Document
 from timApp.document.docviewparams import DocViewParams
 from timApp.document.viewcontext import ViewRoute, ViewContext
+from timApp.user.usergroup import UserGroup
 from timApp.util.utils import dataclass_to_bytearray
 
 if TYPE_CHECKING:
@@ -144,4 +145,23 @@ def set_style_timestamp_hash(style_name: str, hash_val: str) -> None:
 
 def get_style_timestamp_hash(style_name: str) -> str | None:
     res = rclient.get(f"tim-style-hash-{style_name}")
+    return res.decode(encoding="utf-8") if res else None
+
+
+def set_user_global_message(user: "User", message: str | None) -> None:
+    if message:
+        rclient.set(f"tim-global-message-{user.id}", message)
+    else:
+        rclient.delete(f"tim-global-message-{user.id}")
+
+
+def set_usergroup_global_message(ug: UserGroup, message: str | None) -> None:
+    if message:
+        rclient.mset({f"tim-global-message-{u.id}": message for u in ug.users})
+    else:
+        rclient.delete(*[f"tim-global-message-{u.id}" for u in ug.users])
+
+
+def get_user_global_message(user: "User") -> str | None:
+    res = rclient.get(f"tim-global-message-{user.id}")
     return res.decode(encoding="utf-8") if res else None

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -9008,6 +9008,14 @@
           <context context-type="linenumber">280,281</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8983597411711235800" datatype="html">
+        <source>System message</source>
+        <target state="translated">Järjestelmäviesti</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/messaging/tim-message-view.component.ts</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -8910,6 +8910,14 @@
           <context context-type="linenumber">280,281</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="8983597411711235800" datatype="html">
+        <source>System message</source>
+        <target state="translated">Systemmeddelande</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/messaging/tim-message-view.component.ts</context>
+          <context context-type="linenumber">53</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -46,7 +46,12 @@ from timApp.auth.sessioninfo import (
     clear_session,
     set_document_lang_override,
 )
-from timApp.document.caching import check_doc_cache, set_doc_cache, refresh_doc_expire
+from timApp.document.caching import (
+    check_doc_cache,
+    set_doc_cache,
+    refresh_doc_expire,
+    get_user_global_message,
+)
 from timApp.document.create_item import (
     create_or_copy_item,
     create_citation_doc,
@@ -296,8 +301,16 @@ def doc_access_info(doc_name):
     except ItemLockedException as ile:
         view_access = ile.access
 
+    cur_user = get_current_user_object()
+    user_message = get_user_global_message(cur_user)
+
     return json_response(
-        {"can_access": can_access, "right": view_access}, date_conversion=True
+        {
+            "can_access": can_access,
+            "right": view_access,
+            "global_message": user_message,
+        },
+        date_conversion=True,
     )
 
 

--- a/timApp/static/scripts/tim/document/IDocSettings.ts
+++ b/timApp/static/scripts/tim/document/IDocSettings.ts
@@ -52,6 +52,8 @@ export interface IDocSettings {
     mdButtons?: ITemplateButton[];
     lazyAnswers?: boolean;
     parAuthorOnlyEdit?: boolean;
+    pollDocumentViewInfo?: number;
+    pollDocumentViewInfoJitter?: number;
 }
 
 export interface ISlideDocSettings extends IDocSettings {

--- a/timApp/static/scripts/tim/messaging/tim-message.component.ts
+++ b/timApp/static/scripts/tim/messaging/tim-message.component.ts
@@ -36,7 +36,7 @@ const MAX_DISPLAY_LENGTH = 210;
                     <span class="group" *ngIf="messageToGroup">, {{group}}</span>
                     -->
                 </p>
-                <p class="messageDate">
+                <p class="messageDate" *ngIf="message.created">
                     <span i18n>Sent: </span>
                     <span class="sentDate">{{messageDate}}</span>
                 </p>
@@ -65,6 +65,7 @@ const MAX_DISPLAY_LENGTH = 210;
                 </div>
                 <form class="readReceiptArea">
                     <button class="timButton btn-sm mark-as-read"
+                            *ngIf="message.can_mark_as_read"
                             (click)="markAsRead()"
                             [disabled]="!canMarkAsRead || markedAsRead" title="Marks message as read and permanently hides it" i18n-title i18n>
                         Mark as read
@@ -72,7 +73,7 @@ const MAX_DISPLAY_LENGTH = 210;
                     <span class="readReceiptLink" *ngIf="markedAsRead" i18n>
                         Read receipt can be cancelled in <a href="/view/{{message.doc_path}}">the message document</a>
                     </span>
-                    <button class="timButton hide-message" (click)="closeMessage()">
+                    <button class="timButton hide-message" (click)="closeMessage()" *ngIf="message.can_hide">
                         <ng-container *ngIf="!markedAsRead" i18n>Hide</ng-container>
                         <ng-container *ngIf="markedAsRead" i18n>Close</ng-container>
                     </button>
@@ -86,7 +87,7 @@ export class TimMessageComponent implements OnInit {
     @Input()
     message!: TimMessageData;
     errorMessage?: string;
-    @HostBinding("class.global-message") isGlobal: boolean = false;
+    @HostBinding("class.global-message") @Input() isGlobal: boolean = false;
 
     messageDate!: string;
     messageOverMaxLength: boolean = false;
@@ -185,14 +186,15 @@ export class TimMessageComponent implements OnInit {
 
     ngOnInit(): void {
         // TODO Display what group the message is related to; currently can't retrieve from database
-        this.isGlobal = this.message.doc_path.includes("/global/");
+        this.isGlobal =
+            this.isGlobal || this.message.doc_path.includes("/global/");
         if (
             this.message.message_body.length > MAX_DISPLAY_LENGTH &&
             !this.isGlobal
         ) {
             this.messageOverMaxLength = true;
             this.showFullContent = false;
-            this.shownContent = `${this.message.message_body.substr(
+            this.shownContent = `${this.message.message_body.substring(
                 0,
                 MAX_DISPLAY_LENGTH
             )}...`;

--- a/timApp/static/scripts/tim/ui/goto-link.component.ts
+++ b/timApp/static/scripts/tim/ui/goto-link.component.ts
@@ -7,12 +7,7 @@ import humanizeDuration from "humanize-duration";
 import {Users} from "tim/user/userService";
 import {HttpClient} from "@angular/common/http";
 import {vctrlInstance} from "tim/document/viewctrlinstance";
-import type {IRight} from "tim/item/access-role.service";
-
-interface IViewAccessStatus {
-    can_access: boolean;
-    right?: IRight;
-}
+import type {IDocumentViewInfoStatus} from "tim/document/viewctrl";
 
 interface GotoError {
     userMessage?: string;
@@ -126,7 +121,9 @@ export class GotoLinkComponent implements OnInit {
         ) {
             const docPath = path.substring(VIEW_PATH.length);
             const accessInfo = await toPromise(
-                this.http.get<IViewAccessStatus>(`/docViewInfo/${docPath}`)
+                this.http.get<IDocumentViewInfoStatus>(
+                    `/docViewInfo/${docPath}`
+                )
             );
             if (accessInfo.ok) {
                 return {

--- a/timApp/static/scripts/tim/ui/time-left.component.ts
+++ b/timApp/static/scripts/tim/ui/time-left.component.ts
@@ -1,10 +1,11 @@
-import type {OnChanges, SimpleChanges} from "@angular/core";
+import type {OnChanges, OnInit, SimpleChanges} from "@angular/core";
 import {Component, Input} from "@angular/core";
 import {documentglobals} from "tim/util/globals";
 import type {ITimeLeftSettings} from "tim/document/IDocSettings";
 import type {Moment} from "moment";
 import moment from "moment";
 import {showMessageDialog} from "tim/ui/showMessageDialog";
+import {vctrlInstance} from "tim/document/viewctrlinstance";
 
 const TIME_LEFT_DEFAULTS: ITimeLeftSettings = {
     sync_interval: 10 * 60,
@@ -35,7 +36,7 @@ const TIME_LEFT_DEFAULTS: ITimeLeftSettings = {
     `,
     styleUrls: ["./time-left.component.scss"],
 })
-export class TimeLeftComponent implements OnChanges {
+export class TimeLeftComponent implements OnChanges, OnInit {
     @Input() endTime?: string;
     showLowTimeMessage = true;
     isLowTime = false;
@@ -48,6 +49,20 @@ export class TimeLeftComponent implements OnChanges {
     syncInterval = this.settings.sync_interval;
     syncIntervalDeviation = this.settings.sync_interval_deviation;
     endTimeMoment?: Moment;
+
+    ngOnInit() {
+        vctrlInstance?.listen("docViewInfoUpdate", (info) => {
+            if (!info.right) {
+                return;
+            }
+            if (!info.right.accessible_to) {
+                return;
+            }
+
+            this.endTime = info.right.accessible_to.toISOString();
+            this.endTimeMoment = moment(this.endTime);
+        });
+    }
 
     ngOnChanges(c: SimpleChanges) {
         if (c.endTime) {


### PR DESCRIPTION
Testi: <https://timdevs01-4.it.jyu.fi/view/users/admin-admin/test-polling>

Testatut tapaukset:
- Oikeuden kesto vaihdetaan => uusi Time left -aika päivittyy käyttäjälle automaattisesti
- Käyttäjälle asetetaan veisti => viesti tulee näkyviin ja peittää sivun
- Käyttäjälle asetetaan toinen viesti toisen viestin ollessa näkyvissä => vanhan viestin tilalle tulee uusi viesti
- Käyttäjältä otetaan viesti pois => viesti poistuu
- Käyttäjä menee toiseen dokumenttiin viestin kanssa => viesti näkyy toisellakin sivulla
- Nopeustesti => pollauspolun kesto 33 ms
- Kuormatesti => pollauspolku vain lukee data, joten ei lukitusta, mikä voisi timeoutata
- Muita testitapauksia, joita pitäisi testata?

This commit allows polling for document view info route via a document setting:

```yml
pollDocumentViewInfo: 10000
pollDocumentViewInfoJitter: 3000
```

For now, this is implemented as polling, since there is no infrastructure for running WebSockets or implement Server Side Events.

This commit further makes use of this feature in two ways:

- The TimeLeftComponent's time automatically updates if the access_to time changes. This can be useful in exams where a student might get a time extension
- This commit adds the ability to push global messages to user groups to view. The global messages are stored in a in-memory via Redis cache, allowing for low-overhead polling