### PR TITLE
Python auto plot

### DIFF
--- a/timApp/modules/cs/cs.py
+++ b/timApp/modules/cs/cs.py
@@ -24,7 +24,7 @@ from traceback import print_exc
 from urllib.request import urlopen
 
 from cs_logging import get_logger
-from cs_utils import replace_code, check_parsons
+from cs_utils import replace_code, check_parsons, text_value_replace
 from file_handler import FileHandler
 from file_util import write_safe, rm, rm_safe
 from languages import dummy_language, sanitize_cmdline
@@ -78,6 +78,7 @@ from tim_common.fileParams import (
     replace_program_tokens,
 )
 from ttype import TType
+
 
 #  uid = pwd.getpwnam('agent')[2]
 #  os.setuid(uid)
@@ -712,7 +713,7 @@ def handle_common_params(query: QueryClass, ttype: TType):
         "tauno",
         "parsons",
     ]:  # TODO: make tauno, simcir and parsons work without this
-        if not "markup" in js or js["markup"] is None:
+        if "markup" not in js or js["markup"] is None:
             js["markup"] = {}
         js["markup"]["type"] = str(ttype)
 
@@ -1478,7 +1479,7 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
             # Check query parameters
             p0 = FileParams(query, "", "")
 
-            usercode_edit_rules = query.jso.get("markup", {}).get("usercodeEdit", None)
+            usercode_edit_rules = get_param(query, "usercodeEdit", None)
             if p0.by and usercode_edit_rules:
                 p0.by = replace_code(usercode_edit_rules, p0.by)
 
@@ -1997,18 +1998,8 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
             removedir(language.prgpath)
 
         out = out[0 : get_param(query, "maxConsole", 20000)]
-
-        out_replace = get_param(query, "outReplace", None)
-        out_by = get_param(query, "outBy", "")
-        if out_replace:
-            # if type(out_replace) is list:
-            if isinstance(out_replace, list):
-                for rep in out_replace:
-                    replace = rep.get("replace", "")
-                    if replace:
-                        out = re.sub(replace, rep.get("by", out_by), out, flags=re.M)
-            else:
-                out = re.sub(out_replace, out_by, out, flags=re.M)
+        out = text_value_replace(query, out, "outReplace", "outBy")
+        err = text_value_replace(query, err, "errReplace", "errBy")
 
         stdout = get_param(query, "stdout", None)
         if stdout:

--- a/timApp/modules/cs/cs_utils.py
+++ b/timApp/modules/cs/cs_utils.py
@@ -1,5 +1,5 @@
 import re
-from tim_common.fileParams import get_2_items
+from tim_common.fileParams import get_2_items, get_param, QueryClass
 
 
 def replace_code(rules: list, s: str) -> str:
@@ -86,3 +86,19 @@ def check_parsons(
     if p == len(exlines) and p == len(usrlines):
         return 1, correct
     return 0, correct
+
+
+def text_value_replace(
+    query: QueryClass, text: str, replace_key: str, by_key: str
+) -> str:
+    text_replace = get_param(query, replace_key, None)
+    text_by = get_param(query, by_key, "")
+    if text_replace:
+        if isinstance(text_replace, list):
+            for rep in text_replace:
+                replace = rep.get("replace", "")
+                if replace:
+                    text = re.sub(replace, rep.get("by", text_by), text, flags=re.M)
+        else:
+            text = re.sub(text_replace, text_by, text, flags=re.M)
+    return text

--- a/tim_common/fileParams.py
+++ b/tim_common/fileParams.py
@@ -26,6 +26,8 @@ class QueryClass:
         self.jso = None
         self.deleted = {}
         self.randomcheck = ""
+        self.cut_errors = []
+        self.hide_program = False
 
     def set_jso_param(self, value, *keys):
         if self.jso is None:

--- a/tim_common/utils.py
+++ b/tim_common/utils.py
@@ -124,3 +124,25 @@ class DurationField(marshmallow.fields.Field):
 
 class DurationSchema(marshmallow.Schema):
     TYPE_MAPPING = {Duration: DurationField}
+
+
+def replace_in_file(file_path: str, pattern: str, replacement: str) -> int:
+    """
+    Replace a pattern in a file.
+    :param file_path:   from which file to replace
+    :param pattern:     what to replace
+    :param replacement: with what to replace
+    :return:            number of replacements
+    """
+    with open(file_path, "r") as file:
+        content = file.read()
+
+    new_content, num_replacements = re.subn(
+        pattern, replacement, content, flags=re.MULTILINE
+    )
+
+    if num_replacements > 0:
+        with open(file_path, "w") as file:
+            file.write(new_content)
+
+    return num_replacements


### PR DESCRIPTION
Tarkoituksen oli saada --autoplot -optio, jolla Python ohjelma muuttaa komennon plt.show()
sellaiseksi että se tallentuu tiedostoon ja se nostetaan clientille.  Eli tavoite oli että
sama ohjelma toimii headless ja näytön kanssa.

En tiedä kuinka sekaisin meni, kun se pycharmin vaihto jotenkin sotki koko jutun ja vaihdon jälkeen koodasinkin
huomaamatta master-haarassa (joka on nyt mulla ihan sekaisin)

Isoimmat muutokset tein languages.py kohtaan PY3
Sitten jonkin verran muuttelin attribuutteja cs.py.  Loput muutokset on vain koodin
siirtämistä metodeiksi cs/cs_utils.py ja tim_common/utils.py tiedostoissa.
Pari alustusta tuli fileparams.py.

commit oli 6918ace5a