### PR TITLE
Disable logging debug information to browser console and server logs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install APT Packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@v1.0.1
         with:
           packages: libxmlsec1-dev libxmlsec1-openssl
           version: "1.1"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install APT Packages
-        uses: awalsh128/cache-apt-pkgs-action@v1.0.1
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.2
         with:
           packages: libxmlsec1-dev libxmlsec1-openssl
           version: "1.1"

--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -205,8 +205,7 @@ class DocSettings:
     def get_setting_or_default(self, name: str, default: T) -> T:
         try:
             return doc_setting_field_map[name].deserialize(self.__dict.get(name))
-        except ValidationError as e:
-            print(e)
+        except ValidationError:
             return default
 
     def __init__(self, doc: "Document", settings_dict: YamlBlock | None = None):

--- a/timApp/modules/feedback/js/feedback.ts
+++ b/timApp/modules/feedback/js/feedback.ts
@@ -18,7 +18,7 @@ import {
     withDefault,
 } from "tim/plugin/attributes";
 import {documentglobals} from "tim/util/globals";
-import {injectStyle, log} from "tim/util/utils";
+import {injectStyle} from "tim/util/utils";
 import type {EditMode} from "tim/document/popup-menu-dialog.component";
 import {HttpClientModule} from "@angular/common/http";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
@@ -1058,7 +1058,7 @@ export class FeedbackPluginComponent
         if (timComponent) {
             const content = timComponent.getPar()?.getContent();
             if (!content) {
-                log("Not in paragraph, skipping getting answers");
+                // log("Not in paragraph, skipping getting answers");
                 return [];
             }
             // Add additional nodes to be accepted if the need arises.

--- a/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
+++ b/timApp/static/scripts/tim/plugin/tim-menu/tim-menu-plugin.component.ts
@@ -218,7 +218,7 @@ export class TimMenuPluginComponent
             return;
         }
         this.menu = this.attrsall.menu;
-        console.log(this.menu);
+        // console.log(this.menu);
         this.separator = this.markup.separator;
         this.topMenu = this.markup.topMenu;
         this.openAbove = this.markup.openAbove;

--- a/timApp/static/scripts/tim/ui/draggable.ts
+++ b/timApp/static/scripts/tim/ui/draggable.ts
@@ -227,7 +227,7 @@ export class DraggableController implements IController {
             }
             this.element.removeClass("draggable-detached");
             this.element.addClass("draggable-attached");
-            console.log("attach", this.slidePars);
+            // console.log("attach", this.slidePars);
             if (this.slidePars) {
                 vctrlInstance?.removeSlideParsState();
             }
@@ -237,7 +237,7 @@ export class DraggableController implements IController {
             void this.restoreSizeAndPosition(VisibilityFix.Full);
             this.element.removeClass("draggable-attached");
             this.element.addClass("draggable-detached");
-            console.log("detach", this.slidePars);
+            // console.log("detach", this.slidePars);
             if (this.slidePars) {
                 vctrlInstance?.addSlideParsState();
             }

--- a/timApp/static/scripts/tim/user/userService.ts
+++ b/timApp/static/scripts/tim/user/userService.ts
@@ -158,7 +158,7 @@ export class UserService {
             (g) => `answer_review_group:${g.name}`
         );
         const res = groupReviewTags.some((tag) => activeTags.has(tag));
-        console.log(activeTags, groupReviewTags, res);
+        // console.log(activeTags, groupReviewTags, res);
         return res;
     }
 }

--- a/timApp/static/scripts/tim/velp/reviewController.ts
+++ b/timApp/static/scripts/tim/velp/reviewController.ts
@@ -35,7 +35,6 @@ import {
     checkIfElement,
     getElementParent,
     isText,
-    log,
     to,
     truncate,
 } from "tim/util/utils";

--- a/timApp/static/scripts/tim/velp/reviewController.ts
+++ b/timApp/static/scripts/tim/velp/reviewController.ts
@@ -477,8 +477,6 @@ export class ReviewController {
                         a,
                         AnnotationAddReason.LoadingExisting
                     );
-                } else {
-                    log("annotation range invalid, adding to margin only");
                 }
             }
             this.addAnnotationToMargin(
@@ -1440,7 +1438,7 @@ export class ReviewController {
         }
         const parent = document.getElementById(annotation.coord.start.par_id);
         if (parent == null) {
-            log(`par ${annotation.coord.start.par_id} not found`);
+            // log(`par ${annotation.coord.start.par_id} not found`);
             return;
         }
 
@@ -1475,7 +1473,6 @@ export class ReviewController {
         }
 
         if (!annotation.answer) {
-            log("annotation.answer is null");
             return;
         }
         // Find answer browser and its scope
@@ -1483,12 +1480,16 @@ export class ReviewController {
         // query selector element -> toggle annotation
         const loader = parent.getElementsByTagName("TIM-PLUGIN-LOADER")[0];
         if (!loader) {
-            log("tim-plugin-loader not found");
+            console.error(
+                `tim-plugin-loader not found in parent element \'${parent.id}\'`
+            );
             return;
         }
         const taskId = loader.getAttribute("task-id");
         if (!taskId) {
-            log("task-id missing");
+            console.error(
+                `task-id missing from plugin loader \'${loader.id}\'`
+            );
             return;
         }
         let ab = this.getAnswerBrowserFromPluginLoader(loader) ?? null;
@@ -1496,13 +1497,17 @@ export class ReviewController {
         if (!ab) {
             const loaderCtrl = this.vctrl.getPluginLoader(taskId);
             if (!loaderCtrl) {
-                log("getPluginLoader failed");
+                console.error(
+                    `getPluginLoader failed for task id \'${taskId}\'`
+                );
                 return;
             }
             loaderCtrl.loadPlugin();
             ab = await loaderCtrl.abLoad.promise;
             if (!ab) {
-                log("plugin has no answerbrowser");
+                const pluginName =
+                    loaderCtrl.parsedTaskId?.name ?? loaderCtrl.taskId;
+                console.warn(`plugin ${pluginName} has no answerbrowser`);
                 return;
             }
         }
@@ -1528,10 +1533,12 @@ export class ReviewController {
         }
         let r = await to(this.vctrl.getAnnotationAsync(prefix + annotation.id));
         if (!r.ok) {
-            log("falling back to showing margin annotation");
+            // log("falling back to showing margin annotation");
             r = await to(this.vctrl.getAnnotationAsync("m" + annotation.id));
             if (!r.ok) {
-                log("getAnnotationAsync failed even for margin");
+                console.error(
+                    `getAnnotationAsync failed even for annotation \'${annotation.id}\'`
+                );
                 return;
             }
         }


### PR DESCRIPTION
Comments out some console logging that had, apparently, been used for debugging.

Console logging is still being used in some older components, see:

[log(string) from utils.ts](https://github.com/TIM-JYU/TIM/blob/cd708cc8093a1086194f7295b0aec1030dcecb56/timApp/static/scripts/tim/util/utils.ts#L852-L854)
[feedback.ts](https://github.com/TIM-JYU/TIM/blob/cd708cc8093a1086194f7295b0aec1030dcecb56/timApp/modules/feedback/js/feedback.ts#L1061)
[reviewController.ts, multiple cases](https://github.com/TIM-JYU/TIM/blob/cd708cc8093a1086194f7295b0aec1030dcecb56/timApp/static/scripts/tim/velp/reviewController.ts#L481)

Also, one print on server side caused many unnecessary logs:
[docsettings.py](https://github.com/TIM-JYU/TIM/pull/3766/files#diff-0820db03e88f58f7acaddf4d8b3fb5313cd5682a24a0ee8e67fd241bfc372c9aL208-L209)

These are now either removed, or logged as errors/warnings (instead of regular log messages).