### PR TITLE
timDraggableFixed: change default position when slidePars is enabled

### DIFF
--- a/timApp/static/scripts/tim/ui/draggable.ts
+++ b/timApp/static/scripts/tim/ui/draggable.ts
@@ -234,17 +234,29 @@ export class DraggableController implements IController {
         } else {
             this.element.css("position", this.anchor);
             this.element.css("visibility", "visible");
+            if (this.slidePars) {
+                this.initSlidePars();
+            }
             void this.restoreSizeAndPosition(VisibilityFix.Full);
             this.element.removeClass("draggable-attached");
             this.element.addClass("draggable-detached");
-            // console.log("detach", this.slidePars);
-            if (this.slidePars) {
-                vctrlInstance?.addSlideParsState();
-            }
         }
         this.element.css("z-index", this.getVisibleLayer());
 
         this.detachStorage.set(!canDrag);
+    }
+
+    private initSlidePars() {
+        // Move the window to top-left corner unless it was moved previously.
+        if (!this.posStorage.get()) {
+            if (this.setLeft) {
+                this.element.css("left", 0);
+            }
+            if (this.setTop) {
+                this.element.css("top", 0);
+            }
+        }
+        vctrlInstance?.addSlideParsState();
     }
 
     /**
@@ -387,6 +399,10 @@ export class DraggableController implements IController {
 
     private async restoreSizeAndPosition(vf: VisibilityFix) {
         if (!this.posKey) {
+            return;
+        }
+        // Don't try to restore size and position if the element is not draggable.
+        if (!this.canDrag()) {
             return;
         }
         const oldSize = this.sizeStorage.get() ?? this.initialSize;


### PR DESCRIPTION
When slidePars is enabled, move the window to top-left by default. This ensures the window occupies the free space created by the paragraphs that were moved to the right.

---

Jos `float_slide_pars`-lohkoasetus on `true`, tämä PR pakottaa kellutettavan ikkunan oletuksella vasempaan ylänurkkaan.
Tämä PR muuta muuta logiikkaa, sillä kellutettavien lohkoissa käytetään vanhaa Angular.JS:ää. 
Tämän muutoksen pitäisi olla sopivan riittävä mm. SUKOL-kokeisiin.

Testi: <https://tim03.it.jyu.fi/view/sukol/kokeet/2025/a-englanti-2025>  
Tunnuksena toimii oma tuotanto-TIMin tunnus ja salasana. Kyseisellä koneella on kopioa tuotannosta, joten siellä voi testailla myös muita dokumentteja. Omien testien perusteella tämä muuttaa vain niitä lohkoja, jossa on `float_slide_pars="true"`.