### PR TITLE
Fix AnswerBrowser error message alerts

### DIFF
--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -347,7 +347,7 @@ export class AnswerBrowserComponent
                 if (pattern) {
                     displayAlert = !pattern.test(e);
                 }
-                if (displayAlert) {
+                if (displayAlert && !this.alerts.some((m) => m.msg === e)) {
                     this.alerts.push({msg: e, type: "warning"});
                 }
             }

--- a/timApp/tests/browser/test_answerbrowser.py
+++ b/timApp/tests/browser/test_answerbrowser.py
@@ -123,7 +123,9 @@ type: text
         )
         self.test_user_2.grant_access(d, AccessType.view)
         db.session.commit()
-        self.login_browser_test2()
+
+        self.login_browser_quick_test2()
+        self.login_test2()
 
         def do_browser_check(input: str, expect: str):
             self.goto_document(d)

--- a/timApp/tests/browser/test_answerbrowser.py
+++ b/timApp/tests/browser/test_answerbrowser.py
@@ -123,7 +123,7 @@ type: text
         )
         self.test_user_2.grant_access(d, AccessType.view)
         db.session.commit()
-        self.login_browser_quick_test2()
+        self.login_browser_test2()
 
         def do_browser_check(input: str, expect: str):
             self.goto_document(d)


### PR DESCRIPTION
Fixes a bug where AnswerBrowser keeps pumping out identical error messages even when the error message already exists.