### PR TITLE
Add user setting for header menu (navbar) visibility

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -3601,8 +3601,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="582891413766289599" datatype="html">
-        <source> This email is managed by <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong
-                                    [style.color]=&quot;originInfo.bgColor&quot;&gt;"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="."/>. The address will be automatically updated by the system. </source>
+        <source> This email is managed by <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong                                     [style.color]=&quot;originInfo.bgColor&quot;>"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="."/>. The address will be automatically updated by the system. </source>
         <target state="translated"> Tätä sähköpostiosoitetta hallinnoi <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong [style.color]=&quot;originInfo.bgColor&quot;>"/><x id="INTERPOLATION" equiv-text="{{originInfo.name}}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>-järjestelmä. Järjestelmä voi automaattisesti päivittää tämän osoitteen. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
@@ -9162,7 +9161,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="8054904775519687363" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="User"/>User-made styles<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> are made and maintained by TIM&apos;s users. For more information, see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;/view/tim/ohjeita/styles&quot;&gt;"/>style authoring guide<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="User"/>User-made styles<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> are made and maintained by TIM's users. For more information, see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;/view/tim/ohjeita/styles&quot;>"/>style authoring guide<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </source>
         <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>Käyttäjätyylit<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> ovat TIM-käyttäjien luomat. Katso <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;/view/tim/ohjeita/styles&quot;>"/>tyylien laadintaopas<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> lisätietoja varten.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
@@ -9175,6 +9174,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
           <context context-type="linenumber">336,337</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3858364302339756970" datatype="html">
+        <source>Header menu (Navigation bar)</source>
+        <target state="translated">Ylämenu (navigointipalkki)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">424,425</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="653934982330202983" datatype="html">
+        <source>Always show navigation bar (unless overridden in document settings)</source>
+        <target state="translated">Näytä navigointipalkki aina (ellei tätä asetusta ohiteta dokumenttiasetuksilla)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">431</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -5059,8 +5059,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="582891413766289599" datatype="html">
-        <source> This email is managed by <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong
-                                    [style.color]=&quot;originInfo.bgColor&quot;&gt;"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="."/>. The address will be automatically updated by the system. </source>
+        <source> This email is managed by <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong                                     [style.color]=&quot;originInfo.bgColor&quot;>"/><x id="INTERPOLATION"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="."/>. The address will be automatically updated by the system. </source>
         <target state="translated"> Det här e-postmeddelandet hanteras av <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong                                     [style.color]=&quot;originInfo.bgColor&quot;>"/><x id="INTERPOLATION" equiv-text="{{originInfo.name}}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/>. Adressen kommer automatiskt att uppdateras av systemet. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
@@ -9048,8 +9047,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="8720702577528832728" datatype="html">
-        <source> You have no quick styles selected. You can add styles via the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;&gt;"/>Available styles<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> tab. </source>
-        <target state="new"> You have no quick styles selected. You can add styles via the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;&gt;"/>Available styles<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> tab. </target>
+        <source> You have no quick styles selected. You can add styles via the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;>"/>Available styles<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> tab. </source>
+        <target state="new"> You have no quick styles selected. You can add styles via the <x id="START_LINK" ctype="x-a" equiv-text="&lt;a (click)=&quot;changeStyleTab(1)&quot;>"/>Available styles<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> tab. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
           <context context-type="linenumber">206,207</context>
@@ -9064,7 +9063,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="8054904775519687363" datatype="html">
-        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="User"/>User-made styles<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> are made and maintained by TIM&apos;s users. For more information, see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;/view/tim/ohjeita/styles&quot;&gt;"/>style authoring guide<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>. </source>
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="User"/>User-made styles<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> are made and maintained by TIM's users. For more information, see <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;/view/tim/ohjeita/styles&quot;>"/>style authoring guide<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </source>
         <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>Användargjorda stilar<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> skapas och underhålls av TIMs användare. För mer information, se <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;/view/tim/ohjeita/styles&quot;>"/>guide för stilförfattare<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
@@ -9077,6 +9076,22 @@
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
           <context context-type="linenumber">336,337</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3858364302339756970" datatype="html">
+        <source>Header menu (Navigation bar)</source>
+        <target state="translated">Rubrikmeny (navigeringsfält)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">424,425</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="653934982330202983" datatype="html">
+        <source>Always show navigation bar (unless overridden in document settings)</source>
+        <target state="translated">Visa alltid navigeringsfältet (om det inte åsidosätts i dokumentinställningarna)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">431</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/static/scripts/tim/header/site-header.component.ts
+++ b/timApp/static/scripts/tim/header/site-header.component.ts
@@ -87,6 +87,11 @@ export class SiteHeaderComponent implements OnInit {
                 this.displayViewHeader =
                     globals.docSettings.displayViewInitialState;
             }
+            // If not set in document settings, allow user setting to determine default header menu open state
+            else {
+                this.displayViewHeader =
+                    globals.userPrefs.always_show_header_menu;
+            }
         }
 
         this.updateHeaderMenuVisibility();

--- a/timApp/static/scripts/tim/user/settings.component.ts
+++ b/timApp/static/scripts/tim/user/settings.component.ts
@@ -420,7 +420,18 @@ type StyleSelectionType =
                             Clear
                         </button>
                     </div>
-
+                    
+                    <span i18n>Header menu (Navigation bar)</span>
+                    <div>
+                        <div class="checkbox">
+                            <label>
+                                <input type="checkbox" name="header_menu_default_visibility"
+                                       [(ngModel)]="settings.always_show_header_menu"
+                                       [disabled]="saving">
+                                <ng-container i18n>Always show navigation bar (unless overridden in document settings)</ng-container>
+                            </label>
+                        </div>
+                    </div>
                     <span i18n>Opening settings</span>
                     <div>
                         <div class="checkbox">

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -190,6 +190,7 @@ export interface ISettings {
     style_doc_ids: number[];
     quick_select_style_doc_ids: number[];
     parmenu_position: number;
+    always_show_header_menu: boolean;
 }
 
 export interface ILectureInfoGlobals extends IDocumentGlobals {

--- a/timApp/tests/server/test_settings.py
+++ b/timApp/tests/server/test_settings.py
@@ -105,7 +105,7 @@ class SettingsTest(TimRouteTest):
                     '"last_answer_fetch": {}, "auto_mark_all_read": false, '
                     '"bookmarks": [{"Last edited": [{"document 2": '
                     '"/view/users/test-user-1/doc1"}]}], '
-                    '"max_uncollapsed_toc_items": null, "parmenu_position": 1}',
+                    '"max_uncollapsed_toc_items": null, "parmenu_position": 1, "always_show_header_menu": false}',
                     "real_name": "Test user 1",
                 },
                 "velps": [],
@@ -218,6 +218,7 @@ type: python
                 "word_list": "",
                 "parmenu_position": 1,
                 "quick_select_style_doc_ids": [],
+                "always_show_header_menu": False,
             },
         )
         self.json_post(
@@ -236,6 +237,7 @@ type: python
                 "auto_mark_all_read": True,
                 "parmenu_position": 0,
                 "quick_select_style_doc_ids": [],
+                "always_show_header_menu": True,
             },
         )
         self.get(
@@ -256,6 +258,7 @@ type: python
                 "bookmarks": None,
                 "parmenu_position": 0,
                 "quick_select_style_doc_ids": [],
+                "always_show_header_menu": True,
             },
         )
         self.json_post(
@@ -273,6 +276,7 @@ type: python
                 "auto_mark_all_read": False,
                 "parmenu_position": 1,
                 "quick_select_style_doc_ids": [],
+                "always_show_header_menu": False,
             },
         )
         self.get(
@@ -293,6 +297,7 @@ type: python
                 "bookmarks": None,
                 "parmenu_position": 1,
                 "quick_select_style_doc_ids": [],
+                "always_show_header_menu": False,
             },
         )
 

--- a/timApp/user/preferences.py
+++ b/timApp/user/preferences.py
@@ -40,6 +40,7 @@ class Preferences:
     bookmarks: BookmarkCollection | None = None
     max_uncollapsed_toc_items: int | None = None
     parmenu_position: int = ParMenuPosition.Right
+    always_show_header_menu: bool = False
 
     @staticmethod
     def from_json(j: dict) -> "Preferences":


### PR DESCRIPTION
Adds a user setting to control header menu default visibility. Document settings still override the user setting.