### PR TITLE
csplugin: Fix preventSave attribute

### DIFF
--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -2511,6 +2511,9 @@ ${fhtml}
             this.showCodeNow();
         }
         this.countBoard?.count(str);
+        if (this.isText) {
+            this.preventSave = this.countBoard?.preventSave ?? false;
+        }
         if (this.isText || this.clearSaved) {
             this.savedText = "";
         }

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -2695,20 +2695,21 @@ ${fhtml}
         const ty = languageTypes.getRunType(this.selectedLanguage, "cs");
         if (ty === "md") {
             this.showMD();
-            if (nosave || this.nosave || this.preventSave) {
+            if (nosave || this.nosave) {
                 return;
             }
         }
         if (languageTypes.isInArray(ty, csJSTypes)) {
             // this.jstype = ty;
             this.showJS();
-            if (nosave || this.nosave || this.preventSave) {
+            if (nosave || this.nosave) {
                 return;
             }
         }
-        if (!this.preventSave) {
-            await this.doRunCode(ty, nosave || this.nosave);
+        if (this.preventSave) {
+            return;
         }
+        await this.doRunCode(ty, nosave || this.nosave);
     }
 
     runCodeAuto() {

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -2695,18 +2695,20 @@ ${fhtml}
         const ty = languageTypes.getRunType(this.selectedLanguage, "cs");
         if (ty === "md") {
             this.showMD();
-            if (nosave || this.nosave) {
+            if (nosave || this.nosave || this.preventSave) {
                 return;
             }
         }
         if (languageTypes.isInArray(ty, csJSTypes)) {
             // this.jstype = ty;
             this.showJS();
-            if (nosave || this.nosave) {
+            if (nosave || this.nosave || this.preventSave) {
                 return;
             }
         }
-        await this.doRunCode(ty, nosave || this.nosave);
+        if (!this.preventSave) {
+            await this.doRunCode(ty, nosave || this.nosave);
+        }
     }
 
     runCodeAuto() {


### PR DESCRIPTION
Korjaa cspluginin toimintaa niin, että cspluginissa olevasta countboard-komponentista välittyy sen preventSave-attribuutin arvo cspluginille. Tämä mahdollistaa sen, että cspluginiin annettavan vastauksen pituutta pystyy oikeasti rajoittamaan, eli sen avulla voi estää liian lyhyen/pitkän vastauksen tallentamisen.

Liittyy:  #2605 

TODO:
- [x] Ctrl+S pitää vielä saada estettyä myös
  - estetty funktiossa `runCodeCommon`, estämällä `doRunCode`n ajaminen jos `preventSave == true`
  - tämä vaatinee vielä tarkempaa tutkimista: 
    - onko tapauksia, joissa halutaan ajaa doRunCode, mutta ilman että vastaus tallennetaan?
    - esim. halutaan että tehtävä estää liian lyhyen/pitkän koodin tallentaminen, mutta pitäisi pystyä testaamaan/ajamaan koodi silti?

Rajoituksena toistaiseksi myös, että cspluginin pitää olla tekstityyppinen (text, css, md)

Timdevsissä <https://timdevs01-6.it.jyu.fi/view/test/csplugin-preventsave>, esim. testuser 1-3

esim.

> \``` {#ps2 plugin="csPlugin"}
> type: text
> highlight:
> stem: "kysymys?"
> button: Tallenna
> rows: 1 
> autosave: true
> count:
>  preventSave: true
>  chars: {min: 0, max: 10, preventSave: true, show: true}
> \```

Toimiakseen vaatii, että 
- `preventSave: true` on cspluginin `count`-attribuutin alla
- `count`-attribuutin alla on `chars`, `words` tai `lines` -aliattribuutti, jonka määrityksissä löytyy myös `preventSave: true`