### PR TITLE
Simulated drag to touch devices

### DIFF
--- a/timApp/plugin/quantum_circuit/quantumCircuit.py
+++ b/timApp/plugin/quantum_circuit/quantumCircuit.py
@@ -225,6 +225,9 @@ class QuantumCircuitMarkup(GenericMarkupModel):
 
     lazyBody: str | None = None
 
+    removeControls: bool | None = None
+    touchOffset: int | None = None
+
 
 @dataclass
 class QuantumCircuitStateModel:

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
@@ -13,7 +13,10 @@ import {
     Matrix,
 } from "mathjs";
 import {of} from "rxjs";
-import type {ICustomGateInfo} from "tim/plugin/quantumcircuit/quantum-circuit.component";
+import type {
+    ICustomGateInfo,
+    QuantumCircuitMarkupType,
+} from "tim/plugin/quantumcircuit/quantum-circuit.component";
 
 export interface ServiceGate {
     name: string;
@@ -41,6 +44,8 @@ export class GateService {
         [0, 1, 0, 0],
         [0, 0, 0, 1],
     ]);
+
+    markup!: QuantumCircuitMarkupType;
 
     constructor() {
         const H = multiply(
@@ -163,6 +168,14 @@ export class GateService {
         for (const gate of this.gates) {
             this.gateNameToMatrix.set(gate.name, gate.matrix);
         }
+    }
+
+    setMarkup(markup: QuantumCircuitMarkupType) {
+        this.markup = markup;
+    }
+
+    getMarkup(): QuantumCircuitMarkupType {
+        return this.markup;
     }
 
     /**

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit-board.component.scss
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit-board.component.scss
@@ -167,7 +167,6 @@ img {
   margin: 0 0.1em 0 0.1em;
 }
 
-
 .output button {
   background-color: white;
 }
@@ -176,8 +175,18 @@ img {
   pointer-events: none;
 }
 
-
 .gate-drop:hover {
   stroke: grey;
   fill-opacity: 100;
+}
+
+.gate-drop.touch-hover {
+  stroke: grey !important;
+  stroke-width: 5px !important;
+  filter: grayscale(50%) !important;
+}
+
+// Ensure that the text inside the gate does not have extra stroke while hovering
+.gate-text {
+  stroke-width: 1 !important; /* Ensures no stroke width is applied */
 }

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-circuit.component.ts
@@ -1,4 +1,5 @@
 import * as t from "io-ts";
+import type {TypeOf} from "io-ts";
 import type {AfterViewInit, DoBootstrap, OnInit} from "@angular/core";
 import {Component, NgModule, ViewChild, ElementRef} from "@angular/core";
 import {HttpClient, HttpClientModule} from "@angular/common/http";
@@ -179,8 +180,12 @@ const QuantumCircuitMarkup = t.intersection([
         rightAxisLabel: withDefault(t.string, "Output"),
         feedbackShowTable: withDefault(t.boolean, true),
         answerExactMatch: withDefault(t.boolean, false),
+        removeControls: withDefault(t.boolean, true),
+        touchOffset: withDefault(t.number, 0),
     }),
 ]);
+
+export type QuantumCircuitMarkupType = TypeOf<typeof QuantumCircuitMarkup>;
 
 // All data that plugin receives from the server (Markup + any extra state data)
 const QuantumCircuitFields = t.intersection([
@@ -1239,7 +1244,8 @@ export class QuantumCircuitComponent
 
         this.board = new QuantumBoard(
             this.markup.nQubits,
-            this.markup.nMoments
+            this.markup.nMoments,
+            this.markup
         );
 
         try {
@@ -1462,6 +1468,8 @@ export class QuantumCircuitComponent
 
     ngOnInit(): void {
         super.ngOnInit();
+
+        this.gateService.setMarkup(this.markup);
 
         this.initializeBoard(false);
 

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-gate-menu.component.scss
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/quantum-gate-menu.component.scss
@@ -17,7 +17,7 @@ svg text::selection {
   display: flex;
   flex-direction: column;
   border: 1px solid black;
-  max-width: 50vw;
+  max-width: 95vw;
   max-height: 120px;
   overflow-y: auto;
 }


### PR DESCRIPTION
Kosketuslaitteita varten drag-toiminnon simulointi siten, että kohde liikkuu hieman sormen yläpuolella.
Samoin mahdollisuus estää kontrollipallon poistuminen jos kontrolloitavaksi tulee toinen portti.

Molemmat ominaisuudet optiona, eli sellaisenaan minkään ei pitäisi muuttua vielä
nykyisestä.

    removeControls: false     # oletus true jolloin poistaa kontrollipallot kuten nykyisin    
    touchOffset: 40               # oletus 0, jolloin ei tehdä touch ollenkaan vaan käytetään selaimen drag

Jos "asiakas" on tyytyväinen muutoksiin, vaihdetaan em. oletuksiksi.

