### PR TITLE
tim: strengthen double slash cleaning logic

### DIFF
--- a/timApp/tests/server/test_url_redirect.py
+++ b/timApp/tests/server/test_url_redirect.py
@@ -71,3 +71,6 @@ class RedirectTest(TimRouteTest):
         self.get("/test//x///?a=b", expect_status=302, expect_content="/test/x?a=b")
         self.get("/view", expect_status=200)
         self.get("/manage", expect_status=302, expect_content="/view")
+        self.get("/ /example.com/", expect_status=302, expect_content="/example.com")
+        self.get("/%20/example.com/", expect_status=302, expect_content="/example.com")
+        self.get("/%09/example.com/", expect_status=302, expect_content="/example.com")

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -1,3 +1,4 @@
+import re
 import time
 import traceback
 from urllib.parse import urlparse
@@ -318,6 +319,9 @@ if app.config["DEBUG_SQL"]:
 LOG_BEFORE_REQUESTS = app.config["LOG_BEFORE_REQUESTS"]
 
 
+DOUBLE_SLASH_PATH_REGEX = re.compile(r"/\s*/")
+
+
 @app.before_request
 def preprocess_request():
     session.permanent = True
@@ -331,7 +335,8 @@ def preprocess_request():
         p = request.path
         if "//" in p or (p.endswith("/") and p != "/"):
             query_str = request.query_string.decode()
-            fixed_url = p.rstrip("/").replace("//", "/")
+            fixed_url = p.rstrip("/")
+            fixed_url = DOUBLE_SLASH_PATH_REGEX.sub("/", fixed_url)
             if query_str:
                 fixed_url = f"{fixed_url}?{query_str}"
             return redirect(fixed_url)


### PR DESCRIPTION
This commit strengthens cleaning of double slashes in URL paths to prevent a potential open redirect exploit via abuse of whitespace.

***

Tämänhetkinen `//`-merkkijonojen siivous polusta mahdollistaa käyttäjästä riippumattoman ja odottamattoman redirectin, ks. esim <https://tim.jyu.fi/%09/example.com/>. 
Tämä on tunnettu bugi, katso esim. <https://github.com/oauth2-proxy/oauth2-proxy/security/advisories/GHSA-j7px-6hwj-hpjg>

PR vahvistaa `//`-merkkijonojen siivouksen siivoamalla kaikki välilyöntimerkit pois. Mukana yksikkötestit, jotka todentavat korjauksen toimivuuden (korjauksen jälkeen `https://tim.jyu.fi/%09/example.com/` ohjautuu `https://tim.jyu.fi/example.com/` joka ei ole validi polku).