### PR TITLE
remove minor warnings and add COMPS to get_from_url

### DIFF
--- a/timApp/modules/cs/languages.py
+++ b/timApp/modules/cs/languages.py
@@ -1741,8 +1741,8 @@ class MongoDB(Language):
 # Cassandra Query Language language type
 class CQL(Language):
     ttype = "cql"
-    login_cmd_pattern = re.compile(r"LOGIN\s+[^\s]+(\s+[^\s]+)?\s*[;\n]", re.I)
-    use_cmd_pattern = re.compile(r"USE\s+[^\s]+\s*[;\n]", re.I)
+    login_cmd_pattern = re.compile(r"LOGIN\s+\S+(\s+\S+)?\s*[;\n]", re.I)
+    use_cmd_pattern = re.compile(r"USE\s+\S+\s*[;\n]", re.I)
 
     def __init__(self, query, sourcecode):
         super().__init__(query, sourcecode)

--- a/timApp/modules/svn/svn3.py
+++ b/timApp/modules/svn/svn3.py
@@ -31,7 +31,7 @@ import re
 import socketserver
 import time
 
-from tim_common.dumboclient import DumboOptions, call_dumbo
+from tim_common.dumboclient import call_dumbo
 from tim_common.fileParams import (
     get_param,
     get_surrounding_headers2,
@@ -179,6 +179,10 @@ def get_images_md(query):
                 url = url.get("name", "")
         else:
             url = ""
+    return handle_image_size(query, url)
+
+
+def handle_image_size(query, url):
     w = get_clean_param(query, "width", "")
     h = get_clean_param(query, "height", "")
     w = get_clean_param(query, "texwidth", w)
@@ -201,17 +205,7 @@ def get_image_md(query):
     """
     url = get_clean_param(query, "file", "")
     url = get_clean_param(query, "texfile", url)
-    w = get_clean_param(query, "width", "")
-    h = get_clean_param(query, "height", "")
-    w = get_clean_param(query, "texwidth", w)
-    h = get_clean_param(query, "texheight", h)
-    if w:
-        w = "width=" + w + " "
-    if h:
-        h = "height=" + h + " "
-    header, footer = get_surrounding_md_headers2(query, "pluginHeader", None)
-    result = header + "\n\n" + f"![{footer}]({url}){{{w}{h}}}"
-    return result
+    return handle_image_size(query, url)
 
 
 def get_image_html(query):
@@ -632,45 +626,34 @@ def escape_latex(s: str):
 
 
 def get_md(self, query):
-    is_image = self.path.find("/image/") >= 0
-    is_images = self.path.find("/multiimages/") >= 0
-    is_video = self.path.find("/video/") >= 0
-    is_pdf = self.path.find("/pdf/") >= 0
     is_template = self.path.find("/template") >= 0
     tempfile = get_param(query, "file", "")
 
-    if is_image:
+    if self.path.find("/image/") >= 0:
         if is_template:
             return file_to_string("templates/image/" + tempfile)
         s = get_image_md(query)
         return s
 
-    if is_images:
+    if self.path.find("/multiimages/") >= 0:
         if is_template:
             return file_to_string("templates/images/" + tempfile)
         s = get_images_md(query)
         return s
 
-    if is_video:
+    if self.path.find("/video/") >= 0:
         if is_template:
             return file_to_string("templates/video/" + tempfile)
         s = get_video_md(query)
         return s
 
-    if is_pdf:
+    if self.path.find("/pdf/") >= 0:
         if is_template:
             return file_to_string("templates/pdf/" + tempfile)
         s = get_video_md(query)
         return s
 
     # Was none of special, so print the file(s) in query
-
-    cla = get_param(query, "class", "")
-    w = get_param(query, "width", "")
-    if w:
-        w = ' style="width:' + w + '"'
-    if cla:
-        cla = " " + cla
 
     s = ""
 
@@ -689,32 +672,28 @@ def get_md(self, query):
 def get_html(
     self: http.server.BaseHTTPRequestHandler, query: QueryClass, show_html: bool
 ):
-    is_image = self.path.find("/image/") >= 0
-    is_images = self.path.find("/multiimages/") >= 0
-    is_video = self.path.find("/video/") >= 0
-    is_pdf = self.path.find("/pdf/") >= 0
     is_template = self.path.find("/template") >= 0
     tempfile = get_param(query, "file", "")
 
-    if is_image:
+    if self.path.find("/image/") >= 0:
         if is_template:
             return file_to_string("templates/image/" + tempfile)
         s = get_image_html(query)
         return s
 
-    if is_images:
+    if self.path.find("/multiimages/") >= 0:
         if is_template:
             return file_to_string("templates/images/" + tempfile)
         s = get_images_html(query)
         return s
 
-    if is_video:
+    if self.path.find("/video/") >= 0:
         if is_template:
             return file_to_string("templates/video/" + tempfile)
         s = get_video_html(query)
         return s
 
-    if is_pdf:
+    if self.path.find("/pdf/") >= 0:
         if is_template:
             return file_to_string("templates/pdf/" + tempfile)
         s = get_video_html(query)

--- a/timApp/util/flask/requesthelper.py
+++ b/timApp/util/flask/requesthelper.py
@@ -248,6 +248,8 @@ def view_ctx_with_urlmacros(
 
 
 def get_from_url(url: str) -> str:
+    if url.startswith("COMPS"):
+        url = url.replace("COMPS", "/print/tim/components")
     parsed = urlparse(url)
     if not parsed.netloc and not parsed.scheme:
         host = f"http://caddy" if is_localhost() else current_app.config["TIM_HOST"]


### PR DESCRIPTION
Check COMPS to get_from_url so easier to write postprogram libraries for JSFrame-components.

Try to minimize svn3.py and csPlugin.py warnings.

Still one left in svn3.py (I could not correct, code is same on csPlugin):

     Expected type '(Any, Any, ThreadedHTTPServer) -> BaseRequestHandler' (matched generic type '(Any, Any, Self) -> 
     BaseRequestHandler'), got 'Type[TIMShowFileServer]' instead

5 warning left in cs.py ((could not correct):

- Expected type 'str', got 'list | LiteralString | str' instead
- Expected type 'str', got 'list | LiteralString | str' instead
- Unexpected type(s):(str | list | LiteralString)Possible type(s):(LiteralString)(str)
- Unexpected type(s):(list | LiteralString | str)Possible type(s):(LiteralString)(str)
- Expected type 'dict', got 'dict[str, str | Any]' instead

And 4 Too broad exception clause (these must be investigated later).