### PR TITLE
AnswerBrowser: use regular year numbering instead of week numbering

### DIFF
--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -61,7 +61,7 @@
                                     title="List of answers"
                                     [(ngModel)]="selectedAnswer"
                                     (ngModelChange)="changeAnswer(undefined,undefined, true)">
-                                 <option *ngFor="let answer of filteredAnswers; let idx = index" [ngValue]="answer">{{((filteredAnswers.length - idx) + '. ' + (answer.answered_on |  date:'dd.MM.YYYY HH:mm:ss' ))}}</option>
+                                 <option *ngFor="let answer of filteredAnswers; let idx = index" [ngValue]="answer">{{((filteredAnswers.length - idx) + '. ' + (answer.answered_on |  date:'dd.MM.yyyy HH:mm:ss' ))}}</option>
                             </select>
                             <span class="input-group-btn">
                     <button i18n-title title="Next answer" class="btn btn-primary nextAnswer" (click)="changeAnswerTo(1)">&rarr;</button>
@@ -298,13 +298,13 @@
             <span class="answeringTime" *ngIf="taskInfo.starttime || taskInfo.deadline">
         <ng-container i18n>Answering time:</ng-container>
         <span *ngIf="taskInfo.starttime && !taskInfo.deadline">
-            <ng-container i18n>Since</ng-container> {{ taskInfo.starttime | date:'dd.MM.YYYY HH:mm:ss' }}
+            <ng-container i18n>Since</ng-container> {{ taskInfo.starttime | date:'dd.MM.yyyy HH:mm:ss' }}
         </span>
         <span *ngIf="!taskInfo.starttime && taskInfo.deadline">
-            <ng-container i18n>Until</ng-container> {{ taskInfo.deadline | date:'dd.MM.YYYY HH:mm:ss' }}
+            <ng-container i18n>Until</ng-container> {{ taskInfo.deadline | date:'dd.MM.yyyy HH:mm:ss' }}
         </span>
         <span *ngIf="taskInfo.starttime && taskInfo.deadline">
-            {{ taskInfo.starttime | date:'dd.MM.YYYY HH:mm:ss' }} - {{ taskInfo.deadline | date:'dd.MM.YYYY HH:mm:ss' }}
+            {{ taskInfo.starttime | date:'dd.MM.yyyy HH:mm:ss' }} - {{ taskInfo.deadline | date:'dd.MM.yyyy HH:mm:ss' }}
         </span>
     </span>
     </ng-container>


### PR DESCRIPTION
https://timbeta03.tim.education/view/users/test-user-1/datetime vs https://tim.jyu.fi/view/users/sijualle/kokeiluja/datetime

Vaihdoin toistaiseksi vain tuon answerbrowserin, muualla ei käytetä tuota date-pipea ja näytti menevän ajat oikein:
![kuva](https://github.com/user-attachments/assets/0e356d0b-83c6-4f97-b23c-e8b7f3371efa)
