### PR TITLE
Fix Answerbrowser shortcuts

### DIFF
--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1028,15 +1028,15 @@ export class AnswerBrowserComponent
                 await this.changeStudent(1);
                 return true;
             } else if (
-                (e.altKey && e.key === "ArrowLeft") ||
-                e.which === KEY_LEFT
+                e.altKey &&
+                (e.key === "ArrowLeft" || e.which === KEY_LEFT)
             ) {
                 e.preventDefault();
                 await this.changeAnswerTo(-1);
                 return true;
             } else if (
-                (e.altKey && e.key === "ArrowRight") ||
-                e.which === KEY_RIGHT
+                e.altKey &&
+                (e.key === "ArrowRight" || e.which === KEY_RIGHT)
             ) {
                 e.preventDefault();
                 await this.changeAnswerTo(1);

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1017,7 +1017,7 @@ export class AnswerBrowserComponent
         if (this.loading > 0 || this.hidden) {
             return false;
         }
-        if (e.ctrlKey) {
+        if (e.ctrlKey && e.altKey) {
             // e.key does not work on IE but it is more readable, so let's use both
             if (e.key === "ArrowUp" || e.which === KEY_UP) {
                 e.preventDefault();

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1017,7 +1017,7 @@ export class AnswerBrowserComponent
         if (this.loading > 0 || this.hidden) {
             return false;
         }
-        if (e.ctrlKey && e.altKey) {
+        if (e.ctrlKey) {
             // e.key does not work on IE but it is more readable, so let's use both
             if (e.key === "ArrowUp" || e.which === KEY_UP) {
                 e.preventDefault();
@@ -1027,11 +1027,17 @@ export class AnswerBrowserComponent
                 e.preventDefault();
                 await this.changeStudent(1);
                 return true;
-            } else if (e.key === "ArrowLeft" || e.which === KEY_LEFT) {
+            } else if (
+                (e.altKey && e.key === "ArrowLeft") ||
+                e.which === KEY_LEFT
+            ) {
                 e.preventDefault();
                 await this.changeAnswerTo(-1);
                 return true;
-            } else if (e.key === "ArrowRight" || e.which === KEY_RIGHT) {
+            } else if (
+                (e.altKey && e.key === "ArrowRight") ||
+                e.which === KEY_RIGHT
+            ) {
                 e.preventDefault();
                 await this.changeAnswerTo(1);
                 return true;


### PR DESCRIPTION
Currently, keyboard shortcuts in the AnswerBrowser component interfere with standard, built-in keyboard controls for textfields and textareas, mainly

- `CTRL + left arrow` and
- `CTRL + right arrow`,

which are normally used to move the cursor left and right a whole word at a time when navigating (editable) text content.

This behaviour in the answerbrowser results in frequent disruptions, for example, when adding annotations to students' answers and subsequently adding comments to those annotations: since the answerbrowser hijacks the keyboard event from the textfield, trying to navigate the comment text while editing it via the `CTRL + left/right arrow` results in changing the active answer.

This PR corrects this behaviour by adding the `ALT` modifier key to the conflicting AnswerBrowser shortcuts:

`CTRL + ALT + ArrowLeft`: Previous answer \
`CTRL + ALT + ArrowRight`: Next answer 
