### PR TITLE
CLI command to permanently delete docs and folders

### DIFF
--- a/timApp/admin/item_cli.py
+++ b/timApp/admin/item_cli.py
@@ -317,8 +317,8 @@ def perma_del_doc(item_id: int, dry_run: bool) -> list[str]:
         db.session.add(deleted_placeholder)
 
     # Clear disk files and folders related to this document
-    pars_path = get_files_path() / "pars" / f"item_id"
-    ver_path = get_files_path() / "docs" / f"item_id"
+    pars_path = get_files_path() / "pars" / f"{item_id}"
+    ver_path = get_files_path() / "docs" / f"{item_id}"
 
     if not dry_run:
         # TIM documents' paragraphs and history files are stored in a directory corresponding to the document id,

--- a/timApp/admin/item_cli.py
+++ b/timApp/admin/item_cli.py
@@ -1,4 +1,3 @@
-import pathlib
 import shutil
 from secrets import token_urlsafe
 
@@ -6,7 +5,6 @@ import click
 from flask.cli import AppGroup
 from sqlalchemy import select, delete
 
-import timApp.document.docentry
 from timApp.admin.fix_orphan_documents import (
     fix_orphans_without_docentry,
     move_docs_without_block,
@@ -14,7 +12,7 @@ from timApp.admin.fix_orphan_documents import (
 from timApp.admin.util import commit_if_not_dry
 from timApp.document.docentry import DocEntry
 from timApp.document.translation.translation import Translation
-from timApp.item.block import Block, BlockType, BlockAccess
+from timApp.item.block import Block, BlockType
 from timApp.notification.notification import Notification
 from timApp.notification.pending_notification import PendingNotification
 from timApp.readmark.readparagraph import ReadParagraph

--- a/timApp/admin/item_cli.py
+++ b/timApp/admin/item_cli.py
@@ -373,7 +373,7 @@ def perma_del_folder(item_id: int, dry_run: bool) -> list[str]:
         deleted.extend(deleted_docs)
 
     for subfolder in subfolders:
-        deleted_subfolders = perma_del_folder(subfolder.id)
+        deleted_subfolders = perma_del_folder(subfolder.id, dry_run=dry_run)
         deleted.extend(deleted_subfolders)
 
     return deleted


### PR DESCRIPTION
Adds a CLI command to permanently delete TIM documents and folders, including:
- database entries
- disk files

TODO:
- remove resources and entries directly attahed to the document (velps, document comments, etc.)
- plan for dealing with backups

Closes #3670 