### PR TITLE
Fix null reference in textContent()

### DIFF
--- a/timApp/static/scripts/tim/document/structure/parContext.ts
+++ b/timApp/static/scripts/tim/document/structure/parContext.ts
@@ -83,7 +83,8 @@ export class ParContext {
     }
 
     textContent() {
-        return this.getContent().textContent;
+        const c = this.getContent();
+        return c !== null ? c.textContent : "";
     }
 
     equals(other: ParContext) {


### PR DESCRIPTION
ParContext.getContent() may return null when called by ParContext.textContent(). If it is null, we will just return an empty string instead:

https://github.com/TIM-JYU/TIM/blob/437f9a6d41aca01b6bd26298d46e1c9fffdca80e/timApp/static/scripts/tim/document/readings.ts#L155-L159