### PR TITLE
Update QR code generation option in TIM editor menu

### DIFF
--- a/timApp/modules/cs/templates/2/5
+++ b/timApp/modules/cs/templates/2/5
@@ -1,7 +1,7 @@
 QR-code
 Insert QR-code to join to lecture
 #- {nocache="true" math_type="svg" math_preamble="\\usepackage{qrcode}"}
-{%set teksti="https://tim.pm/ohj1"%}
+{% set teksti = "https://tim.jyu.fi/lecture/"~docid~"?lecture=autojoin" %}
 {%set taso="L"%}
 \begin{equation*}
 \qrcode[height=5cm, level=%%taso%%]%%'{' + teksti + '}'%%

--- a/timApp/modules/cs/templates/2/5
+++ b/timApp/modules/cs/templates/2/5
@@ -1,4 +1,8 @@
 QR-code
 Insert QR-code to join to lecture
-![Näytä tätä puhelimelle](https://chart.googleapis.com/chart?chs=400x400&cht=qr&chl=
-https://tim.jyu.fi/lecture/%%docid%%?lecture=autojoin)
+#- {nocache="true" math_type="svg" math_preamble="\\usepackage{qrcode}"}
+{%set teksti="https://tim.pm/ohj1"%}
+{%set taso="L"%}
+\begin{equation*}
+\qrcode[height=5cm, level=%%taso%%]%%'{' + teksti + '}'%%
+\end{equation*}


### PR DESCRIPTION
Päivittää TIMin ParEditorin menussa olevan QR-koodigeneraattorin (Plugins -> Others -> QR code) käyttämään Googlen toimimattoman palvelun sijaan LaTeX:ia/tikz:ia.

Oletuksena QR-koodiin tulee osoite `https://tim.jyu.fi/lecture/"~docid~"?lecture=autojoin`, mutta tätä voi muokata suoraan editorissa.