### PR TITLE
modelAnswer: add externalTemplates attribute

### DIFF
--- a/timApp/user/groups.py
+++ b/timApp/user/groups.py
@@ -45,8 +45,8 @@ from timApp.util.utils import (
     get_current_time,
     is_valid_email,
     partition,
-    render_raw_template_string,
 )
+from tim_common.utils import render_raw_template_string
 from tim_common.marshmallow_dataclass import class_schema
 
 groups = TypedBlueprint("groups", __name__, url_prefix="/groups")

--- a/timApp/user/settings/styles.py
+++ b/timApp/user/settings/styles.py
@@ -32,7 +32,8 @@ from timApp.user.user import User
 from timApp.util.flask.requesthelper import RouteException, NotExist
 from timApp.util.flask.responsehelper import json_response, text_response
 from timApp.util.flask.typedblueprint import TypedBlueprint
-from timApp.util.utils import cache_folder_path, render_raw_template_string
+from timApp.util.utils import cache_folder_path
+from tim_common.utils import render_raw_template_string
 from tim_common.html_sanitize import sanitize_html
 
 styles = TypedBlueprint("styles", __name__, url_prefix="/styles")

--- a/timApp/util/utils.py
+++ b/timApp/util/utils.py
@@ -17,7 +17,6 @@ from types import TracebackType, FrameType
 from typing import Any, Sequence, Callable, TypeVar, Iterable
 
 import dateutil.parser
-import jinja2
 import pytz
 import requests
 from lxml.html import HtmlElement
@@ -506,17 +505,6 @@ def collect_errors_from_hosts(futures: list[Future], hosts: list[str]) -> list[s
     for f, h in zip(futures, hosts):
         wait_response_and_collect_error(f, h, errors)
     return errors
-
-
-def render_raw_template_string(template: str, **context: Any) -> str:
-    """
-    Renders a Jinja2 template outside Flask's context. Skips any injected variables.
-
-    :param template: Template to render.
-    :param context: Specific values to inject.
-    :return: Rendered template.
-    """
-    return jinja2.Template(template).render(**context)
 
 
 TItem = TypeVar("TItem")

--- a/tim_common/utils.py
+++ b/tim_common/utils.py
@@ -3,6 +3,7 @@ import re
 from dataclasses import field
 from typing import Any, Mapping, overload
 
+import jinja2
 import marshmallow
 from isodate import Duration, duration_isoformat, parse_duration
 from marshmallow import ValidationError
@@ -146,3 +147,14 @@ def replace_in_file(file_path: str, pattern: str, replacement: str) -> int:
             file.write(new_content)
 
     return num_replacements
+
+
+def render_raw_template_string(template: str, **context: Any) -> str:
+    """
+    Renders a Jinja2 template outside Flask's context. Skips any injected variables.
+
+    :param template: Template to render.
+    :param context: Specific values to inject.
+    :return: Rendered template.
+    """
+    return jinja2.Template(template).render(**context)


### PR DESCRIPTION
Esimerkki: <https://timbeta01.tim.education/view/users/dz-dz/test-modelanswer-templates>

The `externalTemplates` attribute for `modelAnswer` allows to fetch content from external URLs and insert it into the rendered modelAnswer.

Usage example:

```yml
modelAnswer:
  externalTemplates:
    example:
      url: https://example.com
  answer: |
    Answer content

    ~~~html
    {{example}}
    ~~~
```

The downloaded content is cached by default by the URL. The cache can be purged via the public GET /modelAnswer/clearCache path (allowing e.g., CI to purge cache).