### PR TITLE
Remove doc_id and par_id from /getState

### DIFF
--- a/timApp/answer/routes.py
+++ b/timApp/answer/routes.py
@@ -2106,8 +2106,6 @@ def get_model_answer(task_id: str) -> Response:
 def get_state(
     user_id: int,
     answer_id: int | None = None,
-    par_id: str | None = None,
-    doc_id: int | None = None,
     review: bool = False,
     task_id: str | None = None,
     answernr: int | None = None,
@@ -2151,8 +2149,6 @@ def get_state(
         raise RouteException("Missing answer ID or task ID")
 
     doc.insert_preamble_pars()
-    if par_id:
-        tid.maybe_set_hint(par_id)
 
     user_ctx = user_context_with_logged_in(user)
     try:

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -711,8 +711,6 @@ export class AnswerBrowserComponent
         }
         const orig = par.originalPar;
         const parParams = {
-            doc_id: par.par.docId,
-            par_id: par.par.id,
             ref_from_doc_id: orig.docId,
             ref_from_par_id: orig.id,
         };

--- a/timApp/tests/browser/test_translation.py
+++ b/timApp/tests/browser/test_translation.py
@@ -1,0 +1,54 @@
+from selenium.webdriver.common.by import By
+from timApp.document.editing.routes import mark_as_translated
+from timApp.tests.browser.browsertest import BrowserTest, PREV_ANSWER
+
+
+class TranslationTest(BrowserTest):
+    def test_no_wrong_block_id_hint(self):
+        self.login_browser_quick_test1()
+        self.login_test1()
+        src = self.create_doc(
+            initial_par="""
+``` {#suttu plugin="csPlugin"}
+type: text
+```
+"""
+        )
+        src_par = src.document.get_paragraphs()[0]
+        src_t = self.create_translation(src)
+        src_t_par = src_t.document.get_paragraphs()[0]
+        mark_as_translated(src_t_par)
+        src_t_par.save()
+        dest = self.create_doc(
+            initial_par=f"""
+#- {{rd="{src.id}" rp="{src_par.id}"}}
+"""
+        )
+        dest_t = self.create_translation(dest)
+        dest_t_par = dest_t.document.get_paragraphs()[0]
+        dest_t_par.set_attr("rd", str(src_t.id))
+        dest_t_par.set_attr("rp", src_t_par.id)
+        mark_as_translated(dest_t_par)
+        dest_t_par.save()
+
+        def save(text):
+            textarea = self.find_element_and_move_to("#suttu textarea")
+            textarea.send_keys(text)
+            par = self.find_element_avoid_staleness("#suttu > tim-plugin-loader > div")
+            par.find_element(by=By.CSS_SELECTOR, value="button").click()
+            self.wait_until_present_and_vis("answerbrowser")
+
+        self.goto_document(dest_t)
+        self.wait_until_present_and_vis("#suttu textarea")
+        save("dest translated")
+        self.goto_document(dest)
+        self.wait_until_present_and_vis("#suttu textarea")
+        save(" | dest unstranslated")
+        self.goto_document(dest_t)
+        self.wait_until_present_and_vis("#suttu textarea")
+        self.find_element_and_move_to("#suttu textarea")
+        self.find_element(PREV_ANSWER).click()
+        self.wait_until_hidden(f"answerbrowser .loading")
+        self.should_not_exist("answerbrowser .alert-danger")
+        value = self.find_element("#suttu textarea").get_attribute("value")
+        self.assertEqual("dest translated", value)

--- a/timApp/tests/server/test_plugins.py
+++ b/timApp/tests/server/test_plugins.py
@@ -2063,28 +2063,16 @@ initword: a"""
             expect_status=400,
             expect_content="Non-existent answer",
         )
-        # not found because of wrong hint
         self.get(
             "/getState",
             query_string={
                 "user_id": self.current_user_id(),
                 "answer_id": aid,
-                "par_id": "xxx",
-            },
-            expect_status=400,
-            expect_content="Task not found in the document: t (potentially because of wrong block id hint)",
-        )
-        self.get(
-            "/getState",
-            query_string={
-                "user_id": self.current_user_id(),
-                "answer_id": aid,
-                "par_id": "xxx",
                 "ref_from_par_id": "yyy",
                 "ref_from_doc_id": d.id,
             },
             expect_status=400,
-            expect_content="Task not found in the document: t (potentially because of wrong block id hint)",
+            expect_content="Plugin paragraph not found: yyy",
         )
 
     def test_plugin_empty_markup(self):


### PR DESCRIPTION
Poistaa doc_id ja par_id -parametrit getState-kutsuista.

Tällä hetkellä doc_id:tä ei käytetä ollenkaan, par_id:tä käytetään jonkinlaisena saniteettitarkistuksena joka ei kuitenkaan erikoistilanteissa mene läpi (#3658)

Nykyään getStatessa plugin haetaan suoraan pyynnössä taskId:llä tai kaivetaan vastausid:stä taskId. Käännöksiä varten on erikseen ref_from_doc_id/ref_from_par_id. Tuo vanha par_id on ollut joskus oleellinen kun ei käytetty taskId:tä:
https://github.com/TIM-JYU/TIM/blob/4cbed36653331470b2ffec7a20c6a783cb57d81b/timApp/answer/routes.py#L465

https://tim.jyu.fi/teacher/users/sijualle/kokeiluja/blockidbugi/dest/en vs https://timdevs02.it.jyu.fi/teacher/users/sijualle/kokeiluja/blockidbugi/dest/en

