### PR TITLE
Fix getting max_points value for TIDEPluginData

### DIFF
--- a/timApp/idesupport/utils.py
+++ b/timApp/idesupport/utils.py
@@ -38,7 +38,6 @@ from timApp.printing.printsettings import PrintFormat
 from timApp.timdb.sqa import run_sql
 from timApp.user.user import User
 from timApp.util.flask.requesthelper import NotExist, RouteException
-from timApp.util.logger import log_info
 from tim_common.marshmallow_dataclass import class_schema
 
 IDE_TASK_TAG = "ideTask"  # Identification tag for the TIDE-task

--- a/timApp/idesupport/utils.py
+++ b/timApp/idesupport/utils.py
@@ -746,7 +746,7 @@ def get_ide_user_plugin_data(
     max_points = None
     try:
         max_points = float(plugin.max_points())
-    except ValueError as e:
+    except (ValueError, TypeError):
         pass
 
     return TIDEPluginData(

--- a/timApp/idesupport/utils.py
+++ b/timApp/idesupport/utils.py
@@ -38,6 +38,7 @@ from timApp.printing.printsettings import PrintFormat
 from timApp.timdb.sqa import run_sql
 from timApp.user.user import User
 from timApp.util.flask.requesthelper import NotExist, RouteException
+from timApp.util.logger import log_info
 from tim_common.marshmallow_dataclass import class_schema
 
 IDE_TASK_TAG = "ideTask"  # Identification tag for the TIDE-task
@@ -743,7 +744,11 @@ def get_ide_user_plugin_data(
         elif "source" in extra_file:
             supplementary_files.append(SupplementaryFileSchema.load(extra_file))
 
-    max_points = plugin.values.get("pointsRule", {}).get("maxPoints", None)
+    max_points = None
+    try:
+        max_points = float(plugin.max_points())
+    except ValueError as e:
+        pass
 
     return TIDEPluginData(
         task_files=json_ide_files,


### PR DESCRIPTION
The TIDE-CLI support function `get_ide_user_plugin_data` previously returned the raw value for the `csPlugin` attribute `maxPoints`. However, `maxPoints` is of type `str | int | float | None`, so we cannot use it directly.

This PR rectifies this by calling the task plugin's `max_points()` method, which parses the value of `maxPoints`.

Closes #3812 