### PR TITLE
Quantum circuit: add B and D as basic gates

### DIFF
--- a/timApp/plugin/quantum_circuit/quantumCircuit.py
+++ b/timApp/plugin/quantum_circuit/quantumCircuit.py
@@ -307,7 +307,23 @@ def get_extra_gates() -> dict[str, np.ndarray]:
     Extra gates that are not from qulacs nor custom gates.
     """
     sx = np.array([[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]], complex)
-    return {"SX": sx}
+    B = np.array(
+        [
+            [1 / np.sqrt(2), 0, 1 / np.sqrt(2), 0],
+            [0, 1 / np.sqrt(2), 0, 1 / np.sqrt(2)],
+            [0, 1 / np.sqrt(2), 0, -1 / np.sqrt(2)],
+            [1 / np.sqrt(2), 0, -1 / np.sqrt(2), 0],
+        ]
+    )
+    D = np.array(
+        [
+            [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)],
+            [0, 1 / np.sqrt(2), 1 / np.sqrt(2), 0],
+            [1 / np.sqrt(2), 0, 0, -1 / np.sqrt(2)],
+            [0, 1 / np.sqrt(2), -1 / np.sqrt(2), 0],
+        ]
+    )
+    return {"SX": sx, "B": B, "D": D}
 
 
 def get_gate_matrix(

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
@@ -11,6 +11,8 @@ import {
     pi,
     pow,
     Matrix,
+    sqrt,
+    fraction,
 } from "mathjs";
 import {of} from "rxjs";
 import type {
@@ -92,6 +94,21 @@ export class GateService {
             ],
         ]);
 
+        const sin45 = fraction(1, sqrt(2) as number);
+        const neg_sin45 = fraction(-1, sqrt(2) as number);
+        const B = matrix([
+            [sin45, 0, sin45, 0],
+            [0, sin45, 0, sin45],
+            [0, sin45, 0, neg_sin45],
+            [sin45, 0, neg_sin45, 0],
+        ]);
+        const D = matrix([
+            [sin45, 0, 0, sin45],
+            [0, sin45, sin45, 0],
+            [sin45, 0, 0, neg_sin45],
+            [0, sin45, neg_sin45, 0],
+        ]);
+
         this.gates = [
             {
                 name: "H",
@@ -141,6 +158,20 @@ export class GateService {
                 hidden: false,
                 group: "basic",
                 info: "square root of X",
+            },
+            {
+                name: "B",
+                matrix: B,
+                hidden: false,
+                group: "basic",
+                info: "Bell",
+            },
+            {
+                name: "D",
+                matrix: D,
+                hidden: false,
+                group: "basic",
+                info: "Deutsch",
             },
             {
                 name: "swap",

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
@@ -94,8 +94,10 @@ export class GateService {
             ],
         ]);
 
-        const sin45 = fraction(1, sqrt(2) as number);
-        const neg_sin45 = fraction(-1, sqrt(2) as number);
+        // Fraction only accepts whole numbers as parameters,
+        // so just use `divide` here
+        const sin45 = divide(1, sqrt(2) as number);
+        const neg_sin45 = divide(-1, sqrt(2) as number);
         const B = matrix([
             [sin45, 0, sin45, 0],
             [0, sin45, 0, sin45],

--- a/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
+++ b/timApp/static/scripts/tim/plugin/quantumcircuit/gate.service.ts
@@ -12,7 +12,6 @@ import {
     pow,
     Matrix,
     sqrt,
-    fraction,
 } from "mathjs";
 import {of} from "rxjs";
 import type {


### PR DESCRIPTION
Includes B and D gates in the basic set of gates, so that they do not always have to be declared in the quantum circuit plugin's markup.