### PR TITLE
Fix setting seed number for paragraph randomization macro

### DIFF
--- a/timApp/plugin/pluginControl.py
+++ b/timApp/plugin/pluginControl.py
@@ -209,7 +209,9 @@ class PluginPlacement:
                     rnd_seed = SeedClass(rnd_seed, block.answer_nr)
                 else:  # try with length of answers
                     task_id = block.get_attr("taskId")
-                    doc_id = str(block.doc.doc_id)
+                    doc_id = str(
+                        block.ref_doc.doc_id if block.ref_doc else block.doc.doc_id
+                    )
                     if task_id:
                         answer_and_cnt = answer_map.get(doc_id + "." + task_id, None)
                         if answer_and_cnt:


### PR DESCRIPTION
Previously, `PluginControl.from_par(..)` got the document id with `DocParagraph.doc.doc_id`. For translated documents and reference paragraphs, the document id would point to the translation document or the referreing document instead of the original, so randomization would always receive the same seed number. This meant that randomized tasks would not work in translations or in reference paragraphs.

Fix the above by getting the document id with `DocParagraph.ref_doc.doc_id`. `ref_doc` is set with a call to `Document.dereference_pars(..)` earlier in the call chain.

Closes #3751