### PR TITLE
showVideo: support document language code for defaultSubtitles

### DIFF
--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -224,7 +224,7 @@ const ShowFileAll = t.type({
                        [crossOrigin]="videosettings.crossOrigin"
                        [autoplay]="videoAutoPlay"
                 >
-                        <track *ngFor="let subtitle of markup.subtitles" [src]="subtitle.file" [label]="subtitle.name" />    
+                        <track *ngFor="let subtitle of markup.subtitles" [src]="subtitle.file" [label]="subtitle.name" [srclang]="getVTTSrcLang(subtitle.file)"/>    
                 </video>
             </ng-container>
             <ng-container *ngIf="isNormalSize">
@@ -751,6 +751,15 @@ export class VideoComponent extends AngularPluginBase<
 
     getAttributeType() {
         return ShowFileAll;
+    }
+
+    getVTTSrcLang(file: string) {
+        const end = file.slice(file.lastIndexOf("/") + 1, file.length);
+        if (end.endsWith(".vtt")) {
+            // There's no language code in the subtitle file path
+            return "";
+        }
+        return end;
     }
 }
 

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -684,10 +684,10 @@ export class VideoComponent extends AngularPluginBase<
         }
         const v = this.video.nativeElement;
         if (this.markup.defaultSubtitles) {
-            const track = [...v.textTracks].find((vt) =>
-                vt.language === this.markup.defaultSubtitles
-                    ? true // prefer the document's language code if present
-                    : vt.label === this.markup.defaultSubtitles
+            const track = [...v.textTracks].find(
+                (vt) =>
+                    vt.language === this.markup.defaultSubtitles ||
+                    vt.label === this.markup.defaultSubtitles
             );
             if (track) {
                 track.mode = "showing";

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -684,8 +684,10 @@ export class VideoComponent extends AngularPluginBase<
         }
         const v = this.video.nativeElement;
         if (this.markup.defaultSubtitles) {
-            const track = [...v.textTracks].find(
-                (vt) => vt.label === this.markup.defaultSubtitles
+            const track = [...v.textTracks].find((vt) =>
+                vt.language === this.markup.defaultSubtitles
+                    ? true // prefer the document's language code if present
+                    : vt.label === this.markup.defaultSubtitles
             );
             if (track) {
                 track.mode = "showing";


### PR DESCRIPTION
If `defaultSubtitles` attribute is set on a showVideo plugin, check for the TextTracks `language` property first. This allows us to use the global macro `%%doclang%%` to automatically choose the default subtitle track according to the current document's language.