### PR TITLE
InputDialogComponent: Clean up, fix textarea behavior

### DIFF
--- a/timApp/static/scripts/tim/ui/input-dialog.component.scss
+++ b/timApp/static/scripts/tim/ui/input-dialog.component.scss
@@ -12,4 +12,14 @@
 
 .content {
     white-space: pre;
+    text-wrap-mode: wrap;
+}
+
+textarea {
+    resize: vertical;
+    height: 10em;
+}
+
+tim-loading {
+    margin-right: 1em;
 }


### PR DESCRIPTION
This cleans up and improves the behavior of input dialogs after the recent changes:

- Dialog actions and inputs are disabled while running the async validator
- Reverts `text` to be the default input type instead of textarea (this broke some UI)
- Disables automatic action of the Enter button if the input type is textarea. This prevented multiline inputs before.

---

Näkyvin muutos on inputin korjaus paikoissa, jossa inputin tyyppiä ei ole annettu, esim. "Oma nimi -> Admin: Switch user"

![image](https://github.com/user-attachments/assets/e9e81491-5c06-40e0-96fa-e7e28284f2a5)

Tuotannossa nyt:
![image](https://github.com/user-attachments/assets/5d438552-a08d-47e4-b04c-ddf361f02118)

<https://timbeta02.tim.education> (kokeile `testadmin1`/`admin1pass`):

![image](https://github.com/user-attachments/assets/43dd76b6-599a-4483-b17e-aceadba1e2b7)

Tämä ilmeisesti on  regressio peräisin jostain OSCAR-commitissa, jossa on lisätty textarea-omana input-tyyppinä ja siitä on tehty oletus.

Lisäksi korjaa vähän tyylivikoja tuotannossa textarea-tyypille (käytetään seuraavissa PRissä).

