### PR TITLE
TableForm: Allow running JSRunners after adding a new user

### DIFF
--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -102,6 +102,7 @@ class RunScriptModel:
     button: str | None = None
     all: bool | None = None
     update: bool | None = None
+    onMemberAdd: bool | None = None
     interval: int | None = None
 
 

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -59,13 +59,18 @@ import {
 import {CommonModule} from "@angular/common";
 import type {IAddmemberResponse} from "tim/ui/add-member.component";
 
-const RunScriptModel = t.type({
-    script: nullable(t.string),
-    button: nullable(t.string),
-    all: nullable(t.boolean),
-    update: nullable(t.boolean),
-    interval: nullable(t.number),
-});
+const RunScriptModel = t.intersection([
+    t.type({
+        script: nullable(t.string),
+        button: nullable(t.string),
+        all: nullable(t.boolean),
+        update: nullable(t.boolean),
+        interval: nullable(t.number),
+    }),
+    t.partial({
+        onMemberAdd: nullable(t.boolean),
+    }),
+]);
 
 interface RunScriptModelType extends t.TypeOf<typeof RunScriptModel> {}
 
@@ -506,6 +511,7 @@ export class TableFormComponent
                 interval: null,
                 handle: undefined,
                 running: 0,
+                onMemberAdd: null,
             };
             if (typeof r === "string") {
                 if (r.length == 0) {
@@ -518,6 +524,7 @@ export class TableFormComponent
                 rs.all = r.all;
                 rs.update = r.update;
                 rs.interval = r.interval;
+                rs.onMemberAdd = r.onMemberAdd;
             }
             let script = "";
             if (s) {
@@ -1654,6 +1661,13 @@ Separate multiple addresses with commas or write each address on a new line.`;
                     "\n\n" +
                     result.not_exist.map((u) => `- ${u}`).join("\n");
                 actionMessage += "\n\n" + notFoundText;
+            }
+
+            if (this.runScripts) {
+                const onAddMemberScripts = this.runScripts
+                    .filter((s) => !!s.onMemberAdd)
+                    .map((s) => this.runJsRunner(s));
+                await Promise.all(onAddMemberScripts);
             }
 
             this.setActionInfoText(actionMessage, 10000);

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -259,7 +259,7 @@ const sortLang = "fi";
                 <ng-container *ngIf="runScripts">
                     <button class="timButton"
                             *ngFor="let s of runScripts"
-                            [hidden]="(!s.all && !cbCount) || !s.button"
+                            [hidden]="(!s.all && !cbCount) || s.onMemberAdd"
                             (click)="runJsRunner(s)">
                         {{ s.button }}
                     </button>

--- a/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
+++ b/timApp/static/scripts/tim/plugin/tableForm/table-form.component.ts
@@ -254,7 +254,7 @@ const sortLang = "fi";
                 <ng-container *ngIf="runScripts">
                     <button class="timButton"
                             *ngFor="let s of runScripts"
-                            [hidden]="!s.all && !cbCount"
+                            [hidden]="(!s.all && !cbCount) || !s.button"
                             (click)="runJsRunner(s)">
                         {{ s.button }}
                     </button>


### PR DESCRIPTION
Testisivu: <https://timbeta01.tim.education/view/users/dz-dz/test-add-jsrunner> (kokeile testuser1)

Kaksi muutosta:

- Lisätty `runScripts.onMemberAdd`-asetus TableFormsiin. Sen avulla skripti voidaan ajaa heti sen jälkeen, kun ryhmään on lisätty uusi käyttäjä. Käyttötarkoituksena on esim. fieldien arvojen asettaminen heti, kun käyttäjä luodaan.
- Jos `runScripts.button` on tyhjä tai null, sitä vastaavaa painiketta ei näytetä tableFormin kohdalla

Näiden avulla on mahdollista toteuttaa loputkin SUKOL-koehallintasivun opettajataulukkoon tarvittavia ominaisuuksia.