### PR TITLE
Feature: velp notifications

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10611,6 +10611,22 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">718,719</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="5769201915047199693" datatype="html">
+        <source>New velps</source>
+        <target state="translated">Uudet velpit</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">386</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4823150464798164794" datatype="html">
+        <source>Velp modifications</source>
+        <target state="translated">Velppien muutokset</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">389</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10485,35 +10485,51 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         </context-group>
       </trans-unit>
       <trans-unit id="8036091162175708988" datatype="html">
-        <source>Make sure the exam is ended and login codes are disabled in section <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;3. Manage exams&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/></source>
-        <target state="new">Make sure the exam is ended and login codes are disabled in section <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;3. Manage exams&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/></target>
+        <source>Make sure the exam is ended and login codes are disabled in section <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'3. Manage exams'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/></source>
+        <target state="new">Make sure the exam is ended and login codes are disabled in section <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'3. Manage exams'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/examGroupManager/exam-group-manager.component.ts</context>
           <context context-type="linenumber">717,718</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3550757413033906635" datatype="html">
-        <source>Students can open the exam using the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;Open exam&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> button.</source>
-        <target state="new">Students can open the exam using the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;Open exam&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> button.</target>
+        <source>Students can open the exam using the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'Open exam'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/> button.</source>
+        <target state="new">Students can open the exam using the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'Open exam'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/> button.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/examGroupManager/exam-group-manager.component.ts</context>
           <context context-type="linenumber">720,721</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4189671442877791653" datatype="html">
-        <source>To end the view right, press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;End showing answers to students button&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>. The right is automatically disabled in 1 hour.</source>
-        <target state="new">To end the view right, press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;End showing answers to students button&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/>. The right is automatically disabled in 1 hour.</target>
+        <source>To end the view right, press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'End showing answers to students button'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>. The right is automatically disabled in 1 hour.</source>
+        <target state="new">To end the view right, press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'End showing answers to students button'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/>. The right is automatically disabled in 1 hour.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/examGroupManager/exam-group-manager.component.ts</context>
           <context context-type="linenumber">722,723</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6667488878974100003" datatype="html">
-        <source>Press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;Begin showing answers to students&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> button to allow students to review their answers for 1 hour.</source>
-        <target state="new">Press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i&gt;"/>&apos;Begin showing answers to students&apos;<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i&gt;"/> button to allow students to review their answers for 1 hour.</target>
+        <source>Press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'Begin showing answers to students'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/> button to allow students to review their answers for 1 hour.</source>
+        <target state="new">Press the <x id="START_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;i>"/>'Begin showing answers to students'<x id="CLOSE_ITALIC_TEXT" ctype="x-i" equiv-text="&lt;/i>"/> button to allow students to review their answers for 1 hour.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/plugin/examGroupManager/exam-group-manager.component.ts</context>
           <context context-type="linenumber">718,719</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5769201915047199693" datatype="html">
+        <source>New velps</source>
+        <target state="translated">Nya velper</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">386</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4823150464798164794" datatype="html">
+        <source>Velp modifications</source>
+        <target state="translated">Ändringar till velps</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/user/settings.component.ts</context>
+          <context context-type="linenumber">389</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/migrations/versions/eccae2b73601_add_notificationtypes_for_annotations.py
+++ b/timApp/migrations/versions/eccae2b73601_add_notificationtypes_for_annotations.py
@@ -1,0 +1,45 @@
+"""Add NotificationTypes for Annotations
+
+Revision ID: eccae2b73601
+Revises: a1485d740d43
+Create Date: 2025-03-19 12:23:55.539477
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "eccae2b73601"
+down_revision = "a1485d740d43"
+
+from alembic import op
+import sqlalchemy as sa
+
+e = sa.Enum(
+    "DocModified",
+    "ParAdded",
+    "ParModified",
+    "ParDeleted",
+    "CommentAdded",
+    "CommentModified",
+    "CommentDeleted",
+    "AnswerAdded",
+    "AnnotationAdded",
+    "AnnotationModified",
+    "AnnotationDeleted",
+    name="notificationtype",
+)
+
+
+def upgrade():
+    # Alter the existing enum type to include new values
+    op.execute("ALTER TYPE notificationtype ADD VALUE IF NOT EXISTS 'AnnotationAdded'")
+    op.execute(
+        "ALTER TYPE notificationtype ADD VALUE IF NOT EXISTS 'AnnotationModified'"
+    )
+    op.execute(
+        "ALTER TYPE notificationtype ADD VALUE IF NOT EXISTS 'AnnotationDeleted'"
+    )
+
+
+def downgrade():
+    # Downgrade logic if needed (e.g., removing values, though PostgreSQL doesn't allow removing values from enums)
+    pass

--- a/timApp/notification/notification.py
+++ b/timApp/notification/notification.py
@@ -1,4 +1,4 @@
-import enum
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from sqlalchemy import ForeignKey
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from timApp.item.block import Block
 
 
-class NotificationType(enum.Enum):
+class NotificationType(Enum):
     DocModified = 1
     ParAdded = 2
     ParModified = 3

--- a/timApp/notification/notification.py
+++ b/timApp/notification/notification.py
@@ -22,6 +22,9 @@ class NotificationType(enum.Enum):
     CommentModified = 6
     CommentDeleted = 7
     AnswerAdded = 8
+    AnnotationAdded = 9
+    AnnotationModified = 10
+    AnnotationDeleted = 11
 
     @property
     def is_document_modification(self) -> bool:

--- a/timApp/notification/notification.py
+++ b/timApp/notification/notification.py
@@ -35,6 +35,22 @@ class NotificationType(Enum):
             NotificationType.ParModified,
         )
 
+    @property
+    def is_comment_notification(self) -> bool:
+        return self in (
+            NotificationType.CommentAdded,
+            NotificationType.CommentModified,
+            NotificationType.CommentDeleted,
+        )
+
+    @property
+    def is_velp_notification(self) -> bool:
+        return self in (
+            NotificationType.AnnotationAdded,
+            NotificationType.AnnotationModified,
+            NotificationType.AnnotationDeleted,
+        )
+
 
 class Notification(db.Model):
     """Notification settings for a User for a block."""

--- a/timApp/notification/notify.py
+++ b/timApp/notification/notify.py
@@ -424,49 +424,51 @@ def process_pending_notifications():
         settings = doc.document.get_settings()
         show_only_diff = settings.send_basic_change_notifications()
         # Combine ps to a single mail (tailored for each subscriber) and send it
-        if t == "d":
-            assert all(
-                isinstance(p, DocumentNotification) for p in ps
-            ), "Expected all notifications of type DocumentNotification"
-            condition = Notification.notification_type.in_(
-                (
-                    NotificationType.DocModified,
-                    NotificationType.ParModified,
-                    NotificationType.ParAdded,
-                    NotificationType.ParDeleted,
+        match t:
+            case "d":
+                assert all(
+                    isinstance(p, DocumentNotification) for p in ps
+                ), "Expected all notifications of type DocumentNotification"
+                condition = Notification.notification_type.in_(
+                    (
+                        NotificationType.DocModified,
+                        NotificationType.ParModified,
+                        NotificationType.ParAdded,
+                        NotificationType.ParDeleted,
+                    )
                 )
-            )
-        elif t == "c":
-            assert all(
-                isinstance(p, CommentNotification) for p in ps
-            ), "Expected all notifications of type CommentNotification"
-            condition = Notification.notification_type.in_(
-                (
-                    NotificationType.CommentAdded,
-                    NotificationType.CommentDeleted,
-                    NotificationType.CommentModified,
+            case "c":
+                assert all(
+                    isinstance(p, CommentNotification) for p in ps
+                ), "Expected all notifications of type CommentNotification"
+                condition = Notification.notification_type.in_(
+                    (
+                        NotificationType.CommentAdded,
+                        NotificationType.CommentDeleted,
+                        NotificationType.CommentModified,
+                    )
                 )
-            )
-        elif t == "a":
-            assert all(
-                isinstance(p, AnswerNotification) for p in ps
-            ), "Expected all notifications of type AnswerNotification"
-            condition = Notification.notification_type.in_(
-                (NotificationType.AnswerAdded,)
-            )
-        elif t == "v":
-            assert all(
-                isinstance(p, AnnotationNotification) for p in ps
-            ), "Expected all notifications of type AnnotationNotification"
-            condition = Notification.notification_type.in_(
-                (
-                    NotificationType.AnnotationAdded,
-                    NotificationType.AnnotationModified,
-                    NotificationType.AnnotationDeleted,
+            case "a":
+                assert all(
+                    isinstance(p, AnswerNotification) for p in ps
+                ), "Expected all notifications of type AnswerNotification"
+                condition = Notification.notification_type.in_(
+                    (NotificationType.AnswerAdded,)
                 )
-            )
-        else:
-            assert False, "Unknown notification type"
+            case "v":
+                assert all(
+                    isinstance(p, AnnotationNotification) for p in ps
+                ), "Expected all notifications of type AnnotationNotification"
+                condition = Notification.notification_type.in_(
+                    (
+                        NotificationType.AnnotationAdded,
+                        NotificationType.AnnotationModified,
+                        NotificationType.AnnotationDeleted,
+                    )
+                )
+            case _:
+                assert False, "Unknown notification type"
+
         users_to_notify: set[User] = {n.user for n in doc.get_notifications(condition)}
         for user in users_to_notify:
             if (

--- a/timApp/notification/notify.py
+++ b/timApp/notification/notify.py
@@ -505,7 +505,9 @@ def process_pending_notifications():
                 NotificationType.AnnotationDeleted,
             ]
 
-            # Poster identity should be hidden unless the user has teacher access to the document
+            # Poster identity should be hidden unless:
+            #  - the user has teacher access to the document, or
+            #  - the notification concerns a public annotation in the document.
             subject = get_subject_for(
                 ps_to_consider, doc, show_names=is_annotation or is_teacher
             )

--- a/timApp/notification/pending_notification.py
+++ b/timApp/notification/pending_notification.py
@@ -76,6 +76,18 @@ class CommentNotification(PendingNotification):
     }
 
 
+class AnnotationNotification(PendingNotification):
+    """A notification that an annotation/velp has been added, changed or deleted."""
+
+    @property
+    def grouping_key(self) -> GroupingKey:
+        return self.doc_id, "v"
+
+    __mapper_args__ = {
+        "polymorphic_identity": "v",
+    }
+
+
 class AnswerNotification(PendingNotification):
     """A notification that an answer has been added, changed or deleted."""
 

--- a/timApp/static/scripts/tim/item/manage/notification-options.component.ts
+++ b/timApp/static/scripts/tim/item/manage/notification-options.component.ts
@@ -9,8 +9,10 @@ import {HttpClient} from "@angular/common/http";
 interface INotificationSettings {
     email_doc_modify: boolean;
     email_comment_add: boolean;
-    email_comment_modify: boolean;
     email_answer_add: boolean;
+    email_comment_modify: boolean;
+    email_annotation_add: boolean;
+    email_annotation_modify: boolean;
 }
 
 @Component({
@@ -36,6 +38,14 @@ interface INotificationSettings {
                     <input name="email_answer_add" type="checkbox" [(ngModel)]="notifySettings.email_answer_add"
                            (ngModelChange)="notifyChanged()"/>New answers to tasks
                 </label></div>
+                <div class="checkbox"><label>
+                    <input name="email_annotation_add" type="checkbox" [(ngModel)]="notifySettings.email_annotation_add" 
+                           (ngModelChange)="notifyChanged()"/>New velps
+                </label></div>
+                <div class="checkbox"><label>
+                    <input name="email_annotation_modify" type="checkbox" [(ngModel)]="notifySettings.email_annotation_modify"
+                           (ngModelChange)="notifyChanged()"/>Edited velps
+                </label></div>
             </fieldset>
         </form>
     `,
@@ -47,8 +57,10 @@ export class NotificationOptionsComponent implements OnInit {
     notifySettings: INotificationSettings = {
         email_answer_add: false,
         email_comment_add: false,
-        email_comment_modify: false,
         email_doc_modify: false,
+        email_comment_modify: false,
+        email_annotation_add: false,
+        email_annotation_modify: false,
     };
 
     constructor(private http: HttpClient) {

--- a/timApp/static/scripts/tim/user/settings.component.ts
+++ b/timApp/static/scripts/tim/user/settings.component.ts
@@ -381,6 +381,12 @@ type StyleSelectionType =
                         <i *ngIf="isAnswerAdd(n)"
                            class="notification-icon glyphicon glyphicon-open-file"
                            title="Answer posts" i18n-title></i>
+                        <i *ngIf="isAnnotationAdd(n)"
+                           class="notification-icon glyphicon glyphicon-send"
+                           title="New velps" i18n-title></i>
+                        <i *ngIf="isAnnotationModify(n)"
+                           class="notification-icon glyphicon glyphicon-comment"
+                           title="Velp modifications" i18n-title></i>
                     </li>
                 </ul>
                 <button (click)="getAllNotifications()"
@@ -1359,6 +1365,17 @@ export class SettingsComponent implements DoCheck, AfterViewInit {
 
     isAnswerAdd(n: GroupedNotification) {
         return n.notificationTypes.has(NotificationType.AnswerAdded);
+    }
+
+    isAnnotationAdd(n: GroupedNotification) {
+        return n.notificationTypes.has(NotificationType.AnnotationAdded);
+    }
+
+    isAnnotationModify(n: GroupedNotification) {
+        return (
+            n.notificationTypes.has(NotificationType.AnnotationModified) ||
+            n.notificationTypes.has(NotificationType.AnnotationDeleted)
+        );
     }
 
     async getAllNotifications() {

--- a/timApp/static/scripts/tim/util/globals.ts
+++ b/timApp/static/scripts/tim/util/globals.ts
@@ -164,6 +164,9 @@ export enum NotificationType {
     CommentModified = 6,
     CommentDeleted = 7,
     AnswerAdded = 8,
+    AnnotationAdded = 9,
+    AnnotationModified = 10,
+    AnnotationDeleted = 11,
 }
 
 export interface INotification {

--- a/timApp/tests/db/test_notify.py
+++ b/timApp/tests/db/test_notify.py
@@ -6,25 +6,43 @@ class NotifyTest(TimDbTest):
     def test_notify(self):
         d = self.create_doc()
         n = self.test_user_1.get_notify_settings(d)
+        self.assertFalse(n["email_doc_modify"])
         self.assertFalse(n["email_comment_add"])
         self.assertFalse(n["email_comment_modify"])
-        self.assertFalse(n["email_doc_modify"])
         self.assertFalse(n["email_answer_add"])
+        self.assertFalse(n["email_annotation_add"])
+        self.assertFalse(n["email_annotation_modify"])
         self.test_user_1.set_notify_settings(
-            d, doc_modify=True, comment_add=True, comment_modify=True, answer_add=True
+            d,
+            doc_modify=True,
+            comment_add=True,
+            comment_modify=True,
+            answer_add=True,
+            annotation_add=True,
+            annotation_modify=True,
         )
         db.session.commit()
         n = self.test_user_1.get_notify_settings(d)
-        self.assertTrue(n["email_comment_add"])
-        self.assertTrue(n["email_comment_modify"])
         self.assertTrue(n["email_doc_modify"])
+        self.assertTrue(n["email_comment_add"])
+        self.assertTrue(n["email_comment_modify"])
         self.assertTrue(n["email_answer_add"])
+        self.assertTrue(n["email_annotation_add"])
+        self.assertTrue(n["email_annotation_modify"])
         self.test_user_1.set_notify_settings(
-            d, doc_modify=False, comment_add=True, comment_modify=True, answer_add=True
+            d,
+            doc_modify=False,
+            comment_add=True,
+            comment_modify=True,
+            answer_add=True,
+            annotation_add=True,
+            annotation_modify=False,
         )
         db.session.commit()
         n = self.test_user_1.get_notify_settings(d)
+        self.assertFalse(n["email_doc_modify"])
         self.assertTrue(n["email_comment_add"])
         self.assertTrue(n["email_comment_modify"])
-        self.assertFalse(n["email_doc_modify"])
         self.assertTrue(n["email_answer_add"])
+        self.assertTrue(n["email_annotation_add"])
+        self.assertFalse(n["email_annotation_modify"])

--- a/timApp/tests/server/test_comments.py
+++ b/timApp/tests/server/test_comments.py
@@ -138,6 +138,8 @@ class CommentTest(NotifyTestBase):
                 "email_comment_modify": True,
                 "email_doc_modify": True,
                 "email_answer_add": False,
+                "email_annotation_add": False,
+                "email_annotation_modify": False,
             },
         )
         process_pending_notifications()

--- a/timApp/tests/server/test_manage.py
+++ b/timApp/tests/server/test_manage.py
@@ -17,6 +17,8 @@ class ManageTest(TimRouteTest):
                 "email_comment_add": False,
                 "email_comment_modify": False,
                 "email_answer_add": False,
+                "email_annotation_add": False,
+                "email_annotation_modify": False,
             },
         )
 
@@ -25,11 +27,15 @@ class ManageTest(TimRouteTest):
             "email_comment_add": False,
             "email_comment_modify": False,
             "email_answer_add": False,
+            "email_annotation_add": False,
+            "email_annotation_modify": False,
         }, {
             "email_doc_modify": False,
             "email_comment_add": True,
             "email_comment_modify": True,
             "email_answer_add": True,
+            "email_annotation_add": True,
+            "email_annotation_modify": True,
         }:
             self.json_post(f"/notify/{d.id}", new_settings)
             self.get(f"/notify/{d.id}", expect_content=new_settings)

--- a/timApp/tests/server/test_notify.py
+++ b/timApp/tests/server/test_notify.py
@@ -41,6 +41,8 @@ class NotifyTestBase(TimRouteTest):
                 "email_comment_modify": False,
                 "email_doc_modify": True,
                 "email_answer_add": False,
+                "email_annotation_add": False,
+                "email_annotation_modify": False,
             },
         )
         self.login_test1()
@@ -61,6 +63,8 @@ class NotifyTest(NotifyTestBase):
                 "email_comment_modify": False,
                 "email_doc_modify": False,
                 "email_answer_add": False,
+                "email_annotation_add": False,
+                "email_annotation_modify": False,
             },
             n,
         )
@@ -69,6 +73,8 @@ class NotifyTest(NotifyTestBase):
             "email_comment_modify": False,
             "email_doc_modify": True,
             "email_answer_add": False,
+            "email_annotation_add": True,
+            "email_annotation_modify": True,
         }
         self.update_notify_settings(d, new_settings)
         n = self.get(notify_url)
@@ -243,6 +249,8 @@ class NotifyFolderTest(NotifyTestBase):
                 "email_comment_modify": False,
                 "email_doc_modify": True,
                 "email_answer_add": False,
+                "email_annotation_add": False,
+                "email_annotation_modify": False,
             },
         )
         r = self.get("/notify/all")
@@ -266,6 +274,8 @@ class NotifyFolderTest(NotifyTestBase):
                 "email_comment_modify": False,
                 "email_doc_modify": True,
                 "email_answer_add": False,
+                "email_annotation_add": False,
+                "email_annotation_modify": False,
             },
         )
         r = self.get("/notify/all")
@@ -373,6 +383,8 @@ type: text
                 "email_comment_modify": False,
                 "email_doc_modify": False,
                 "email_answer_add": True,
+                "email_annotation_add": False,
+                "email_annotation_modify": False,
             },
         )
         self.login_test1()

--- a/timApp/tests/server/test_notify.py
+++ b/timApp/tests/server/test_notify.py
@@ -1,7 +1,9 @@
 from sqlalchemy import select
 
 from timApp.auth.accesstype import AccessType
+from timApp.document.docentry import DocEntry
 from timApp.document.docinfo import DocInfo
+from timApp.document.docparagraph import DocParagraph
 from timApp.document.randutils import random_id
 from timApp.notification.notification import NotificationType
 from timApp.notification.notify import (
@@ -15,6 +17,9 @@ from timApp.notification.pending_notification import (
 from timApp.notification.send_email import sent_mails_in_testing
 from timApp.tests.server.timroutetest import TimRouteTest
 from timApp.timdb.sqa import db, run_sql
+from timApp.velp.velp_models import Velp
+from timApp.velp.annotation import AnnotationVisibility
+from timApp.velp.annotation_model import AnnotationPosition, AnnotationCoordinate
 
 
 class NotifyTestBase(TimRouteTest):
@@ -53,6 +58,58 @@ class NotifyTestBase(TimRouteTest):
         if add_new_par:
             self.new_par(d.document, "test")
         return d, title, url
+
+    def prepare_annotation_doc(
+        self, annotation_visibility: AnnotationVisibility | None = None
+    ) -> tuple[DocEntry, Velp, AnnotationPosition, int, DocParagraph]:
+        self.login_test1()
+        initial_par = """
+                #- 
+                test text 1
+                """
+        d = self.create_doc(initial_par=initial_par)
+        self.test_user_2.grant_access(d, AccessType.view)
+        self.test_user_1.set_notify_settings(
+            d,
+            doc_modify=False,
+            comment_modify=False,
+            comment_add=False,
+            answer_add=False,
+            annotation_add=True,
+            annotation_modify=True,
+        )
+        self.test_user_2.set_notify_settings(
+            d,
+            doc_modify=False,
+            comment_modify=False,
+            comment_add=False,
+            answer_add=False,
+            annotation_add=True,
+            annotation_modify=True,
+        )
+        velp, velp_ver = create_new_velp(
+            self.test_user_1.id,
+            "test velp",
+            0,
+        )
+        db.session.commit()
+        par1 = d.document.get_paragraphs()[0]
+        ann_pos = AnnotationPosition(
+            start=AnnotationCoordinate(par_id=par1.id, offset=5),
+            end=AnnotationCoordinate(par_id=par1.id, offset=8),
+        )
+        ann_resp = self.post_annotation(
+            doc_id=d.id,
+            velp_id=velp.id,
+            coord=ann_pos,
+            points=None,
+            visible_to=annotation_visibility
+            if annotation_visibility
+            else AnnotationVisibility.everyone,
+            style=1,
+        )
+        ann_id: int = ann_resp.get("id")
+        return d, velp, ann_pos, ann_id, par1
 
 
 class NotifyTest(NotifyTestBase):
@@ -425,52 +482,8 @@ from timApp.velp.annotation_model import (
 
 
 class VelpNotifyTest(NotifyTestBase):
-    def test_annotation_notification(self):
-        self.login_test1()
-        initial_par = """
-        #- 
-        test text 1
-        """
-        d = self.create_doc(initial_par=initial_par)
-        self.test_user_2.grant_access(d, AccessType.view)
-        self.test_user_1.set_notify_settings(
-            d,
-            doc_modify=False,
-            comment_modify=False,
-            comment_add=False,
-            answer_add=False,
-            annotation_add=True,
-            annotation_modify=False,
-        )
-        self.test_user_2.set_notify_settings(
-            d,
-            doc_modify=False,
-            comment_modify=False,
-            comment_add=False,
-            answer_add=False,
-            annotation_add=True,
-            annotation_modify=False,
-        )
-        velp, velp_ver = create_new_velp(
-            self.test_user_1.id,
-            "test velp",
-            0,
-        )
-        db.session.commit()
-        par1 = d.document.get_paragraphs()[0]
-        ann_pos = AnnotationPosition(
-            start=AnnotationCoordinate(par_id=par1.id, offset=5),
-            end=AnnotationCoordinate(par_id=par1.id, offset=8),
-        )
-        ann_resp = self.post_annotation(
-            doc_id=d.id,
-            velp_id=velp.id,
-            coord=ann_pos,
-            points=None,
-            visible_to=AnnotationVisibility.everyone,
-            style=1,
-        )
-
+    def test_add_annotation_notification(self):
+        d, velp, ann_pos, ann_id, par1 = self.prepare_annotation_doc()
         process_pending_notifications()
         self.assertEqual(1, len(sent_mails_in_testing))
         mail_from = "no-reply@tim.jyu.fi"
@@ -486,77 +499,63 @@ class VelpNotifyTest(NotifyTestBase):
             sent_mails_in_testing[-1],
         )
 
-        ann_id = ann_resp.get("id")
+    def test_edit_annotation_notification(self):
+        d, velp, ann_pos, ann_id, par1 = self.prepare_annotation_doc()
+        process_pending_notifications()
+        sent_mails_in_testing.clear()
+        # Modifying the annotation
+        self.edit_annotation(
+            annotation_id=ann_id,
+            visible_to=AnnotationVisibility.everyone,
+            color="#FF0000",
+        )
+        process_pending_notifications()
+        self.assertEqual(1, len(sent_mails_in_testing))
+        mail_from = "no-reply@tim.jyu.fi"
+        self.assertEqual(
+            {
+                "mail_from": mail_from,
+                "msg": f"Velp modified by user 1 Test: "
+                f"http://localhost/view/{d.name}#{par1.id}\n\ntest velp",
+                "rcpt": "test2@example.com",
+                "reply_to": "test1@example.com",
+                "subject": f"user 1 Test modified a velp in the document {d.title}",
+            },
+            sent_mails_in_testing[-1],
+        )
+
+    def test_delete_annotation_notification(self):
+        d, velp, ann_pos, ann_id, par1 = self.prepare_annotation_doc()
+        process_pending_notifications()
+        sent_mails_in_testing.clear()
+        # Deleting the annotation
         self.delete_annotation(ann_id)
         process_pending_notifications()
         self.assertEqual(1, len(sent_mails_in_testing))
         mail_from = "no-reply@tim.jyu.fi"
-        # FIXME: msg and subject strings (should be 'deleted' instead of 'posted')
         self.assertEqual(
             {
                 "mail_from": mail_from,
-                "msg": f"Velp posted by user 1 Test: "
+                "msg": f"Velp deleted by user 1 Test: "
                 f"http://localhost/view/{d.name}#{par1.id}\n\ntest velp",
                 "rcpt": "test2@example.com",
                 "reply_to": "test1@example.com",
-                "subject": f"user 1 Test posted a velp to the document {d.title}",
+                "subject": f"user 1 Test deleted a velp from the document {d.title}",
             },
-            sent_mails_in_testing[0],
+            sent_mails_in_testing[-1],
         )
 
-    def test_annotation_comment(self):
-        self.login_test1()
-        initial_par = """
-        #- 
-        test text 1
-        """
-        d = self.create_doc(initial_par=initial_par)
-        self.test_user_2.grant_access(d, AccessType.view)
-        self.test_user_1.set_notify_settings(
-            d,
-            doc_modify=False,
-            comment_modify=False,
-            comment_add=False,
-            answer_add=False,
-            annotation_add=True,
-            annotation_modify=False,
-        )
-        self.test_user_2.set_notify_settings(
-            d,
-            doc_modify=False,
-            comment_modify=False,
-            comment_add=False,
-            answer_add=False,
-            annotation_add=True,
-            annotation_modify=False,
-        )
-        velp, velp_ver = create_new_velp(
-            self.test_user_1.id,
-            "test velp",
-            0,
-        )
-        db.session.commit()
-        par1 = d.document.get_paragraphs()[0]
-        ann_pos = AnnotationPosition(
-            start=AnnotationCoordinate(par_id=par1.id, offset=5),
-            end=AnnotationCoordinate(par_id=par1.id, offset=8),
-        )
-        ann_resp = self.post_annotation(
-            doc_id=d.id,
-            velp_id=velp.id,
-            coord=ann_pos,
-            points=None,
-            visible_to=AnnotationVisibility.everyone,
-            style=1,
-        )
+    def test_add_annotation_comment(self):
+        d, velp, ann_pos, ann_id, par1 = self.prepare_annotation_doc()
         process_pending_notifications()
 
+        sent_mails_in_testing.clear()
         comm_resp = self.post_annotation_comment(
-            annotation_id=ann_resp.get("id"), comment="test comment"
+            annotation_id=ann_id, comment="test comment"
         )
         process_pending_notifications()
 
-        self.assertEqual(2, len(sent_mails_in_testing))
+        self.assertEqual(1, len(sent_mails_in_testing))
         mail_from = "no-reply@tim.jyu.fi"
         self.assertEqual(
             {
@@ -569,3 +568,41 @@ class VelpNotifyTest(NotifyTestBase):
             },
             sent_mails_in_testing[-1],
         )
+
+    def test_nonpublic_annotation_notification(self):
+        d, velp, ann_pos, ann_id, par1 = self.prepare_annotation_doc(
+            annotation_visibility=AnnotationVisibility.teacher
+        )
+        process_pending_notifications()
+
+        # Non-public annotations will not trigger notifications
+        self.assertEqual(0, len(sent_mails_in_testing))
+
+        self.edit_annotation(
+            annotation_id=ann_id,
+            visible_to=AnnotationVisibility.everyone,
+        )
+        process_pending_notifications()
+        self.assertEqual(1, len(sent_mails_in_testing))
+        mail_from = "no-reply@tim.jyu.fi"
+        self.assertEqual(
+            {
+                "mail_from": mail_from,
+                "msg": f"Velp modified by user 1 Test: "
+                f"http://localhost/view/{d.name}#{par1.id}\n\ntest velp",
+                "rcpt": "test2@example.com",
+                "reply_to": "test1@example.com",
+                "subject": f"user 1 Test modified a velp in the document {d.title}",
+            },
+            sent_mails_in_testing[-1],
+        )
+
+        sent_mails_in_testing.clear()
+        # Test that setting annotation back to private does not send notification
+        self.edit_annotation(
+            annotation_id=ann_id,
+            visible_to=AnnotationVisibility.myself,
+        )
+        process_pending_notifications()
+        sent = sent_mails_in_testing
+        self.assertEqual(0, len(sent_mails_in_testing))

--- a/timApp/tests/server/timroutetest.py
+++ b/timApp/tests/server/timroutetest.py
@@ -61,6 +61,8 @@ from timApp.timdb.sqa import db, run_sql
 from timApp.user.user import User
 from timApp.user.usergroup import UserGroup
 from timApp.util.utils import remove_prefix
+from timApp.velp.annotation_model import AnnotationPosition
+from timApp.velp.annotations import AnnotationVisibility
 from tim_common.timjsonencoder import TimJsonEncoder
 
 
@@ -1168,6 +1170,87 @@ class TimRouteTestBase(TimDbTest):
                     "curr": glob_id,
                     "orig": glob_id,
                 },
+            },
+            **kwargs,
+        )
+
+    def post_annotation(
+        self,
+        doc_id: int,
+        velp_id: int,
+        visible_to: AnnotationVisibility | int,
+        coord: AnnotationPosition,
+        points: float | None = None,
+        color: str | None = None,
+        answer_id: int | None = None,
+        draw_data: list[dict] | None = None,
+        style: int | None = None,
+        **kwargs,
+    ):
+        return self.json_post(
+            "/add_annotation",
+            {
+                "coord": coord,
+                "doc_id": doc_id,
+                "points": points,
+                "velp_id": velp_id,
+                "visible_to": visible_to.value
+                if isinstance(visible_to, AnnotationVisibility)
+                else visible_to,
+                "color": color,
+                "answer_id": answer_id,
+                "draw_data": draw_data,
+                "style": style,
+            },
+            **kwargs,
+        )
+
+    def post_annotation_comment(
+        self,
+        annotation_id: int,
+        comment: str,
+        **kwargs,
+    ):
+        return self.json_post(
+            "/add_annotation_comment",
+            {"id": annotation_id, "content": comment},
+            **kwargs,
+        )
+
+    def delete_annotation(
+        self,
+        annotation_id: int,
+        **kwargs,
+    ):
+        return self.json_post(
+            "/invalidate_annotation",
+            {"id": annotation_id},
+            **kwargs,
+        )
+
+    def edit_annotation(
+        self,
+        annotation_id: int,
+        visible_to: AnnotationVisibility | int,
+        points: float | None = None,
+        color: str | None = None,
+        coord: AnnotationPosition | None = None,
+        draw_data: list[dict] | None = None,
+        style: int | None = None,
+        **kwargs,
+    ):
+        return self.json_post(
+            "/update_annotation",
+            {
+                "id": annotation_id,
+                "visible_to": visible_to.value
+                if isinstance(visible_to, AnnotationVisibility)
+                else visible_to,
+                "points": points,
+                "color": color,
+                "coord": coord,
+                "draw_data": draw_data,
+                "style": style,
             },
             **kwargs,
         )

--- a/timApp/tim_app.py
+++ b/timApp/tim_app.py
@@ -79,6 +79,7 @@ from timApp.notification.pending_notification import (
     DocumentNotification,
     CommentNotification,
     AnswerNotification,
+    AnnotationNotification,
 )
 from timApp.peerreview.peerreview import PeerReview
 from timApp.plugin.calendar.models import (
@@ -144,6 +145,7 @@ all_models = (
     AccessTypeModel,
     Annotation,
     AnnotationComment,
+    AnnotationNotification,
     Answer,
     AnswerNotification,
     AnswerSaver,

--- a/timApp/user/user.py
+++ b/timApp/user/user.py
@@ -1403,6 +1403,8 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
             "email_comment_add": False,
             "email_comment_modify": False,
             "email_answer_add": False,
+            "email_annotation_add": False,
+            "email_annotation_modify": False,
         }
 
         for nn in n:
@@ -1422,6 +1424,13 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
                 result["email_comment_modify"] = True
             if nn.notification_type in (NotificationType.AnswerAdded,):
                 result["email_answer_add"] = True
+            if nn.notification_type in (NotificationType.AnnotationAdded,):
+                result["email_annotation_add"] = True
+            if nn.notification_type in (
+                NotificationType.AnnotationModified,
+                NotificationType.AnnotationDeleted,
+            ):
+                result["email_annotation_modify"] = True
 
         return result
 
@@ -1432,6 +1441,8 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
         comment_add: bool,
         comment_modify: bool,
         answer_add: bool,
+        annotation_add: bool,
+        annotation_modify: bool,
     ):
         # TODO: Instead of conversion, expose all notification types in UI
         notification_types = []
@@ -1455,6 +1466,15 @@ class User(db.Model, TimeStampMixin, SCIMEntity):
             )
         if answer_add:
             notification_types.extend((NotificationType.AnswerAdded,))
+        if annotation_add:
+            notification_types.extend((NotificationType.AnnotationAdded,))
+        if annotation_modify:
+            notification_types.extend(
+                (
+                    NotificationType.AnnotationModified,
+                    NotificationType.AnnotationDeleted,
+                )
+            )
 
         self.notifications.filter((Notification.block_id == item.id)).delete(
             synchronize_session=False

--- a/timApp/velp/annotation.py
+++ b/timApp/velp/annotation.py
@@ -119,9 +119,10 @@ def add_annotation(
 
     # Only public annotations in the document (not in task answers) will trigger a notification
     if ann.visible_to == AnnotationVisibility.everyone.value and not ann.answer_id:
+        text = ann.velp_content.content
         notify_doc_watchers(
             d,
-            ann.velp_content,
+            text if text is not None else "",
             NotificationType.AnnotationAdded,
             ann.paragraph_id_start,
         )
@@ -218,9 +219,12 @@ def update_annotation(
 
     # Only public annotations in the document (not in task answers) will trigger a notification
     if ann.visible_to == AnnotationVisibility.everyone.value and not ann.answer_id:
-        ann_text = f"{ann.velp_content}\n{ann.comments}"
+        ann_text = ann.velp_content.content
         notify_doc_watchers(
-            d, ann_text, NotificationType.AnnotationModified, ann.paragraph_id_start
+            d,
+            ann_text if ann_text is not None else "",
+            NotificationType.AnnotationModified,
+            ann.paragraph_id_start,
         )
 
     return json_response(ann, date_conversion=True)
@@ -256,10 +260,10 @@ def invalidate_annotation(id: int) -> Response:
         and annotation.visible_to == AnnotationVisibility.everyone.value
         and not annotation.answer_id
     ):
-        ann_text = f"{annotation.velp_content}\n{annotation.comments}"
+        ann_text = annotation.velp_content.content
         notify_doc_watchers(
             d,
-            ann_text,
+            ann_text if ann_text is not None else "",
             NotificationType.AnnotationDeleted,
             annotation.paragraph_id_start,
         )
@@ -307,7 +311,7 @@ def add_comment_route(id: int, content: str) -> Response:
 
     # Only public annotations in the document (not in task answers) will trigger a notification
     if a and a.visible_to == AnnotationVisibility.everyone.value and not a.answer_id:
-        ann_text = f"{content}"
+        ann_text = content
         notify_doc_watchers(
             d, ann_text, NotificationType.AnnotationModified, a.paragraph_id_start
         )

--- a/timApp/velp/annotation.py
+++ b/timApp/velp/annotation.py
@@ -122,7 +122,7 @@ def add_annotation(
 
 
 def notify_annotation_subscribers(
-    document: DocInfo | DocEntry,
+    document: DocInfo | DocEntry | None,
     annotation: Annotation,
     notify_type: NotificationType,
     alt_msg: str | None = None,


### PR DESCRIPTION
Adds subcribable email notifications for annotations ("velps") placed in documents. 
Only publicly viewable annotations will trigger notifications. Answer review annotations do not trigger notifications.

TODO:
- [x] tests for annotation notifications specifically

See also #406.
Closes #998.