### PR TITLE
Improve multisave automatic saving, check readonly attributes, log answer requests

### DIFF
--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -277,6 +277,8 @@ BACKUP_ANSWER_FILE = "answers.backup"
 # The hosts where to back up the answers. Every entry should start with "https://".
 BACKUP_ANSWER_HOSTS = None
 
+ANSWER_LOG_FILE = None
+
 SYNC_USER_GROUPS_SEND_SECRET = None
 """
 Secret to use to when syncing user group info. If None, no user group memberships.

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -1289,7 +1289,9 @@ export class CsController extends CsBase implements ITimComponent {
             return;
         }
 
-        this.editor.setReadOnly(this.markup.editorreadonly === true);
+        this.editor.setReadOnly(
+            this.markup.editorreadonly === true || this.readonly
+        );
         if (this.attrsall.submittedFiles || this.markup.files) {
             const files = new OrderedSet<EditorFile>((f) => f.path);
             const defaultMode =
@@ -1589,7 +1591,7 @@ export class CsController extends CsBase implements ITimComponent {
         }
         await this.runCode();
         this.cdr.detectChanges();
-        return {saved: true, message: undefined};
+        return {saved: !this.edited, message: this.connectionErrorMessage};
     }
 
     formBehavior(): FormModeOption {

--- a/timApp/modules/fields/js/dropdown-plugin.component.ts
+++ b/timApp/modules/fields/js/dropdown-plugin.component.ts
@@ -83,7 +83,7 @@ const DropdownAll = t.intersection([
                 [(ngModel)]="selectedWord"
                 (ngModelChange)="updateSelection()"
                 [ngClass]="{warnFrame: isUnSaved(), alertFrame: saveFailed}"
-                [disabled]="attrsall['preview']"
+                [disabled]="attrsall['preview'] || readonly"
                 [ngStyle]="styles"
                 [tooltip]="connectionErrorMessage"
                 [isOpen]="connectionErrorMessage !== undefined"
@@ -250,7 +250,10 @@ export class DropdownPluginComponent
             this.saveFailed = true;
         }
         this.initialWord = this.selectedWord;
-        return {saved: r.ok, message: this.error};
+        return {
+            saved: r.ok,
+            message: this.error ?? this.connectionErrorMessage,
+        };
     }
 
     updateSelection() {

--- a/timApp/modules/fields/js/multisave.ts
+++ b/timApp/modules/fields/js/multisave.ts
@@ -337,6 +337,7 @@ export class MultisaveComponent
                         const reg = new RegExp(`^${o.expect}$`);
                         if (reg.test(msg)) {
                             msg = o.replace;
+                            break;
                         }
                     }
                 }

--- a/timApp/modules/fields/js/multisave.ts
+++ b/timApp/modules/fields/js/multisave.ts
@@ -16,7 +16,7 @@ import {
     Info,
     withDefault,
 } from "tim/plugin/attributes";
-import {escapeRegExp, scrollToElement} from "tim/util/utils";
+import {escapeRegExp, scrollToElement, timeout} from "tim/util/utils";
 import type {TaskId} from "tim/plugin/taskid";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
@@ -49,6 +49,15 @@ const multisaveMarkup = t.intersection([
         testOnly: t.boolean,
         savedText: t.string,
         unsavedText: t.string,
+        timer: t.number,
+        saveDelay: t.number,
+        showMessages: t.boolean,
+        messageOverrides: t.array(
+            t.type({
+                expect: t.string,
+                replace: t.string,
+            })
+        ),
     }),
     GenericPluginMarkup,
     t.type({
@@ -92,6 +101,9 @@ const multisaveAll = t.intersection([
                 </li>
             </ul>
         </div>
+        <div *ngIf="saveMessages" class="saveMessages">
+            <div *ngFor="let m of saveMessages">{{m}}</div>
+        </div>
         <div *ngIf="allSaved()">
             {{allSavedText}}
         </div>
@@ -133,6 +145,8 @@ export class MultisaveComponent
     unsavedTasksWithAliases: {component: ITimComponent; alias?: string}[] = [];
     requiresTaskId = false;
     listener = false;
+    timer?: number;
+    saveMessages: string[] = [];
 
     constructor(
         el: ElementRef<HTMLElement>,
@@ -295,6 +309,9 @@ export class MultisaveComponent
 
         const promises = [];
         for (const v of componentsToSave) {
+            if (this.markup.saveDelay) {
+                await timeout(this.markup.saveDelay);
+            }
             const result = v.save();
             promises.push(result);
         }
@@ -303,6 +320,7 @@ export class MultisaveComponent
         this.savedFields = 0;
         let savedIndex = 0;
         const fieldsToUpdate: string[] = [];
+        this.saveMessages = [];
         for (const p of promises) {
             const result = await p;
             if (result.saved) {
@@ -312,7 +330,24 @@ export class MultisaveComponent
                     fieldsToUpdate.push(tid.docTask().toString());
                 }
             }
+            if (this.markup.showMessages && result.message) {
+                let msg = result.message;
+                if (this.markup.messageOverrides) {
+                    for (const o of this.markup.messageOverrides) {
+                        const reg = new RegExp(`^${o.expect}$`);
+                        if (reg.test(msg)) {
+                            msg = o.replace;
+                        }
+                    }
+                }
+                if (!this.saveMessages.includes(msg)) {
+                    this.saveMessages.push(msg);
+                }
+            }
             savedIndex++;
+        }
+        if (this.markup.timer && !this.allSaved()) {
+            this.setTimer();
         }
         if (this.markup.autoUpdateTables) {
             this.vctrl.updateAllTables(fieldsToUpdate);
@@ -378,6 +413,22 @@ export class MultisaveComponent
         this.hasUnsavedTargets = true;
         this.refreshUnsavedList();
         this.isSaved = false;
+        if (this.markup.timer) {
+            if (this.timer) {
+                window.clearTimeout(this.timer);
+            }
+            this.setTimer();
+        }
+    }
+
+    private setTimer() {
+        if (!this.markup.timer) {
+            return;
+        }
+        if (this.timer) {
+            window.clearTimeout(this.timer);
+        }
+        this.timer = window.setTimeout(() => this.save(), this.markup.timer);
     }
 
     public informAboutChanges(taskId: TaskId, state: ChangeType, tag?: string) {

--- a/timApp/modules/fields/js/textfield-plugin.component.ts
+++ b/timApp/modules/fields/js/textfield-plugin.component.ts
@@ -644,6 +644,8 @@ export class TextfieldPluginComponent
                 defaultErrorMessage;
             this.redAlert = true;
             this.saveFailed = true;
+            this.saveResponse.saved = false;
+            this.saveResponse.message = this.errormessage;
         }
         return this.saveResponse;
     }

--- a/timApp/modules/fields/multisave.py
+++ b/timApp/modules/fields/multisave.py
@@ -22,6 +22,12 @@ class MultisaveStateModel:
 
 
 @dataclass
+class MessageOverrides:
+    expect: str
+    replace: str
+
+
+@dataclass
 class MultisaveMarkupModel(GenericMarkupModel):
     aliases: dict[str, str] | Missing = missing
     areas: list[str] | Missing = missing
@@ -36,6 +42,10 @@ class MultisaveMarkupModel(GenericMarkupModel):
     savedText: str | Missing = missing
     tags: list[str] | Missing = missing
     unsavedText: str | Missing = missing
+    timer: int | Missing = missing
+    saveDelay: int | Missing = missing
+    showMessages: bool | Missing = False
+    messageOverrides: list[MessageOverrides] | Missing = missing
 
     # Sisu export-related fields; TODO: Should be a separate plugin.
     destCourse: str | Missing = missing

--- a/timApp/static/scripts/tim/plugin/qst/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst/qst.component.ts
@@ -174,7 +174,7 @@ export class QstComponent
         if (!this.pluginMeta.isPreview()) {
             this.vctrl.addTimComponent(this);
         }
-        if (this.attrsall.markup.invalid || this.attrsall.markup.readonly) {
+        if (this.attrsall.markup.invalid || this.readonly) {
             this.enabled = false;
         }
         this.preview = makePreview(this.attrsall.markup, {

--- a/timApp/static/scripts/tim/plugin/qst/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst/qst.component.ts
@@ -116,6 +116,7 @@ export class QstComponent
     private newAnswer?: AnswerTable;
     private changes = false;
     saveFailed = false;
+    private enabled = true;
 
     constructor(
         el: ElementRef<HTMLElement>,
@@ -173,11 +174,14 @@ export class QstComponent
         if (!this.pluginMeta.isPreview()) {
             this.vctrl.addTimComponent(this);
         }
+        if (this.attrsall.markup.invalid || this.attrsall.markup.readonly) {
+            this.enabled = false;
+        }
         this.preview = makePreview(this.attrsall.markup, {
             answerTable: this.attrsall.state ?? [],
             showCorrectChoices: this.attrsall.show_result,
             showExplanations: this.attrsall.show_result,
-            enabled: !this.attrsall.markup.invalid,
+            enabled: this.enabled,
         });
         this.button = this.buttonText() ?? $localize`Save`;
     }
@@ -337,7 +341,7 @@ export class QstComponent
         if (data.web.markup && data.web.show_result) {
             this.preview = makePreview(data.web.markup, {
                 answerTable: data.web.state,
-                enabled: true,
+                enabled: this.enabled ?? true,
             });
             this.preview.showExplanations = true;
             this.preview.showCorrectChoices = true;
@@ -354,7 +358,7 @@ export class QstComponent
             answerTable: this.savedAnswer,
             showCorrectChoices: this.attrsall.show_result,
             showExplanations: this.attrsall.show_result,
-            enabled: !this.attrsall.markup.invalid,
+            enabled: this.enabled,
         });
         this.checkChanges();
         this.saveFailed = false;


### PR DESCRIPTION
- Qst/Dropdown/Csplugin: Estä vastaaminen jos readonly: true
- Multisave: lisää attribuutteja automaattisen tallentamisen ja tallennusvirheiden näyttämisen tueksi
  - timer: Automaattinen tallennus x millisekunnin välein
  - saveDelay: ms odotus kahden eri tehtävän tallentamisen välillä
  - showMessages: Jos true niin kerää ja näyttää virheviestit plugineilta joita yritettiin tallentaa. Toistaiseksi vaan raaka divlista jokaisesta uniikista viestistä
  - messageOverrides: lista `{excpect: str/regex, override: str}` jolla voi ylikirjoittaa tallennettavien plugineiden virheviestejä
- conf ANSWER_LOG_FILE: tallentaa raakatiedon vastauspyynnöistä ennen oikeustarkistuksia/pluginkutsuja tms vastauskäsittelyjä