### PR TITLE
config: require SameSite=Lax for session cookies

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -169,10 +169,15 @@ HOME_ORGANIZATION = "jyu.fi"
 LOAD_STUDENT_IDS_IN_TEACHER = False
 
 HAS_HTTPS = TIM_HOST.startswith("https:")
-SESSION_COOKIE_SAMESITE = (
-    "None" if HAS_HTTPS else None
-)  # Required for Aalto iframe to work.
-SESSION_COOKIE_SECURE = HAS_HTTPS  # Required by Chrome due to SameSite=None setting.
+
+# Following current web dev recommendations, first-party cookies must be marked with either
+# SameSite=Lax or SameSite=Strict. See
+# https://web.dev/articles/first-party-cookie-recipes#the_good_first-party_cookie_recipe
+# TODO: For cases where sessions are used across different domains, we need to provide
+#     a list of allowed domains for which to allow the session cookie as a third-party cookie.
+#     Or see e.g., https://developers.google.com/privacy-sandbox/cookies/chips
+SESSION_COOKIE_SAMESITE = "Lax" if HAS_HTTPS else None
+SESSION_COOKIE_SECURE = HAS_HTTPS  # Require HTTPS or localhost for session cookies
 
 BOOKMARKS_ENABLED = True
 

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -417,10 +417,20 @@ def after_request(resp: Response):
     # lang is used to preserve the active language preference which may be either
     # a specific language or "UseWebBrowser" which defaults to browser preference
     if not request.cookies.get("lang"):
-        resp.set_cookie("lang", locale)
+        resp.set_cookie(
+            "lang",
+            locale,
+            samesite=app.config["SESSION_COOKIE_SAMESITE"],
+            secure=app.config["SESSION_COOKIE_SECURE"],
+        )
     # script_lang is used by Caddy to serve correct Angular scripts
     # It always contains a specific valid language, never "UseWebBrowser"
-    resp.set_cookie("script_lang", locale)
+    resp.set_cookie(
+        "script_lang",
+        locale,
+        samesite=app.config["SESSION_COOKIE_SAMESITE"],
+        secure=app.config["SESSION_COOKIE_SECURE"],
+    )
     return resp
 
 

--- a/timApp/user/settings/settings.py
+++ b/timApp/user/settings/settings.py
@@ -24,6 +24,7 @@ from timApp.document.viewcontext import default_view_ctx, ViewRoute
 from timApp.folder.folder import Folder
 from timApp.item.block import Block, BlockType
 from timApp.notification.notify import get_current_user_notifications
+from timApp.tim_app import app
 from timApp.timdb.sqa import db, run_sql
 from timApp.user.consentchange import ConsentChange
 from timApp.user.preferences import Preferences
@@ -179,7 +180,12 @@ def save_settings() -> Response:
     db.session.commit()
     r = json_response(user.get_prefs().to_json(with_style=True))
     if new_prefs.language:
-        r.set_cookie("lang", new_prefs.language)
+        r.set_cookie(
+            "lang",
+            new_prefs.language,
+            samesite=app.config["SESSION_COOKIE_SAMESITE"],
+            secure=app.config["SESSION_COOKIE_SECURE"],
+        )
     return r
 
 
@@ -191,7 +197,12 @@ def save_language_route(lang: str) -> Response:
     u.set_prefs(prefs)
     db.session.commit()
     r = ok_response()
-    r.set_cookie("lang", lang)
+    r.set_cookie(
+        "lang",
+        lang,
+        samesite=app.config["SESSION_COOKIE_SAMESITE"],
+        secure=app.config["SESSION_COOKIE_SECURE"],
+    )
 
     refresh()
 

--- a/timApp/util/locale.py
+++ b/timApp/util/locale.py
@@ -1,4 +1,4 @@
-from flask import request, Response
+from flask import request, Response, current_app
 
 from timApp.auth.sessioninfo import (
     logged_in,
@@ -26,7 +26,12 @@ def get_locale(force_refresh: bool = False) -> str:
 
 
 def update_locale_lang(resp: Response) -> Response:
-    resp.set_cookie("lang", get_locale(force_refresh=True))
+    resp.set_cookie(
+        "lang",
+        get_locale(force_refresh=True),
+        samesite=current_app.config["SESSION_COOKIE_SAMESITE"],
+        secure=current_app.config["SESSION_COOKIE_SECURE"],
+    )
     return resp
 
 


### PR DESCRIPTION
Due to changes in how Chrome handles third-party cookies, this commit makes session cookie a first-party cookie by setting SameSite=Lax. This essentially restricts the use of the cookie within the TIM website.

***

Chrome on alkanut varoittaa siitä, että kolmannen osapuolten keksejä (=keksit, joita lähetetään sivulle jonkun ulkopuolisen sivun kautta, [katso MDN](https://developer.mozilla.org/en-US/docs/Web/Privacy/Third-party_cookies)) mahdollisesti estetään ellei niitä konfiguroi oikein. Uusimmilla Chromen versioilla tulee devauskonsoliin seuraavia viestejä:

```
Chrome is moving towards a new experience that allows users to choose to browse without third-party cookies.
``` 

Tällä hetkellä TIMin sessiokekseille asetetaan `SameSite=None`, mikä sallii sessiokeksin lähettämisen mistä tahansa TIMin ulkopuoliselta sivulta esim. print-polun, files-polun tai iframen kautta. Chrome varoittaa, että se jatkossa keksien lähettämisen tällaisissa tapauksissa.
TIMin kannalta tämä ei ole oikeastaan ongelma, mutta olisi hyvä eksplisiittisesti merkitä sessiokeksin ns. ensimmäisen osapuolen keksiksi.

Tämä PR  muuttaa `SameSite`-asetuksen arvoon `Lax`, mikä määrittää TIMin sessiokeksit ensimmäisen osapuolen keksiksi. Käytännössä tämä tarkoittaa, että TIMin sessiokeksi on käytössä vain tim.jyu.fi -domainin alla.
Jatkossa jos sessiokeksiin haluaa päästä TIMin ulkopuolella, pitäisi rakentaa siis erillinen whitelist sallituista domainista. Tästä on nyt vain TODO lisätty, sillä TIMilla ei ole aktiivista integraatiota muista paikoista (oli joskus Aalto, muttei enää).

PR:n myötä Chromen varoitusteksti poistuu.

Testattu timbeta02:lla, että nykyiset TIMin iframet TIMin sisällä eivät mene rikki.
