### PR TITLE
Feature ide extra files

### DIFF
--- a/timApp/idesupport/utils.py
+++ b/timApp/idesupport/utils.py
@@ -164,7 +164,7 @@ IdeFileSchema = class_schema(IdeFile)()
 @dataclass
 class SupplementaryFile:
     filename: str
-    content: str = ""
+    content: str
 
     def to_json(self) -> dict[str, str | None]:
         return {
@@ -174,6 +174,17 @@ class SupplementaryFile:
 
 
 SupplementaryFileSchema = class_schema(SupplementaryFile)()
+
+
+@dataclass
+class IdeAsset:
+    url: str
+
+    def to_json(self) -> dict[str, str | None]:
+        return {"url": self.url}
+
+
+IdeAssetSchema = class_schema(IdeAsset)()
 
 
 @dataclass
@@ -242,6 +253,11 @@ class TIDEPluginData:
     supplementary_files: List[SupplementaryFile] | None = None
     """
     Supplementary files for the task
+    """
+
+    ide_assets: List[IdeAsset] | None = None
+    """
+    Files that cli tool has to download
     """
 
     path: str | None = None
@@ -704,11 +720,16 @@ def get_ide_user_plugin_data(
         ide_file.set_combined_code()
         json_ide_files = [ide_file.to_json()]
 
-    # supplementary_files = generate_supplementary_files(
-    #     task_type=task_info.type, task_name=ide_task_id
-    # )
+    supplementary_files = []
 
-    supplementary_files = plugin_json["markup"].get("ide_extra_files") or []
+    ide_extra_files = plugin_json["markup"].get("ide_extra_files") or []
+
+    for extra_file in ide_extra_files:
+        if extra_file["content"] is not None:
+            supplementary_files.append(SupplementaryFileSchema.load(extra_file))
+        elif extra_file["source"] is not None:
+            # TODO: fetch the data from disk/internet and slap it in the content-field of a SupplementaryFile
+            pass
 
     return TIDEPluginData(
         task_files=json_ide_files,

--- a/timApp/idesupport/utils.py
+++ b/timApp/idesupport/utils.py
@@ -177,17 +177,6 @@ SupplementaryFileSchema = class_schema(SupplementaryFile)()
 
 
 @dataclass
-class IdeAsset:
-    url: str
-
-    def to_json(self) -> dict[str, str | None]:
-        return {"url": self.url}
-
-
-IdeAssetSchema = class_schema(IdeAsset)()
-
-
-@dataclass
 class TIDETaskInfo:
     """
     Information about the TIDE-task

--- a/timApp/idesupport/utils.py
+++ b/timApp/idesupport/utils.py
@@ -708,7 +708,7 @@ def get_ide_user_plugin_data(
     #     task_type=task_info.type, task_name=ide_task_id
     # )
 
-    supplementary_files = plugin_json["markup"].get("ide_extra_files")
+    supplementary_files = plugin_json["markup"].get("ide_extra_files") or []
 
     return TIDEPluginData(
         task_files=json_ide_files,

--- a/timApp/idesupport/utils.py
+++ b/timApp/idesupport/utils.py
@@ -704,9 +704,11 @@ def get_ide_user_plugin_data(
         ide_file.set_combined_code()
         json_ide_files = [ide_file.to_json()]
 
-    supplementary_files = generate_supplementary_files(
-        task_type=task_info.type, task_name=ide_task_id
-    )
+    # supplementary_files = generate_supplementary_files(
+    #     task_type=task_info.type, task_name=ide_task_id
+    # )
+
+    supplementary_files = plugin_json["markup"].get("ide_extra_files")
 
     return TIDEPluginData(
         task_files=json_ide_files,

--- a/timApp/upload/upload.py
+++ b/timApp/upload/upload.py
@@ -26,6 +26,9 @@ from timApp.auth.accesshelper import (
     verify_answer_access,
 )
 from timApp.auth.accesstype import AccessType
+from timApp.auth.oauth2.models import Scope
+from timApp.auth.oauth2.oauth2 import require_oauth
+from authlib.integrations.flask_oauth2 import current_token
 from timApp.auth.sessioninfo import get_current_user_object, user_context_with_logged_in
 from timApp.auth.sessioninfo import logged_in, get_current_user_group_object
 from timApp.document.docentry import DocEntry
@@ -616,6 +619,7 @@ def save_file_and_grant_access(
 
 
 @upload.get("/files/<path:file_id>/<file_filename>")
+@require_oauth(Scope.user_tasks.value, optional=True)
 def get_file(file_id: str, file_filename: str) -> Response:
     if file_id.isdigit():
         f = UploadedFile.get_by_id_and_filename(int(file_id), file_filename)
@@ -623,7 +627,10 @@ def get_file(file_id: str, file_filename: str) -> Response:
         f = UploadedFile.get_by_doc_and_filename(file_id, file_filename)
     if not f:
         raise NotExist("File not found")
-    verify_view_access(f, check_parents=True)
+
+    user = current_token.user if current_token else None
+
+    verify_view_access(f, check_parents=True, user=user)
     file_path = f.filesystem_path.as_posix()
     send_plain = get_option(request, "plain", False)
     if send_plain:
@@ -689,6 +696,7 @@ def get_reviewcanvas_pdf(user_name: str, doc_id: int, task_id: str, answer_id: i
 
 
 @upload.get("/images/<path:image_id>/<image_filename>")
+@require_oauth(Scope.user_tasks.value, optional=True)
 def get_image(image_id: str, image_filename: str) -> Response:
     if image_id.isdigit():
         f = UploadedFile.get_by_id_and_filename(int(image_id), image_filename)
@@ -696,7 +704,10 @@ def get_image(image_id: str, image_filename: str) -> Response:
         f = UploadedFile.get_by_doc_and_filename(image_id, image_filename)
     if not f:
         raise NotExist("Image not found")
-    verify_view_access(f, check_parents=True)
+
+    user = current_token.user if current_token else None
+
+    verify_view_access(f, check_parents=True, user=user)
     if image_filename != f.filename:
         raise NotExist("Image not found")
     imgtype = guess_image_mime(f.filesystem_path)


### PR DESCRIPTION
Adds possibility to define extra files for IDE task downloads.

Example usage:

`````yaml
``` {#lentokone plugin="csPlugin" ideTask="lentsikka-tehtävä" id="kBaKtXsqMJ8X"}

filename: exercise.py
type: py
path: user
fullprogram: |!!
# BYCODEBEGIN
# BYCODEEND
!!
ide_extra_files:
    - content: |
        def for_local_testing():
            # assert ... 
      filename: extra_file.py
    - source: /files/41/file_in_tim.py
      filename: file_from_tim.py
    - source: /images/42/image_in_tim.gif
      filename: image_from_tim.gif
    - source: "https://url-to-image.jpg"
      filename: file_from_url.jpg
```
`````
