### PR TITLE
Fix sending oversized translation requests

### DIFF
--- a/timApp/document/translation/deepl.py
+++ b/timApp/document/translation/deepl.py
@@ -402,8 +402,6 @@ class DeeplTranslationService(RegisteredTranslationService):
             call = self._translate(
                 session,
                 protected_texts[start:i],
-                # if i < len(protected_texts)
-                # else protected_texts[start : i + 1],
                 # Send uppercase, because it is used in DeepL documentation.
                 source_lang_code.upper() if source_lang_code else None,
                 target_lang.lang_code.upper(),

--- a/timApp/document/translation/deepl.py
+++ b/timApp/document/translation/deepl.py
@@ -484,7 +484,7 @@ class DeeplTranslationService(RegisteredTranslationService):
                 return_langs = return_langs + [en]
         return return_langs
 
-    @cache.memoize(timeout=LANGUAGES_CACHE_TIMEOUT, args_to_ignore=["self"])
+    # @cache.memoize(timeout=LANGUAGES_CACHE_TIMEOUT, args_to_ignore=["self"])
     def languages(self) -> LanguagePairing:
         """
         Asks the DeepL API for the list of supported languages and turns the

--- a/timApp/document/translation/deepl.py
+++ b/timApp/document/translation/deepl.py
@@ -358,9 +358,7 @@ class DeeplTranslationService(RegisteredTranslationService):
             num_params = 0
             start = i
 
-            if not len(protected_texts[i]) < DEEPL_REQUEST_SIZE_LIMIT:
-                i += 1
-            else:
+            if len(protected_texts[i]) < DEEPL_REQUEST_SIZE_LIMIT:
                 # In addition to the text parameters limit, requests also have a size limit in bytes
                 while (
                     i < len(protected_texts)
@@ -370,6 +368,8 @@ class DeeplTranslationService(RegisteredTranslationService):
                     req_chars += len(protected_texts[i])
                     num_params += 1
                     i += 1
+            else:
+                i += 1
 
             call = self._translate(
                 session,

--- a/timApp/document/translation/routes.py
+++ b/timApp/document/translation/routes.py
@@ -136,6 +136,11 @@ def translate_full_document(
     # The order of paragraphs in both docs must match, so that correct
     # ones are modified.
     for tr_paragraph, text in zip(tr_paragraphs, translated_texts):
+        # Do not modify paragraph, if translation request returns an empty text block,
+        # since this means there was an oversized translation request. We should keep the source text block
+        # intact so the user may split it up in the original or translate it manually.
+        if not text:
+            continue
         # Note that the paragraph's text is stripped, as extra newlines at
         # start or end seem to break plugins.
         tr.document.modify_paragraph(tr_paragraph.id, text.strip())


### PR DESCRIPTION
Requests sent to the DeepL API previously only considered the API limit on text parameters per request. For some documents, translation requests would fail because the enforced text parameter limit still allowed the request size limit to be exceeded.

This PR corrects this issue by limiting the request payload size to within the API limits.

Oversized translation requests will not throw an exception anymore, they are simply ignored so that valid sections of the document are still able to be translated. There is currently no simple way to split the text content of those requests into multiple requests without breaking the document or running into errors.

Caching for `DeeplTranslationService.languages()` has been disabled for now. It seems to cause occasional problems with the returned LanguagePairing missing mappings for English and Portuguese as source languages.

TODO:
- <s>Extremely long, continuous sections may still exceed the request size limit. These need to either be split into further requests, or omitted from the translation requests altogether.</s>

TEST DOC:
- <https://timbeta01.tim.education/view/test/pr/3711>