### PR TITLE
Add current URL params to translation link buttons in the header bar

### DIFF
--- a/timApp/static/scripts/tim/header/header.component.ts
+++ b/timApp/static/scripts/tim/header/header.component.ts
@@ -58,7 +58,7 @@ function isExpired(tag: ITag) {
                 <ng-container *ngIf="translations && translations.length > 1">
             <span *ngFor="let tr of translations">
                 <a class="label label-primary"
-                   href="/{{ route }}/{{ tr.path }}">{{ tr.lang_id || 'language not set' }}</a>&ngsp;
+                   href="/{{ route }}/{{ tr.path + this.sanitizeSearch() }}">{{ tr.lang_id || 'language not set' }}</a>&ngsp;
             </span>
                 </ng-container>
             </div>


### PR DESCRIPTION
If the current document request contained url parameters, they are added to the document's translation link buttons in the page's header bar. This improves navigability between translations when documents employ url params to set macro/variable values.