### PR TITLE
Answerbrowser adjustments

### DIFF
--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -37,6 +37,7 @@ import type {
     IAnswerBrowserSettings,
     IGenericPluginMarkup,
     IGenericPluginTopLevelFields,
+    IPointsLimiterSettings,
 } from "tim/plugin/attributes";
 import type {IUser} from "tim/user/IUser";
 import {sortByRealName} from "tim/user/IUser";
@@ -283,7 +284,7 @@ export class AnswerBrowserComponent
     private answerLoader?: AnswerLoadCallback;
     pointsStep: number = 0.01;
     autosave: boolean = true;
-    limitPoints: boolean = true;
+    limitPoints: IPointsLimiterSettings = {min: 0, max: undefined};
     markupSettings: IAnswerBrowserSettings = DEFAULT_MARKUP_CONFIG;
     modelAnswer?: IModelAnswerSettings;
     private modelAnswerFetched = false;
@@ -448,7 +449,7 @@ export class AnswerBrowserComponent
         if (this.markupSettings.autosave != undefined) {
             this.autosave = this.markupSettings.autosave;
         }
-        if (this.markupSettings.limitPoints != undefined) {
+        if (this.markupSettings.limitPoints) {
             this.limitPoints = this.markupSettings.limitPoints;
         }
         if (this.markupSettings.showValidOnly != undefined) {
@@ -1029,43 +1030,18 @@ export class AnswerBrowserComponent
     }
 
     /**
-     *
+     * Handle focus out event for the points field
      * @param ev FocusEvent
      */
     handlePointsFocusOut(ev: FocusEvent) {
         ev.preventDefault();
         this.shouldFocus = false;
         if (
-            this.autosave &&
-            ev.type == "blur" &&
-            this.points != this.selectedAnswer?.points
+            // this.autosave &&
+            ev.type == "blur"
+            // this.points != this.selectedAnswer?.points
         ) {
-            this.savePoints();
-        }
-    }
-
-    /**
-     * If the AnswerBrowserSetting `limitPoints` is set,
-     * limits the points given for the answer to the value defined by PointRule.maxPoints (see tim/tim_common/markupmodels.py).
-     * TODO: Maybe expand the `limitPoints` option to include its own min, max values and use those instead of pointsrule,
-     *  so that we can also limit the minimum allowed points for task answers.
-     */
-    maybeLimitPoints() {
-        if (!this.limitPoints) {
-            return;
-        }
-        let maxpoints;
-        if (this.taskInfo?.maxPoints) {
-            maxpoints = parseFloat(this.taskInfo.maxPoints.toString());
-        }
-
-        if (
-            maxpoints &&
-            !isNaN(maxpoints) &&
-            this.points &&
-            this.points > maxpoints
-        ) {
-            this.points = maxpoints;
+            this.trySavePoints(true);
         }
     }
 

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -284,7 +284,7 @@ export class AnswerBrowserComponent
     private answerLoader?: AnswerLoadCallback;
     pointsStep: number = 0.01;
     autosave: boolean = true;
-    limitPoints: IPointsLimiterSettings = {min: 0, max: undefined};
+    limitPoints: IPointsLimiterSettings = {min: undefined, max: undefined};
     markupSettings: IAnswerBrowserSettings = DEFAULT_MARKUP_CONFIG;
     modelAnswer?: IModelAnswerSettings;
     private modelAnswerFetched = false;

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -601,7 +601,10 @@ export class AnswerBrowserComponent
         this.selectedAnswer.valid = this.isValidAnswer;
     }
 
-    trySavePoints(updateAnswers: boolean = false) {
+    trySavePoints(
+        updateAnswers: boolean = false,
+        updatePointsState: boolean = true
+    ) {
         if (!this.selectedAnswer || !this.user) {
             return true;
         }
@@ -622,7 +625,7 @@ export class AnswerBrowserComponent
         }
 
         const doSavePoints = async () => {
-            await this.savePoints(false);
+            await this.savePoints(updatePointsState);
             if (updateAnswers) {
                 await this.getAnswersAndUpdate();
             }
@@ -943,7 +946,7 @@ export class AnswerBrowserComponent
      * @param dir -1 for older answer, 1 for newer answer
      */
     async changeAnswerTo(dir: -1 | 1) {
-        if (!this.trySavePoints(true)) {
+        if (!this.trySavePoints(true, false)) {
             return;
         }
         if (!(await this.checkUnsavedAnnotations())) {
@@ -965,7 +968,7 @@ export class AnswerBrowserComponent
     }
 
     async newTask() {
-        if (!this.trySavePoints(true)) {
+        if (!this.trySavePoints(true, false)) {
             return;
         }
 
@@ -1036,12 +1039,8 @@ export class AnswerBrowserComponent
     handlePointsFocusOut(ev: FocusEvent) {
         ev.preventDefault();
         this.shouldFocus = false;
-        if (
-            // this.autosave &&
-            ev.type == "blur"
-            // this.points != this.selectedAnswer?.points
-        ) {
-            this.trySavePoints(true);
+        if (this.autosave && ev.type == "blur") {
+            this.trySavePoints(false, true);
         }
     }
 
@@ -1091,7 +1090,7 @@ export class AnswerBrowserComponent
         if (this.users.length <= 0) {
             return;
         }
-        if (!this.trySavePoints()) {
+        if (!this.trySavePoints(false, false)) {
             return;
         }
         const shouldRefocusPoints = this.shouldFocus;

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -146,8 +146,6 @@ const DEFAULT_MARKUP_CONFIG: IAnswerBrowserSettings = {
     validOnlyText: $localize`Show valid only`,
     showReview: false,
     showInitialAskNew: true,
-    autosave: true,
-    limitPoints: true,
 };
 
 @Component({
@@ -447,11 +445,11 @@ export class AnswerBrowserComponent
             this.pointsStep = this.markupSettings?.pointsStep;
         }
         // Save points for the answer when the points field loses focus
-        if (this.markupSettings.autosave) {
-            this.autosave = this.markupSettings?.autosave;
+        if (this.markupSettings.autosave != undefined) {
+            this.autosave = this.markupSettings.autosave;
         }
-        if (this.markupSettings.limitPoints) {
-            this.limitPoints = this.markupSettings?.limitPoints;
+        if (this.markupSettings.limitPoints != undefined) {
+            this.limitPoints = this.markupSettings.limitPoints;
         }
         if (this.markupSettings.showValidOnly != undefined) {
             this.onlyValid = this.markupSettings.showValidOnly;

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -11,6 +11,8 @@ export const AnswerBrowserSettings = t.partial({
     showValidOnly: t.boolean,
     showReview: t.boolean,
     showInitialAskNew: t.boolean,
+    autosave: t.boolean,
+    limitPoints: t.boolean,
 });
 
 export interface IAnswerBrowserSettings

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -5,6 +5,14 @@ So, do NOT import anything client-side-specific (like AngularJS) in this module 
 
 import * as t from "io-ts";
 
+export const PointsLimiterSettings = t.partial({
+    min: t.number,
+    max: t.number,
+});
+
+export interface IPointsLimiterSettings
+    extends t.TypeOf<typeof PointsLimiterSettings> {}
+
 export const AnswerBrowserSettings = t.partial({
     pointsStep: nullable(t.number),
     validOnlyText: t.string,
@@ -12,9 +20,8 @@ export const AnswerBrowserSettings = t.partial({
     showReview: t.boolean,
     showInitialAskNew: t.boolean,
     autosave: t.boolean,
-    limitPoints: t.boolean,
+    limitPoints: nullable(PointsLimiterSettings),
 });
-
 export interface IAnswerBrowserSettings
     extends t.TypeOf<typeof AnswerBrowserSettings> {
     // Empty

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -105,7 +105,7 @@
                      <span *ngIf="hasUserChanged()"> <tim-loading></tim-loading> </span>
                  </div>
                  <div class="flex ab-option-row">
-                            <form (ngSubmit)="savePoints()" class="point-form form-inline">
+                            <form (ngSubmit)="trySavePoints(false, true)" class="point-form form-inline">
                                 <label class="inline" *ngIf="showTeacher() || (giveCustomPoints && allowCustomPoints())">
                                     <ng-container i18n>Points:</ng-container><input class="form-control input-xs"
                                                   [ngClass]="{ unsaved: points != selectedAnswer?.points,

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -97,13 +97,13 @@
                     title="Link to peer review"
                 href="{{ getReviewLink() }}">Review</a>
                 </span>
-             <div *ngIf="answers.length == 0 && viewctrl.teacherMode">
-                 <ng-container *ngIf="!hasUserChanged()">
-                    <span i18n *ngIf="!isGlobal()">(no answers from the selected user)</span>
-                    <span i18n *ngIf="isGlobal()">(no answers)</span>
-                 </ng-container>
-                 <span *ngIf="hasUserChanged()"> <tim-loading></tim-loading> </span>
-             </div>
+                 <div *ngIf="answers.length == 0 && viewctrl.teacherMode">
+                     <ng-container *ngIf="!hasUserChanged()">
+                        <span i18n *ngIf="!isGlobal()">(no answers from the selected user)</span>
+                        <span i18n *ngIf="isGlobal()">(no answers)</span>
+                     </ng-container>
+                     <span *ngIf="hasUserChanged()"> <tim-loading></tim-loading> </span>
+                 </div>
                  <div class="flex ab-option-row">
                             <form (ngSubmit)="savePoints()" class="point-form form-inline">
                                 <label class="inline" *ngIf="showTeacher() || (giveCustomPoints && allowCustomPoints())">
@@ -111,8 +111,9 @@
                                                   [ngClass]="{ unsaved: points != selectedAnswer?.points,
                                                   'no-step': !markupSettings.pointsStep }"
                                                   (focus)="shouldFocusIfSelectedAnswer()"
-                                                  (blur)="shouldFocus = false"
+                                                  (blur)="handlePointsFocusOut($event)"
                                                   [(ngModel)]="points"
+                                                                                    (ngModelChange)="maybeLimitPoints()"
                                                   (keydown)="handlePointScroll($event)"
                                                   name="points"
                                                   type="number"
@@ -124,7 +125,7 @@
 
                                 <button i18n-title title="Save points"
                                         class="timButton btn-xs"
-                                        *ngIf="selectedAnswer && points != selectedAnswer.points">
+                                        *ngIf="selectedAnswer && points != selectedAnswer.points && !autosave">
                                     <i class="glyphicon glyphicon-ok"></i>
                                 </button>
                             </form>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -113,14 +113,13 @@
                                                   (focus)="shouldFocusIfSelectedAnswer()"
                                                   (blur)="handlePointsFocusOut($event)"
                                                   [(ngModel)]="points"
-                                                                                    (ngModelChange)="maybeLimitPoints()"
                                                   (keydown)="handlePointScroll($event)"
                                                   name="points"
                                                   type="number"
                                                   step="{{ pointsStep }}"
                                                   style="max-width: 5em"
                                                   autocomplete="off"
-                                                  size="2">
+                                                  size="2" min="{{limitPoints.min}}" max="{{limitPoints.max}}">
                                 </label>
 
                                 <button i18n-title title="Save points"

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -212,6 +212,8 @@ class AnswerBrowserInfo:
     showValidOnly: bool | None | Missing = missing
     showReview: bool | None | Missing = missing
     showInitialAskNew: bool | None | Missing = missing
+    autosave: bool | None | Missing = missing
+    limitPoints: bool | None | Missing = missing
 
 
 @dataclass

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -206,6 +206,12 @@ class UndoInfo:
 
 
 @dataclass
+class PointsLimiterInfo:
+    min: int | float | None | Missing = missing
+    max: int | float | None | Missing = missing
+
+
+@dataclass
 class AnswerBrowserInfo:
     pointsStep: float | None | Missing = missing
     validOnlyText: str | None | Missing = missing
@@ -213,7 +219,7 @@ class AnswerBrowserInfo:
     showReview: bool | None | Missing = missing
     showInitialAskNew: bool | None | Missing = missing
     autosave: bool | None | Missing = missing
-    limitPoints: bool | None | Missing = missing
+    limitPoints: PointsLimiterInfo | Missing | None = missing
 
 
 @dataclass


### PR DESCRIPTION
Makes the following adjustments to the Points field in the AnswerBrowser component:

- Autosave option: the points value is automatically saved when the field loses focus
  - Adjustable with the plugin attribute
  ```
  answerBrowser:
    autosave: true / false (default: true)
  ```

- Limit maximum allowed points for a task answer
  - Adjustable with the plugin attribute
  ```
  answerBrowser:
    limitPoints:
      min: [number]
      max: [number]
  ```

- Hide point field buttons when autosave option is on


Closes #3796 