### PR TITLE
Feature tableform useradd simple

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -591,3 +591,58 @@ PRINT_MAX_LATEX_MEMORY = 5000000
 """
 Maximum amount of memory that can be used by a single LaTeX process to typeset PDFs.
 """
+
+# Group addition settings
+
+GROUPS_MISSING_USER_CREATE_ALLOW = False
+"""
+If True, yet non-existing users can be added to groups.
+In that case, a new user account is created with the email address of the user.
+"""
+
+GROUPS_EXISTING_USER_ADD_NOTIFY_EXISTING_HEAD = (
+    "TIM: You’ve Been Added to '{{group_name}}'"
+)
+"""
+When notifying existing users about being added to the group,
+this will be the subject of the email.
+"""
+GROUPS_EXISTING_USER_ADD_NOTIFY_EXISTING_BODY = """
+Hi!
+
+You’ve been added to the TIM group '{{group_name}}'.
+As a member, you now have access to all group resources available at <{{host}}>.
+
+If you have any questions, please contact {{support_contact}}.
+"""
+"""
+When notifying existing users about being added to the group,
+this will be the body of the email.
+"""
+
+GROUPS_MISSING_USER_ADD_NOTIFY_HEAD = (
+    "TIM: You have been added to group '{{group_name}}' – Complete Your Sign-Up"
+)
+"""
+When notifying new users about being added to the group,
+this will be the subject of the email.
+"""
+GROUPS_MISSING_USER_ADD_NOTIFY_BODY = """
+Hi!
+
+You’ve been added to the TIM group '{{group_name}}' using this email address. 
+An account has been created for you, but a password was not set during the process.
+
+To complete your sign-up and access your account:
+1. Visit <{{host}}> and click Log in on the top of the page.
+2. Use email login with this email and use the "Forgot password" option to set your password.
+
+Once your password is set, you’ll have full access to the group’s resources.
+
+If you do not recognize this email, please ignore it.
+If you have any questions or need assistance, feel free to contact {{support_contact}}.
+"""
+"""
+When notifying new users about being added to the group,
+this will be the body of the email.
+"""

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10505,6 +10505,80 @@ Ole hyvä ja luo ensin kirjautumiskoodit.</target>
           <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6082636692959910230" datatype="html">
+        <source>Add users</source>
+        <target state="translated">Lisää käyttäjä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1577,1576</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="494185651714406389" datatype="html">
+        <source>There are not groups defined in this table.</source>
+        <target state="translated">Ei ryhmiä määriteltynä tässä taulukossa.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1592</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5791799200547215180" datatype="html">
+        <source>Updated group.</source>
+        <target state="translated">Ryhmä päivitetty.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1631</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6129598176641143387" datatype="html">
+        <source>New members will be notified by email.</source>
+        <target state="translated">Uusille jäsenille on lähetetään ilmoitus sähköpostitse.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1638,1636</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8143693159335456296" datatype="html">
+        <source>Please provide email addresses or usernames.
+Separate multiple addresses with commas or write each address on a new line.</source>
+        <target state="translated">Anna ryhmään lisättävät sähköpostiosoitteet tai käyttäjätunnukset.
+Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1577</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1454510249537401836" datatype="html">
+        <source>If the address does not have a TIM account, a new account will be created for them.</source>
+        <target state="translated">Jos osoitetta ei löydy järjestelmästä, sille luodaan uusi käyttäjätunnus.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1583,1581</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6785769560062512577" datatype="html">
+        <source>Added <x id="PH" equiv-text="result.added.length"/> users:</source>
+        <target state="translated">Lisätty <x id="PH" equiv-text="result.added.length"/> käyttäjää:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1634</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="116165617457296609" datatype="html">
+        <source>Users already in group:</source>
+        <target state="translated">Käyttäjät jo ryhmässä:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1646</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4576508930871695312" datatype="html">
+        <source>Users not found in TIM or address was wrong:</source>
+        <target state="translated">TIM-käyttäjiä ei löydy tai annettu osoite on väärin:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1653</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="8149301268971106238" datatype="html">
         <source>My TIM settings</source>
         <target state="translated">Omat TIM asetukset</target>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10418,6 +10418,80 @@ Please generate login codes first.</target>
           <context context-type="linenumber">47,49</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="6082636692959910230" datatype="html">
+        <source>Add users</source>
+        <target state="new">Add users</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1577,1576</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="494185651714406389" datatype="html">
+        <source>There are not groups defined in this table.</source>
+        <target state="new">There are not groups defined in this table.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1592</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5791799200547215180" datatype="html">
+        <source>Updated group.</source>
+        <target state="new">Updated group.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1631</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6129598176641143387" datatype="html">
+        <source>New members will be notified by email.</source>
+        <target state="new">New members will be notified by email.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1638,1636</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8143693159335456296" datatype="html">
+        <source>Please provide email addresses or usernames.
+Separate multiple addresses with commas or write each address on a new line.</source>
+        <target state="new">Please provide email addresses or usernames.
+Separate multiple addresses with commas or write each address on a new line.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1577</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1454510249537401836" datatype="html">
+        <source>If the address does not have a TIM account, a new account will be created for them.</source>
+        <target state="new">If the address does not have a TIM account, a new account will be created for them.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1583,1581</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6785769560062512577" datatype="html">
+        <source>Added <x id="PH" equiv-text="result.added.length"/> users:</source>
+        <target state="new">Added <x id="PH" equiv-text="result.added.length"/> users:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1634</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="116165617457296609" datatype="html">
+        <source>Users already in group:</source>
+        <target state="new">Users already in group:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1646</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4576508930871695312" datatype="html">
+        <source>Users not found in TIM or address was wrong:</source>
+        <target state="new">Users not found in TIM or address was wrong:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/tableForm/table-form.component.ts</context>
+          <context context-type="linenumber">1653</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -158,6 +158,9 @@ class TableFormMarkupModel(GenericMarkupModel):
     usernames: bool | Missing = missing
     dataView: DataViewSettingsModel | Missing | None = missing
     replyToEmail: str | Missing | None = missing
+    addUsersButton: str | Missing | None = missing
+    notifyOnAdd: bool | Missing = False
+    createMissingUsers: bool | Missing = False
 
 
 TableFormMarkupSchema = class_schema(TableFormMarkupModel)

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.scss
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.scss
@@ -1,0 +1,5 @@
+.action-info-content {
+  white-space: pre;
+  text-wrap-mode: wrap;
+  font-size: 0.8em;
+}

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -51,10 +51,13 @@ import {
     clone,
     defaultErrorMessage,
     maxContentOrFitContent,
+    splitItems,
     to,
     to2,
+    toPromise,
 } from "tim/util/utils";
 import {CommonModule} from "@angular/common";
+import type {IAddmemberResponse} from "tim/ui/add-member.component";
 
 const RunScriptModel = t.type({
     script: nullable(t.string),
@@ -115,6 +118,9 @@ const TableFormMarkup = t.intersection([
         runScripts: t.array(t.union([t.string, RunScriptModel])),
         dataView: nullable(DataViewSettingsType),
         replyToEmail: nullable(t.string),
+        addUsersButton: nullable(t.string),
+        notifyOnAdd: t.boolean,
+        createMissingUsers: t.boolean,
     }),
     GenericPluginMarkup,
     t.type({
@@ -200,10 +206,20 @@ const sortLang = "fi";
                        [taskid]="getTaskId()"></tim-table>
 
             <div class="hidden-print">
+                <tim-alert *ngIf="actionInfo" severity="info" [closeable]="true"
+                           (closing)="resetActionInfoText()">
+                    <p class="action-info-content">{{actionInfo}}</p>
+                </tim-alert>
                 <button class="timButton"
                         *ngIf="(tableCheck() && !autosave && !locked) || saveFailed"
                         (click)="saveText()">
                     {{ buttonText() }}
+                </button>
+                <button class="timButton"
+                        *ngIf="addUsersButton"
+                        (click)="addUsers()"
+                >
+                    {{ addUsersButton }}
                 </button>
                 <button class="timButton"
                         *ngIf="reportCheck()"
@@ -213,34 +229,34 @@ const sortLang = "fi";
                 <button class="timButton"
                         (click)="closeTable()"
                         *ngIf="hideButtonText">
-                    {{hideButtonText}}
+                    {{ hideButtonText }}
                 </button>
                 <button class="timButton"
                         (click)="forceUpdateTable()"
                         *ngIf="forceUpdateButtonText">
-                    {{forceUpdateButtonText}}
+                    {{ forceUpdateButtonText }}
                 </button>
                 <button class="timButton"
                         (click)="removeUsers()"
                         *ngIf="removeUsersButtonText && cbCount">
-                    {{removeUsersButtonText}}
+                    {{ removeUsersButtonText }}
                 </button>
                 <button class="timButton"
                         (click)="listUsernames()"
                         *ngIf="userListButtonText && cbCount">
-                    {{userListButtonText}}
+                    {{ userListButtonText }}
                 </button>
                 <button class="timButton"
                         (click)="emailUsers()"
                         *ngIf="emailUsersButtonText && cbCount">
-                    {{emailUsersButtonText}}
+                    {{ emailUsersButtonText }}
                 </button>
                 <ng-container *ngIf="runScripts">
                     <button class="timButton"
                             *ngFor="let s of runScripts"
                             [hidden]="!s.all && !cbCount"
                             (click)="runJsRunner(s)">
-                        {{s.button}}
+                        {{ s.button }}
                     </button>
                 </ng-container>
                 <ng-container *ngIf="sisugroups && cbCount">
@@ -282,7 +298,7 @@ const sortLang = "fi";
                               [storageKey]="this.taskIdFull"
                               [replyToEmail]="markup['replyToEmail']"
             ></tim-message-send>
-            <pre *ngIf="result">{{result}}</pre>
+            <pre *ngIf="result">{{ result }}</pre>
             <pre *ngIf="error" [innerHtml]="error"></pre>
             <p *ngIf="footer" [innerHtml]="footer | purify" class="plgfooter"></p>
         </div>
@@ -290,7 +306,7 @@ const sortLang = "fi";
             <button class="timButton"
                     [disabled]="loading"
                     (click)="openTable()">
-                {{openButtonText}}
+                {{ openButtonText }}
             </button>
             <tim-loading *ngIf="loading"></tim-loading>
         </div>
@@ -343,6 +359,8 @@ export class TableFormComponent
     private taskLocations: Record<string, string> = {};
     private changedCells: string[] = []; // Use same type as data.userdata?
     private clearStylesCells = new Set<string>();
+    private isAddingUsers = false;
+    actionInfo?: string;
 
     runScripts?: RunScriptType[];
 
@@ -414,6 +432,10 @@ export class TableFormComponent
 
     get sisugroups() {
         return this.markup.sisugroups;
+    }
+
+    get addUsersButton() {
+        return this.markup.addUsersButton;
     }
 
     /**
@@ -1544,6 +1566,113 @@ export class TableFormComponent
 
     getAttributeType() {
         return TableFormAll;
+    }
+
+    async addUsers() {
+        if (this.isAddingUsers) {
+            return;
+        }
+        this.isAddingUsers = true;
+
+        let prompt = $localize`Please provide email addresses or usernames.
+Separate multiple addresses with commas or write each address on a new line.`;
+
+        if (this.markup.createMissingUsers) {
+            prompt +=
+                "\n\n" +
+                $localize`If the address does not have a TIM account, a new account will be created for them.`;
+        }
+        if (this.markup.notifyOnAdd) {
+            prompt += "\n" + $localize`New members will be notified by email.`;
+        }
+
+        const res = await to2(
+            showInputDialog<IAddmemberResponse>({
+                title: $localize`Add users`,
+                text: prompt,
+                okText: $localize`Add`,
+                inputType: "textarea",
+                isInput: InputDialogKind.InputAndValidator,
+                defaultValue: "",
+                validator: async (input: string) => {
+                    if (!this.markup.groups) {
+                        return {
+                            ok: false,
+                            result: $localize`There are not groups defined in this table.`,
+                        };
+                    }
+                    const group = this.markup.groups[0];
+                    const r = await toPromise(
+                        this.http.post<IAddmemberResponse>(
+                            `/groups/addmember/${group}`,
+                            {
+                                names: splitItems(input),
+                                create_missing_users:
+                                    !!this.markup.createMissingUsers,
+                                notify_new: !!this.markup.notifyOnAdd,
+                            }
+                        )
+                    );
+                    if (r.ok) {
+                        return r;
+                    } else {
+                        return {
+                            ok: false,
+                            result: r.result.error.error,
+                        };
+                    }
+                },
+            })
+        );
+        if (res.ok) {
+            const result = res.result;
+
+            let actionMessage = $localize`Updated group.`;
+
+            if (result.added.length > 0) {
+                const addedText =
+                    $localize`Added ${result.added.length} users:` +
+                    "\n\n" +
+                    result.added.map((u) => `- ${u}`).join("\n");
+                actionMessage += "\n\n" + addedText;
+                if (this.markup.notifyOnAdd) {
+                    actionMessage +=
+                        "\n\n" +
+                        $localize`New members will be notified by email.`;
+                }
+            }
+            if (result.already_belongs.length > 0) {
+                const alreadyInGroupText =
+                    $localize`Users already in group:` +
+                    "\n\n" +
+                    result.already_belongs.map((u) => `- ${u}`).join("\n");
+                actionMessage += "\n\n" + alreadyInGroupText;
+            }
+            if (result.not_exist.length > 0) {
+                const notFoundText =
+                    $localize`Users not found in TIM or address was wrong:` +
+                    "\n\n" +
+                    result.not_exist.map((u) => `- ${u}`).join("\n");
+                actionMessage += "\n\n" + notFoundText;
+            }
+
+            this.setActionInfoText(actionMessage, 10000);
+            await this.forceUpdateTable();
+        }
+        this.isAddingUsers = false;
+    }
+
+    resetActionInfoText() {
+        this.actionInfo = undefined;
+    }
+
+    setActionInfoText(text: string, resetMs?: number) {
+        this.actionInfo = text;
+        if (resetMs) {
+            setTimeout(() => {
+                this.resetActionInfoText();
+            }, resetMs);
+        }
     }
 }
 

--- a/timApp/static/scripts/tim/ui/add-member.component.ts
+++ b/timApp/static/scripts/tim/ui/add-member.component.ts
@@ -1,8 +1,8 @@
 import {Component, Input} from "@angular/core";
 import {HttpClient} from "@angular/common/http";
-import {toPromise} from "tim/util/utils";
+import {splitItems, toPromise} from "tim/util/utils";
 
-interface IAddmemberResponse {
+export interface IAddmemberResponse {
     added: string[];
     already_belongs: string[];
     not_exist: string[];
@@ -67,10 +67,7 @@ export class AddMemberComponent {
             this.http.post<IAddmemberResponse>(
                 `/groups/addmember/${this.group}`,
                 {
-                    names: this.users
-                        .split("\n")
-                        .flatMap((n) => n.split(/,|;/))
-                        .map((n) => n.replace(/^ *- */, "").trim()),
+                    names: splitItems(this.users),
                 }
             )
         );

--- a/timApp/static/scripts/tim/util/utils.ts
+++ b/timApp/static/scripts/tim/util/utils.ts
@@ -1086,3 +1086,17 @@ export function replaceStyle(
     }
     el.setAttribute("href", newPath);
 }
+
+/**
+ * Splits the given string into items. The items are separated by newlines, commas, or semicolons.
+ * Any leading dashes are removed from the items.
+ *
+ * @param itemsString String to split into items.
+ * @returns Array of items.
+ */
+export function splitItems(itemsString: string): string[] {
+    return itemsString
+        .split("\n")
+        .flatMap((n) => n.split(/[,;]/))
+        .map((n) => n.replace(/^ *- */, "").trim());
+}


### PR DESCRIPTION
This change adds a native member creation button to tableForm. Additionally, the button allows creating user accounts for non-existing users and notify them about it.

---

Testisivu: <https://timbeta02.tim.education/view/users/dz-dz/test-adduser-notify-table>

Lisää tableFormiin kolme asetusta:

```yml
# Näytää "Lisää jäsenet" -painikkeen suoraan tableFormsissa
addUsersButton: Lisää opettaja hallintaryhmään
# Jos true, uusille jäsenille lähetetään erillinen ilmoitus ryhmään liittymisestä
notifyOnAdd: true
# Jos true ja lisättävälle spostiosoitteelle ei ole TIM-tunnusta, sille tehdään TIM-tunnus automaattisesti
# Jos lisäksi notifyOnAdd on true, käyttäjälle sposti, jossa on ensimmäisen kerran kirjautumisohjeet
createMissingUsers: true
```

Sähköpostien sisällöt ovat toistaiseksi muokattavissa vain palvelinasetuksissa, mutta ehkä jatkossa ne voisivat olla kenttiä jossain dokumentissa.
Lisäksi `createMissingUsers` toimii vain, jos palvelinasetus `GROUPS_MISSING_USER_CREATE_ALLOW` on laitettu päälle. Yleisen käytön kannalta voisi miettiä, voisiko tunnusten luominen sallia aina (tai esim. tietylle käyttäjäryhmälle).

