### PR TITLE
Fix velp color controls

### DIFF
--- a/timApp/static/scripts/tim/util/math.ts
+++ b/timApp/static/scripts/tim/util/math.ts
@@ -1,0 +1,13 @@
+/* Utility math functions for dealing with numbers, ranges, etc.
+ * NOTE: Keep this file free from external dependencies.
+ */
+
+/**
+ * Clamps a number value to within the given range of values.
+ * @param num value to clamp
+ * @param min minimum return value
+ * @param max maximum return value
+ */
+export function clamp(num: number, min: number, max: number) {
+    return num < min ? min : num > max ? max : num;
+}

--- a/timApp/static/scripts/tim/velp/annotation.component.ts
+++ b/timApp/static/scripts/tim/velp/annotation.component.ts
@@ -126,12 +126,16 @@ export async function updateAnnotationServer(
                 
                 <div>
                     <div *ngIf="showFull">
-                        <p class="points-input" [hidden]="!canEditAnnotation() || !allowChangePoints()"><label>
-                            Points: <input type="number"
-                                           [(ngModel)]="values.points"
-                                           step="any"
-                                           [disabled]="!canEditAnnotation()"/></label>
-                            <span [hidden]="!canEditAnnotation()" style="float: right">
+                        <p class="points-input">
+                            <ng-container *ngIf="canEditAnnotation() || allowChangePoints()">
+                                <label>
+                                Points: <input type="number"
+                                               [(ngModel)]="values.points"
+                                               step="any"
+                                               [disabled]="!canEditAnnotation()"/>
+                                </label>
+                            </ng-container>
+                            <span *ngIf="canEditAnnotation()" style="float: right">
                                 <input type="color" [(ngModel)]="values.color"
                                        (ngModelChange)="onColorUpdate($event)"
                                        title="Change annotation color"

--- a/timApp/static/scripts/tim/velp/annotation.component.ts
+++ b/timApp/static/scripts/tim/velp/annotation.component.ts
@@ -372,6 +372,10 @@ export class AnnotationComponent
         this.annotation = a;
         this.original = a.getEditableValues();
         this.values = clone(this.original);
+        this.values.visible_to =
+            this.allowChangePoints() || this.vctrl.item.rights.teacher
+                ? this.values.visible_to
+                : 1; /* value for "Just me", ie. visible only the user who added the annotation. */
         this.onColorUpdate(this.values.color ?? "");
         this.refreshMath = true;
     }

--- a/timApp/static/scripts/tim/velp/annotation.component.ts
+++ b/timApp/static/scripts/tim/velp/annotation.component.ts
@@ -127,7 +127,7 @@ export async function updateAnnotationServer(
                 <div>
                     <div *ngIf="showFull">
                         <p class="points-input">
-                            <ng-container *ngIf="canEditAnnotation() || allowChangePoints()">
+                            <ng-container *ngIf="canEditAnnotation() && allowChangePoints()">
                                 <label>
                                 Points: <input type="number"
                                                [(ngModel)]="values.points"
@@ -242,6 +242,7 @@ export class AnnotationComponent
             {id: 3, name: "Teachers"},
             {id: 4, name: "Users with access"},
         ],
+        default: 1,
     };
     styleOptions = {
         values: [
@@ -249,6 +250,7 @@ export class AnnotationComponent
             {id: 2, name: "Text"},
             {id: 3, name: "Text (always visible)"},
         ],
+        default: 1,
     };
     newcomment = "";
     showFull = false;
@@ -372,10 +374,6 @@ export class AnnotationComponent
         this.annotation = a;
         this.original = a.getEditableValues();
         this.values = clone(this.original);
-        this.values.visible_to =
-            this.allowChangePoints() || this.vctrl.item.rights.teacher
-                ? this.values.visible_to
-                : 1; /* value for "Just me", ie. visible only the user who added the annotation. */
         this.onColorUpdate(this.values.color ?? "");
         this.refreshMath = true;
     }

--- a/timApp/static/templates/velpWindow.html
+++ b/timApp/static/templates/velpWindow.html
@@ -54,7 +54,7 @@
                 </p>
 
 
-                <p ng-show="$ctrl.allowChangePoints()" class="header"><input id="addVelpPoints" type="number" style="width: 50%;"
+                <p class="header"><input ng-if="$ctrl.allowChangePoints()" id="addVelpPoints" type="number" style="width: 50%;"
                                                         title="Default points from this velp"
                                                         ng-model="$ctrl.velp.points"
                                                         step="0.01"


### PR DESCRIPTION
Closes #3801 

Relaxes the original constraints placed on changing the color of velps/annotations. Users may now freely choose the color of their velp (templates) and annotations.

The default visibility of annotations is now private (labeled as "Just me" in the annotation) when the user/annotator does not have at least teacher rights to the document. Users with at least teacher rights to the document will continue to have their annotations visible publicly by default.