### PR TITLE
Directory listing access/visibility level badges

### DIFF
--- a/timApp/item/routes.py
+++ b/timApp/item/routes.py
@@ -1,6 +1,7 @@
 """Routes for document view."""
 import dataclasses
 import html
+import logging
 import time
 from difflib import context_diff
 from typing import Union, Any, ValuesView, Generator
@@ -1450,6 +1451,23 @@ def get_item(item_id: int):
         raise NotExist("Item not found")
     verify_view_access(i)
     return json_response(i)
+
+
+@view_page.get("/items/accesses/<int:item_id>")
+def get_item_accesses(item_id: int):
+    """Return a list of usergroup ids that have any access to the item"""
+
+    i = Item.find_by_id(item_id)
+    if not i:
+        raise NotExist("Item not found")
+    verify_view_access(i)
+
+    accs = list(set(v.usergroup.id for v in i.block.accesses.values()))
+
+    # from timApp.util.logger import log_info
+    # log_info(str(accs))
+
+    return json_response(accs)
 
 
 @view_page.post("/items/relevance/set/<int:item_id>")

--- a/timApp/static/scripts/tim/folder/directory-list.component.scss
+++ b/timApp/static/scripts/tim/folder/directory-list.component.scss
@@ -1,3 +1,25 @@
 .icon-inline {
   margin-left: 0.5em;
 }
+
+.accessbadge-public {
+    border: solid 2px green;
+    border-radius: 15px;
+    padding: 3px;
+    color: green;
+    font-size: x-small;
+}
+.accessbadge-private {
+    border: solid 2px darkgray;
+    border-radius: 15px;
+    padding: 3px;
+    color: darkgray;
+    font-size: x-small;
+}
+.accessbadge-group {
+    border: solid 2px darkblue;
+    border-radius: 15px;
+    padding: 3px;
+    color: darkblue;
+    font-size: x-small;
+}

--- a/timApp/static/scripts/tim/folder/directory-list.component.ts
+++ b/timApp/static/scripts/tim/folder/directory-list.component.ts
@@ -2,9 +2,18 @@ import {Component} from "@angular/core";
 import type {DocumentOrFolder, IFolder, IItem} from "tim/item/IItem";
 import {Users} from "tim/user/userService";
 import {folderglobals} from "tim/util/globals";
+import {to, toPromise} from "tim/util/utils";
+import {$http} from "tim/util/ngimport";
 
 const MESSAGE_LIST_ARCHIVE_FOLDER_PREFIX = "archives/";
 const TIM_MESSAGES_FOLDER_PREFIX = "messages/tim-messages";
+
+enum AccessLevelBadge {
+    NO_BADGE = -1,
+    PUBLIC = 0,
+    GROUP = 1,
+    PRIVATE = 2,
+}
 
 @Component({
     selector: "tim-index",
@@ -35,7 +44,7 @@ const TIM_MESSAGES_FOLDER_PREFIX = "messages/tim-messages";
                 <td></td>
                 <td></td>
             </tr>
-            <tr *ngFor="let item of itemList">
+            <tr *ngFor="let item of itemList; index as i">
                 <td>
                     <a *ngIf="item.isFolder" href="/view/{{ item.path }}">
                         <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>
@@ -43,8 +52,16 @@ const TIM_MESSAGES_FOLDER_PREFIX = "messages/tim-messages";
                 </td>
                 <td>
                     <a href="/view/{{ item.path }}">{{ item.title }}</a>&ngsp;
-                    <a><i *ngIf="item.unpublished" class="glyphicon glyphicon-lock"
-                          title="Unpublished item"></i></a>
+                    <ng-container [ngSwitch]="getItemBadge(i)">  
+                        <a *ngSwitchCase="AccessLevelBadge.PUBLIC">
+                            <!-- <i *ngIf="item.unpublished" class="glyphicon glyphicon-lock" title="Unpublished item"></i> -->
+                            <i class="accessbadge-public" title="Item is visible to public groups (anonymous users, logged-in users or jyu.fi users.">Public</i>
+                        </a>
+                        <a *ngSwitchCase="AccessLevelBadge.PRIVATE">
+                            <i class="accessbadge-private" title="Private item">Private</i>
+                        </a>
+                        <a *ngSwitchDefault></a>
+                    </ng-container>
                 </td>
                 <td></td>
                 <td>{{ item.modified }}</td>
@@ -86,6 +103,7 @@ const TIM_MESSAGES_FOLDER_PREFIX = "messages/tim-messages";
 })
 export class DirectoryListComponent {
     itemList: DocumentOrFolder[];
+    itemBadges: AccessLevelBadge[];
     item: IFolder;
     canCreate: boolean;
     showId = false;
@@ -103,9 +121,42 @@ export class DirectoryListComponent {
         ) {
             this.itemList = this.itemList.sort((a, b) => b.id - a.id);
         }
+        this.itemBadges = [this.itemList.length];
+        for (let i = 0; i < this.itemList.length; i++) {
+            this.getAccessLevelBadge(this.itemList[i]).then(
+                (value) => (this.itemBadges[i] = value)
+            );
+        }
     }
 
     listOwnerNames(i: IItem) {
         return i.owners.map((o) => o.name).join(", ");
     }
+
+    async getAccessLevelBadge(i: IItem): Promise<AccessLevelBadge> {
+        const res = await to($http.get<number[]>(`/items/accesses/${i.id}`));
+        let ugids: number[] = [];
+        if (res.ok) {
+            ugids = res.result.data;
+        }
+
+        // TODO: clear scheme for badges, ie.
+        //  - what badges are needed
+        //  - how do badges map to different access combinations
+        // Logged-in users = 0, Anon users = 1, jyu.fi users = 5
+        if (ugids.includes(0) || ugids.includes(1) || ugids.includes(5)) {
+            return AccessLevelBadge.PUBLIC;
+        } else if (ugids.length > 1 && i.owners.length != ugids.length) {
+            // we currently don't use the 'Group' badge, since we would have to do db queries to distinguish
+            // personal groups from actual groups
+            // return AccessLevelBadge.PUBLIC;
+            return AccessLevelBadge.NO_BADGE;
+        } else return AccessLevelBadge.PRIVATE;
+    }
+
+    getItemBadge(index: number) {
+        return this.itemBadges[index];
+    }
+
+    protected readonly AccessLevelBadge = AccessLevelBadge;
 }


### PR DESCRIPTION
WIP, see #3679 

Replace lock icon for directory list items with badges indicating access level, currently `Public` and `Private` (and empty).

![image](https://github.com/user-attachments/assets/3dbc7360-c66e-4a4b-9511-23a9f26c1345)

TODO:
- proper scheme for badges
  - what badges are needed
  - how do badges map to different access right combinations
- consistent styling according to UI theme used, mainly coloring 