### PR TITLE
settings: Add support for quick themes

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -9128,6 +9128,54 @@
           <context context-type="linenumber">966,964</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3217189464299162022" datatype="html">
+        <source>Quick themes</source>
+        <target state="translated">Pikatyylit</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/sidebarmenu/tabs/settings-tab.component.ts</context>
+          <context context-type="linenumber">59,60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="853806060840861954" datatype="html">
+        <source>Quick select styles</source>
+        <target state="translated">Pikatyylit</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">189</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4161663426352478871" datatype="html">
+        <source> Styles that are available in the Quick select menu (in the Settings menu on the left of the page) are listed here. You can review and remove styles that you use. </source>
+        <target state="translated"> Tyylit, jotka ovat käytössä Pikatyylit-valikossa (Asetukset-valikossa sivun vasemmassa laidassa) ovat listattu tähän. Voit katsoa ja poistaa tyylejä, joita aiot käyttää. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">192,193</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4570636567629984302" datatype="html">
+        <source> You can also reorder styles by dragging them in the list below. </source>
+        <target state="translated"> Voit myös järjestää tyylejä raahaamalla ne alla olevassa luettelossa. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">196</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8720702577528832728" datatype="html">
+        <source> You have no quick styles selected. You can add styles via the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;>"/>Available styles<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> tab. </source>
+        <target state="translated"> Et ole valinnut yhtään pikatyyliä. Voit lisätä tyylit <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;>"/>Saatavilla olevat tyylit<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>-välilehdessä. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">206,207</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8594707912435167235" datatype="html">
+        <source> Add to Quick select </source>
+        <target state="translated"> Lisää pikatyyleihin </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">275</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -9030,6 +9030,54 @@
           <context context-type="linenumber">966,964</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3217189464299162022" datatype="html">
+        <source>Quick themes</source>
+        <target state="new">Quick themes</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/sidebarmenu/tabs/settings-tab.component.ts</context>
+          <context context-type="linenumber">59,60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="853806060840861954" datatype="html">
+        <source>Quick select styles</source>
+        <target state="new">Quick select styles</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">189</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4161663426352478871" datatype="html">
+        <source> Styles that are available in the Quick select menu (in the Settings menu on the left of the page) are listed here. You can review and remove styles that you use. </source>
+        <target state="new"> Styles that are available in the Quick select menu (in the Settings menu on the left of the page) are listed here. You can review and remove styles that you use. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">192,193</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4570636567629984302" datatype="html">
+        <source> You can also reorder styles by dragging them in the list below. </source>
+        <target state="new"> You can also reorder styles by dragging them in the list below. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">196</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8720702577528832728" datatype="html">
+        <source> You have no quick styles selected. You can add styles via the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;&gt;"/>Available styles<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> tab. </source>
+        <target state="new"> You have no quick styles selected. You can add styles via the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;&gt;"/>Available styles<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> tab. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">206,207</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8594707912435167235" datatype="html">
+        <source> Add to Quick select </source>
+        <target state="new"> Add to Quick select </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">275</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -188,6 +188,7 @@ export interface ISettings {
     auto_mark_all_read: boolean;
     max_uncollapsed_toc_items: number | null;
     style_doc_ids: number[];
+    quick_select_style_doc_ids: number[];
     parmenu_position: number;
 }
 

--- a/timApp/tests/server/test_settings.py
+++ b/timApp/tests/server/test_settings.py
@@ -101,11 +101,11 @@ class SettingsTest(TimRouteTest):
                     '"remember_last_sidebar_menu_tab": false, '
                     '"remember_last_sidebar_menu_state": false, "word_list": '
                     '"", "email_exclude": "", "language": null, '
-                    '"style_doc_ids": [], "last_answer_fetch": {}, '
-                    '"auto_mark_all_read": false, "bookmarks": [{"Last edited": '
-                    '[{"document 2": "/view/users/test-user-1/doc1"}]}], '
-                    '"max_uncollapsed_toc_items": null, '
-                    '"parmenu_position": 1}',
+                    '"style_doc_ids": [], "quick_select_style_doc_ids": [], '
+                    '"last_answer_fetch": {}, "auto_mark_all_read": false, '
+                    '"bookmarks": [{"Last edited": [{"document 2": '
+                    '"/view/users/test-user-1/doc1"}]}], '
+                    '"max_uncollapsed_toc_items": null, "parmenu_position": 1}',
                     "real_name": "Test user 1",
                 },
                 "velps": [],
@@ -217,6 +217,7 @@ type: python
                 "use_document_word_list": False,
                 "word_list": "",
                 "parmenu_position": 1,
+                "quick_select_style_doc_ids": [],
             },
         )
         self.json_post(
@@ -234,6 +235,7 @@ type: python
                 "remember_last_sidebar_menu_tab": True,
                 "auto_mark_all_read": True,
                 "parmenu_position": 0,
+                "quick_select_style_doc_ids": [],
             },
         )
         self.get(
@@ -253,6 +255,7 @@ type: python
                 "auto_mark_all_read": True,
                 "bookmarks": None,
                 "parmenu_position": 0,
+                "quick_select_style_doc_ids": [],
             },
         )
         self.json_post(
@@ -269,6 +272,7 @@ type: python
                 "remember_last_sidebar_menu_tab": True,
                 "auto_mark_all_read": False,
                 "parmenu_position": 1,
+                "quick_select_style_doc_ids": [],
             },
         )
         self.get(
@@ -288,6 +292,7 @@ type: python
                 "max_uncollapsed_toc_items": None,
                 "bookmarks": None,
                 "parmenu_position": 1,
+                "quick_select_style_doc_ids": [],
             },
         )
 

--- a/timApp/user/preferences.py
+++ b/timApp/user/preferences.py
@@ -34,6 +34,7 @@ class Preferences:
     email_exclude: str = ""
     language: str | None = None
     style_doc_ids: list[int] = attr.Factory(list)
+    quick_select_style_doc_ids: list[int] = attr.Factory(list)
     last_answer_fetch: dict[str, str] = attr.Factory(dict)
     auto_mark_all_read: bool = False
     bookmarks: BookmarkCollection | None = None

--- a/timApp/user/settings/settings.py
+++ b/timApp/user/settings/settings.py
@@ -2,27 +2,43 @@
 from dataclasses import field
 from typing import Any, Sequence
 
-from flask import render_template, flash, Response
+from flask import render_template, flash, Response, session
 from flask import request
 from flask_babel import refresh
 from jinja2 import TemplateNotFound
-from sqlalchemy import select
+from sqlalchemy import select, Row
 
 from timApp.admin.user_cli import do_soft_delete
 from timApp.answer.answer_models import AnswerUpload
 from timApp.answer.routes import hide_points, hide_points_modifier
-from timApp.auth.accesshelper import verify_logged_in, verify_admin, verify_view_access
+from timApp.auth.accesshelper import (
+    verify_logged_in,
+    verify_admin,
+    verify_view_access,
+    get_doc_or_abort,
+)
+from timApp.auth.get_user_rights_for_item import get_user_rights_for_item
 from timApp.auth.sessioninfo import get_current_user_object, clear_session
 from timApp.document.docentry import DocEntry
+from timApp.document.viewcontext import default_view_ctx, ViewRoute
 from timApp.folder.folder import Folder
 from timApp.item.block import Block, BlockType
 from timApp.notification.notify import get_current_user_notifications
 from timApp.timdb.sqa import db, run_sql
 from timApp.user.consentchange import ConsentChange
 from timApp.user.preferences import Preferences
-from timApp.user.settings.style_utils import is_style_doc
+from timApp.user.settings.style_utils import (
+    is_style_doc,
+    StyleForUserContext,
+    get_style_for_user,
+)
 from timApp.user.user import User, Consent, get_owned_objects_query
-from timApp.util.flask.requesthelper import get_option, RouteException, NotExist
+from timApp.util.flask.requesthelper import (
+    get_option,
+    RouteException,
+    NotExist,
+    view_ctx_with_urlmacros,
+)
 from timApp.util.flask.responsehelper import json_response, ok_response
 from timApp.util.flask.typedblueprint import TypedBlueprint
 
@@ -51,6 +67,64 @@ def show() -> str:
 @settings_page.get("/get")
 def get_settings() -> Response:
     return json_response(get_current_user_object().get_prefs())
+
+
+@settings_page.get("/quickThemes")
+def get_quick_themes() -> Response:
+    verify_logged_in()
+    user = get_current_user_object()
+    prefs = user.get_prefs()
+    ordering = {d: i for i, d in enumerate(prefs.quick_select_style_doc_ids)}
+
+    current_quick_select = set(session.get("quick_select_styles", []))
+
+    style_doc_names: Sequence[Row[tuple[int, str]]] = run_sql(
+        select(DocEntry.id, Block.description)
+        .join(Block)
+        .filter(DocEntry.id.in_(prefs.quick_select_style_doc_ids))
+    ).all()
+
+    return json_response(
+        sorted(
+            [
+                {
+                    "id": doc_id,
+                    "title": title,
+                    "enabled": doc_id in current_quick_select,
+                }
+                for doc_id, title in style_doc_names
+            ],
+            key=lambda d: ordering[d["id"]],
+        )
+    )
+
+
+@settings_page.post("/quickThemes")
+def set_quick_themes(
+    themes: list[int], doc_id: int | None = None, view_route: str | None = None
+) -> Response:
+    verify_logged_in()
+    user = get_current_user_object()
+    prefs = user.get_prefs()
+
+    selectable_quick_select = set(prefs.quick_select_style_doc_ids)
+    themes = [t for t in themes if t in selectable_quick_select]
+    session["quick_select_styles"] = themes
+
+    style_context = None
+    if doc_id:
+        doc_info = get_doc_or_abort(doc_id)
+        view_ctx = (
+            default_view_ctx
+            if not view_route or view_route not in ViewRoute.__members__.keys()
+            else view_ctx_with_urlmacros(ViewRoute(view_route))
+        )
+        user_rights = get_user_rights_for_item(doc_info, user)
+        style_context = StyleForUserContext(
+            doc_info=doc_info, view_ctx=view_ctx, user_rights=user_rights
+        )
+
+    return json_response({"style_path": get_style_for_user(prefs, style_context)})
 
 
 def verify_new_styles(curr_styles: list[int], new_styles: list[int]) -> None:
@@ -91,6 +165,9 @@ def save_settings() -> Response:
             j[attr] = val
         new_prefs = Preferences.from_json(j)
         verify_new_styles(curr_prefs.style_doc_ids, new_prefs.style_doc_ids)
+        verify_new_styles(
+            curr_prefs.quick_select_style_doc_ids, new_prefs.quick_select_style_doc_ids
+        )
         user.set_prefs(new_prefs)
     except TypeError as e:
         raise RouteException(f"Invalid settings: {e}")


### PR DESCRIPTION
Quick themes are toggle buttons in the Settings tab that allow to quickly enable and disable user themes. The selections are preserved on a per-session basis, allowing to modify which styles to keep enabled for different devices.

For example, the feature can be used to add a toggle button for one's favorite dark theme and have it easily be enabled or disabled for different devices.