### PR TITLE
TableForm: export reports as Excel files

### DIFF
--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -667,7 +667,8 @@ def parse_row(rd: list[str | float | None], regex_filter: re.Pattern) -> None:
 
 
 def filter_csv_report(report_filter: str | Missing, content: str) -> Tuple[str, str]:
-    csv, output = "", ""
+    csv = content
+    output = ""
     if isinstance(report_filter, str) and report_filter:
         params = JsRunnerParams(code=report_filter, data=content)
         try:

--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -441,6 +441,13 @@ def check_field_filtering(
     return r_filter.is_match(target)
 
 
+@tableForm_plugin.get("/generateCSV")
+@use_args(GenerateSpreadSheetSchema())
+def gen_csv_legacy(args: GenerateSpreadSheetModel) -> Response | str:
+    """Legacy route for documents that have direct links to the route."""
+    return gen_spreadsheet(args)
+
+
 @tableForm_plugin.get("/generateReport")
 @use_args(GenerateSpreadSheetSchema())
 def gen_spreadsheet(args: GenerateSpreadSheetModel) -> Response | str:

--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -9,7 +9,6 @@ from zipfile import ZipFile, ZIP_DEFLATED
 
 from flask import render_template_string, Response, send_file
 from marshmallow.utils import missing
-from msgpack.fallback import BytesIO
 from openpyxl import Workbook
 from openpyxl.writer.excel import ExcelWriter
 from sqlalchemy import select
@@ -679,10 +678,10 @@ def filter_csv_report(report_filter: str | Missing, content: str) -> Tuple[str, 
 
 
 def create_and_send_report(
-    filename: str, content: str | BytesIO, mimetype: str
+    filename: str, content: str | io.BytesIO, mimetype: str
 ) -> Response:
     file_io = content
-    if not isinstance(content, BytesIO):
+    if not isinstance(content, io.BytesIO):
         # Re-encode to UTF-8-BOM since that's what Excel opens by default
         file_io = io.BytesIO(content.encode("utf-8-sig"))
     return send_file(

--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -615,11 +615,11 @@ def gen_spreadsheet(args: GenerateSpreadSheetModel) -> Response | str:
                 tmp_file = tmp_dir + "/" + file_name
                 wb.save(tmp_file)
                 return send_file(
-                         tmp_file,
-                         as_attachment=True,
-                         download_name=file_name,
-                         mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                     )
+                    tmp_file,
+                    as_attachment=True,
+                    download_name=file_name,
+                    mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                )
 
             case "csv":
                 csv = csv_string(data, "excel", separator)

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -1105,7 +1105,7 @@ export class TableFormComponent
         }
 
         const win = window.open(
-            "/tableForm/generateCSV?" +
+            "/tableForm/generateReport?" +
                 $httpParamSerializer({
                     ...reportParams,
                     ...filterParams,

--- a/timApp/tests/server/test_tableform.py
+++ b/timApp/tests/server/test_tableform.py
@@ -33,7 +33,7 @@ class TableFormTest(TimRouteTest):
 
         # Test that user filtering still works with the wildcard
         self.get(
-            f"/tableForm/generateCSV",
+            f"/tableForm/generateReport",
             query_string={
                 "docId": doc.id,
                 "fields": "mmcqexample",


### PR DESCRIPTION
Adds support for generating reports in Excel file format (.xlsx) in the TableForm component.

For now, numeric cell values are parsed via regex, string substitutions and type casting, handled cases include
- spaces
- comma (`,`) and dot (`.`) as decimal separators
- multiple commas and/or dots

In the future, the parsing/filtering/type casting mechanism should probably be replaced by something that is configurable from the browser (ie. via the runScripts plugin setting).