### PR TITLE
Feature preview md

### DIFF
--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -2726,14 +2726,14 @@ ${fhtml}
         this.hasBeenRun = true;
         const ty = languageTypes.getRunType(this.selectedLanguage, "cs");
         if (ty === "md") {
-            this.showMD();
+            await this.showMD();
             if (nosave || this.nosave) {
                 return;
             }
         }
         if (languageTypes.isInArray(ty, csJSTypes)) {
             // this.jstype = ty;
-            this.showJS();
+            await this.showJS();
             if (nosave || this.nosave) {
                 return;
             }

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -22,8 +22,6 @@ import {
     ViewChild,
 } from "@angular/core";
 
-import {$rootScope} from "tim/util/ngimport";
-
 import {HttpClient, HttpHeaders} from "@angular/common/http";
 import type {SafeResourceUrl} from "@angular/platform-browser";
 import {DomSanitizer} from "@angular/platform-browser";
@@ -66,6 +64,7 @@ import {
 import {InputDialogKind} from "tim/ui/input-dialog.kind";
 import {showInputDialog} from "tim/ui/showInputDialog";
 import html2canvas from "html2canvas";
+import {vctrlInstance} from "tim/document/viewctrlinstance";
 import type {
     SimcirConnectorDef,
     SimcirDeviceInstance,
@@ -3846,8 +3845,6 @@ ${fhtml}
         this.exportingMD = false;
     }
 
-    private scope = $rootScope.$new(); // TODO: remove this when ParCompiler is updated to Angular 2+
-
     async showMD() {
         this.runError = false;
         this.result = "";
@@ -3892,10 +3889,15 @@ ${fhtml}
             element.addClass("mdPreviewDiv");
 
             data.texts = element.wrapAll("<div>").parent().html();
+            const viewCtrl = vctrlInstance;
+            if (!viewCtrl) {
+                // TODO: remove this when ParCompiler is updated to Angular 2+
+                throw new Error("ViewCtrl was undefined");
+            }
             await ParCompiler.compileAndAppendTo(
                 this.preview,
                 data,
-                this.scope
+                viewCtrl.scope
             );
         } else {
             const data = r.result;

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -3883,14 +3883,15 @@ ${fhtml}
         );
         if (r.ok) {
             const data = r.result;
-            // const element: JQuery = $($.parseHTML(data.texts) as HTMLElement[]);
+            const element: JQuery = $($.parseHTML(data.texts) as HTMLElement[]);
             // Remove par class as it's used to identify real paragraphs
-            // element.removeClass("par");
+            element.removeClass("par");
             // Remove editline as well as it's not valid for preview
-            // element.children(".editline").remove();
-            // this.mdHtml = element.wrapAll("<div>").parent().html();
-            // Process math in the preview, since the math may require MathJax
-            // await ParCompiler.processAllMathDelayed(this.preview, 0);
+            element.children(".editline").remove();
+            // give class for possibility of styling
+            element.addClass("mdPreviewDiv");
+
+            data.texts = element.wrapAll("<div>").parent().html();
             await ParCompiler.compileAndAppendTo(
                 this.preview,
                 data,

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -3846,7 +3846,7 @@ ${fhtml}
         this.exportingMD = false;
     }
 
-    private scope = $rootScope.$new();
+    private scope = $rootScope.$new(); // TODO: remove this when ParCompiler is updated to Angular 2+
 
     async showMD() {
         this.runError = false;

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -21,6 +21,9 @@ import {
     HostListener,
     ViewChild,
 } from "@angular/core";
+
+import {$rootScope} from "tim/util/ngimport";
+
 import {HttpClient, HttpHeaders} from "@angular/common/http";
 import type {SafeResourceUrl} from "@angular/platform-browser";
 import {DomSanitizer} from "@angular/platform-browser";
@@ -3843,6 +3846,8 @@ ${fhtml}
         this.exportingMD = false;
     }
 
+    private scope = $rootScope.$new();
+
     async showMD() {
         this.runError = false;
         this.result = "";
@@ -3878,14 +3883,19 @@ ${fhtml}
         );
         if (r.ok) {
             const data = r.result;
-            const element: JQuery = $($.parseHTML(data.texts) as HTMLElement[]);
+            // const element: JQuery = $($.parseHTML(data.texts) as HTMLElement[]);
             // Remove par class as it's used to identify real paragraphs
-            element.removeClass("par");
+            // element.removeClass("par");
             // Remove editline as well as it's not valid for preview
-            element.children(".editline").remove();
-            this.mdHtml = element.wrapAll("<div>").parent().html();
+            // element.children(".editline").remove();
+            // this.mdHtml = element.wrapAll("<div>").parent().html();
             // Process math in the preview, since the math may require MathJax
-            await ParCompiler.processAllMathDelayed(this.preview, 0);
+            // await ParCompiler.processAllMathDelayed(this.preview, 0);
+            await ParCompiler.compileAndAppendTo(
+                this.preview,
+                data,
+                this.scope
+            );
         } else {
             const data = r.result;
             this.runError = true;


### PR DESCRIPTION
Näyttää preview `type: md` pluginissa vaikka siellä kirjoittaisi pluginin YAML-koodia.  Saa kirjoittaa myös useita lohkoja.

Testattu:

- tavallinen teksti + LaTeX (md)
- erilaiset cspluginit (md, cs, html) 
- iframes (ei liity tähän, mutta siihen liittyvä async lisätty)
- ihtml (kuten edellä)
- jsframe (ei liitty tähän)

Voisi rikkoa korkeintaa type: md plugineja, koska vain `showMD()`-metodissa muutoksia parin tekoälyn
ehdottaman await lisäksi.