### PR TITLE
Feature: Report Content Dialog

### DIFF
--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -2,12 +2,9 @@ from flask import Response, Blueprint
 
 from timApp.util.flask.requesthelper import use_model
 from timApp.util.flask.responsehelper import ok_response
-from timApp.util.flask.typedblueprint import TypedBlueprint
 from dataclasses import dataclass, field
 from timApp.notification.send_email import send_email
 from timApp.tim_app import app
-
-from marshmallow import Schema, fields
 
 content_report = Blueprint("content_report", __name__, url_prefix="")
 
@@ -32,17 +29,15 @@ def report_content(report: ContentReport) -> Response:
     
     {'User name: ' + report.name if report.name else 'Name not supplied'}.
 
-    {'User wishes a followup email to address: ' + report.email if report.email else 'Email not supplied'}
+    {'User wishes a follow up email to address: ' + report.email if report.email else 'Email not supplied'}
 
     """
 
-    mail_subject = f"Content Report for {report.reportedUrl}"
-    user_email = report.email if report.email else ""
-    reply_addresses = f'{app.config["HELP_EMAIL"]}, ' + user_email
+    reply_addresses = ",".join([app.config["CONTENT_REPORT_EMAIL"], report.email])
 
     send_email(
-        rcpt=app.config["HELP_EMAIL"],
-        subject=mail_subject,
+        rcpt=app.config["CONTENT_REPORT_EMAIL"],
+        subject="New Content Report",
         mail_from=app.config["MAIL_FROM"],
         reply_to=reply_addresses,
         msg=report_message,

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -25,20 +25,11 @@ def report_content(
     if not (reportedUrl is None or reportedUrl == ""):
         # Handle difference in http or https protocols between user and host
 
-        # def find_domain(s: str) -> str:
-        #     alku = s.find(":")
-        #     alku = alku + 2 if alku > 0 else 0
-        #     return s[alku : reportedUrl[alku:].find("/") + 1]
-
-        # host_address = find_domain(request.host_url)
-        # user_url_parsed = find_domain(reportedUrl)
-
         user_url_parts = reportedUrl.strip(" /").partition("://")
         user_url_parsed = user_url_parts[2] if user_url_parts[2] else user_url_parts[0]
 
         host_url_parsed = request.host_url.rstrip("/").partition("://")[2]
 
-        # if not (user_url_parsed.startswith(host_address)):
         if not (user_url_parsed.startswith(host_url_parsed)):
             return json_response(
                 {
@@ -47,7 +38,6 @@ def report_content(
                 }
             )
 
-    sanitized_reason = sanitize_html(reason)
     sanitized_url = ""
     if reportedUrl:
         sanitized_url = sanitize_html(reportedUrl)
@@ -55,9 +45,9 @@ def report_content(
     report_message = f"""
     User Submitted Content Report for a TIM Page
 
-    User has reported harmful or inappropriate content in the page: {sanitized_url}.
+    {'User has reported harmful or inappropriate content in the page: ' + sanitized_url if sanitized_url else 'User reports harmful or inappropriate content in TIM. Url not supplied.'}
 
-    Description: {sanitized_reason}
+    Description: {reason}
 
     {'User wishes a follow up email to address: ' + email if email else 'Email not supplied'}
 

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -1,91 +1,36 @@
-from marshmallow import Schema, fields, pre_load
-from flask import Response, Blueprint, request
-from marshmallow import validate, fields, post_load
+from flask import Response
 
-from timApp.util.flask.requesthelper import use_model
 from timApp.util.flask.responsehelper import ok_response
-from dataclasses import dataclass, field
 from timApp.notification.send_email import send_email
 from timApp.tim_app import app
-import datetime as dt
 
-content_report = Blueprint("content_report", __name__, url_prefix="")
+from timApp.util.flask.typedblueprint import TypedBlueprint
+from timApp.util.utils import get_current_time
 
-
-# @dataclass
-# class ContentReport:
-#     reason: str
-#     name: str
-#     # email: str = field(metadata={"validate": validate.Email()})
-#     email: str = field(
-#         metadata={
-#             "marshmallow_field": marshmallow.fields.Email(allow_none=True),
-#         }
-#     )
-#     reportedUrl: str = field(metadata={"validate": validate.URL()})
-#     # reportedUrl: str = field(
-#     #     metadata={
-#     #         "marshmallow_field": marshmallow.fields.URL(schemes=("http", "https")),
-#     #     }
-#     # )
-#     createdAt: dt.datetime = field(
-#         default_factory=lambda: dt.datetime.now(tz=dt.timezone.utc)
-#     )
-
-
-@dataclass
-class ContentReport:
-    name: str
-    reason: str
-    email: str
-    reportedUrl: str
-    createdAt: dt.datetime = field(
-        default_factory=lambda: dt.datetime.now(tz=dt.timezone.utc)
-    )
-
-
-class ReportSchema(Schema):
-    name: str = fields.Str(allow_none=True)
-    reason: str = fields.Str(required=True)
-    email: str = fields.Email(allow_none=True, missing=None)
-    reportedUrl = fields.Url(allow_none=True)
-    createdAt: dt.datetime = fields.DateTime(
-        default=lambda: dt.datetime.now(tz=dt.timezone.utc)
-    )
-
-    @pre_load
-    def empty_email_to_none(self, data, **kwargs):
-        if "email" in data and data["email"] == "":
-            data["email"] = None
-        return data
-
-    @post_load
-    def make_content_report(self, data, **kwargs):
-        return ContentReport(**data)
-
-
-content_report_schema = ReportSchema()
+content_report = TypedBlueprint("content_report", __name__, url_prefix="")
 
 
 @content_report.post("/report")
-def report_content() -> Response:
-    report = content_report_schema.load(request.json)
+def report_content(
+    reason: str,
+    reportedUrl: str | None = None,
+    email: str | None = None,
+) -> Response:
+    now = get_current_time()
 
     report_message = f"""
     User Submitted Content Report for a TIM Page
 
-    User has reported harmful or inappropriate content in the page: {report.reportedUrl}.
+    User has reported harmful or inappropriate content in the page: {reportedUrl}.
 
-    Description: {report.reason}
+    Description: {reason}
 
-    {'User name: ' + report.name if report.name else 'Name not supplied'}.
+    {'User wishes a follow up email to address: ' + email if email else 'Email not supplied'}
 
-    {'User wishes a follow up email to address: ' + report.email if report.email else 'Email not supplied'}
-
-    Report created at: {report.createdAt}
+    Report created at: {now}
     """
 
-    user_mail = "" if report.email is None else report.email
+    user_mail = "" if email is None else email
     reply_addresses = ",".join([app.config["CONTENT_REPORT_EMAIL"], user_mail])
 
     send_email(

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -1,39 +1,92 @@
-from flask import Response, Blueprint
+from marshmallow import Schema, fields, pre_load
+from flask import Response, Blueprint, request
+from marshmallow import validate, fields, post_load
 
 from timApp.util.flask.requesthelper import use_model
 from timApp.util.flask.responsehelper import ok_response
 from dataclasses import dataclass, field
 from timApp.notification.send_email import send_email
 from timApp.tim_app import app
+import datetime as dt
 
 content_report = Blueprint("content_report", __name__, url_prefix="")
 
 
+# @dataclass
+# class ContentReport:
+#     reason: str
+#     name: str
+#     # email: str = field(metadata={"validate": validate.Email()})
+#     email: str = field(
+#         metadata={
+#             "marshmallow_field": marshmallow.fields.Email(allow_none=True),
+#         }
+#     )
+#     reportedUrl: str = field(metadata={"validate": validate.URL()})
+#     # reportedUrl: str = field(
+#     #     metadata={
+#     #         "marshmallow_field": marshmallow.fields.URL(schemes=("http", "https")),
+#     #     }
+#     # )
+#     createdAt: dt.datetime = field(
+#         default_factory=lambda: dt.datetime.now(tz=dt.timezone.utc)
+#     )
+
+
 @dataclass
 class ContentReport:
-    reason: str
     name: str
+    reason: str
     email: str
     reportedUrl: str
+    createdAt: dt.datetime = field(
+        default_factory=lambda: dt.datetime.now(tz=dt.timezone.utc)
+    )
+
+
+class ReportSchema(Schema):
+    name: str = fields.Str(allow_none=True)
+    reason: str = fields.Str(required=True)
+    email: str = fields.Email(allow_none=True, missing=None)
+    reportedUrl = fields.Url(allow_none=True)
+    createdAt: dt.datetime = fields.DateTime(
+        default=lambda: dt.datetime.now(tz=dt.timezone.utc)
+    )
+
+    @pre_load
+    def empty_email_to_none(self, data, **kwargs):
+        if "email" in data and data["email"] == "":
+            data["email"] = None
+        return data
+
+    @post_load
+    def make_content_report(self, data, **kwargs):
+        return ContentReport(**data)
+
+
+content_report_schema = ReportSchema()
 
 
 @content_report.post("/report")
-@use_model(ContentReport)
-def report_content(report: ContentReport) -> Response:
+def report_content() -> Response:
+    report = content_report_schema.load(request.json)
+
     report_message = f"""
     User Submitted Content Report for a TIM Page
-    
+
     User has reported harmful or inappropriate content in the page: {report.reportedUrl}.
 
     Description: {report.reason}
-    
+
     {'User name: ' + report.name if report.name else 'Name not supplied'}.
 
     {'User wishes a follow up email to address: ' + report.email if report.email else 'Email not supplied'}
 
+    Report created at: {report.createdAt}
     """
 
-    reply_addresses = ",".join([app.config["CONTENT_REPORT_EMAIL"], report.email])
+    user_mail = "" if report.email is None else report.email
+    reply_addresses = ",".join([app.config["CONTENT_REPORT_EMAIL"], user_mail])
 
     send_email(
         rcpt=app.config["CONTENT_REPORT_EMAIL"],

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -38,14 +38,10 @@ def report_content(
                 }
             )
 
-    sanitized_url = ""
-    if reportedUrl:
-        sanitized_url = sanitize_html(reportedUrl)
-
     report_message = f"""
     User Submitted Content Report for a TIM Page
 
-    {'User has reported harmful or inappropriate content in the page: ' + sanitized_url if sanitized_url else 'User reports harmful or inappropriate content in TIM. Url not supplied.'}
+    {'User has reported harmful or inappropriate content in the page: ' + reportedUrl if reportedUrl else 'User has reported harmful or inappropriate content in TIM. URL not supplied.'}
 
     Description: {reason}
 

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -1,7 +1,7 @@
 from flask import Response, request
 
 from timApp.util.flask.requesthelper import RouteException
-from timApp.util.flask.responsehelper import json_response
+from timApp.util.flask.responsehelper import json_response, ok_response
 from timApp.notification.send_email import send_email
 from timApp.tim_app import app
 
@@ -57,4 +57,4 @@ def report_content(
         msg=report_message,
     )
 
-    return json_response({"status": "ok"})
+    return ok_response()

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -26,7 +26,14 @@ def report_content(
     if not (
         reportedUrl is None or reportedUrl == ""
     ) and not reportedUrl.strip().startswith(request.host_url):
-        return json_response({"status": "error", "description": "invalid_url"})
+        return json_response(
+            {
+                "status": "error",
+                "description": "invalid_url",
+                "host": request.host_url,
+                "reportedUrl": reportedUrl,
+            }
+        )
 
     sanitized_reason = sanitize_html(reason)
 

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -1,11 +1,12 @@
 from flask import Response, request
+
+from timApp.util.flask.requesthelper import RouteException
 from timApp.util.flask.responsehelper import json_response
 from timApp.notification.send_email import send_email
 from timApp.tim_app import app
 
 from timApp.util.flask.typedblueprint import TypedBlueprint
 from timApp.util.utils import get_current_time, is_valid_email
-from tim_common.html_sanitize import sanitize_html
 
 content_report = TypedBlueprint("content_report", __name__, url_prefix="")
 
@@ -19,7 +20,7 @@ def report_content(
     now = get_current_time()
 
     if not (email is None or email == "") and not is_valid_email(email):
-        return json_response({"status": "error", "description": "invalid_email"})
+        raise RouteException("invalid_email")
 
     # If given, the url address should start with the host name
     if not (reportedUrl is None or reportedUrl == ""):
@@ -31,12 +32,7 @@ def report_content(
         host_url_parsed = request.host_url.rstrip("/").partition("://")[2]
 
         if not (user_url_parsed.startswith(host_url_parsed)):
-            return json_response(
-                {
-                    "status": "error",
-                    "description": "invalid_url",
-                }
-            )
+            raise RouteException("invalid_url")
 
     report_message = f"""
     User Submitted Content Report for a TIM Page

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -1,11 +1,12 @@
-from flask import Response
+from flask import Response, request
 
-from timApp.util.flask.responsehelper import ok_response
+from timApp.util.flask.responsehelper import json_response
 from timApp.notification.send_email import send_email
 from timApp.tim_app import app
 
 from timApp.util.flask.typedblueprint import TypedBlueprint
-from timApp.util.utils import get_current_time
+from timApp.util.utils import get_current_time, is_valid_email
+from tim_common.html_sanitize import sanitize_html
 
 content_report = TypedBlueprint("content_report", __name__, url_prefix="")
 
@@ -18,20 +19,31 @@ def report_content(
 ) -> Response:
     now = get_current_time()
 
+    if not (email is None or email == "") and not is_valid_email(email):
+        return json_response({"status": "error", "description": "invalid_email"})
+
+    # If given, the url address should start with the host name
+    if not (
+        reportedUrl is None or reportedUrl == ""
+    ) and not reportedUrl.strip().startswith(request.host_url):
+        return json_response({"status": "error", "description": "invalid_url"})
+
+    sanitized_reason = sanitize_html(reason)
+
     report_message = f"""
     User Submitted Content Report for a TIM Page
 
     User has reported harmful or inappropriate content in the page: {reportedUrl}.
 
-    Description: {reason}
+    Description: {sanitized_reason}
 
     {'User wishes a follow up email to address: ' + email if email else 'Email not supplied'}
 
     Report created at: {now}
     """
 
-    user_mail = "" if email is None else email
-    reply_addresses = ",".join([app.config["CONTENT_REPORT_EMAIL"], user_mail])
+    user_reply = "" if email is None else email
+    reply_addresses = ",".join([app.config["CONTENT_REPORT_EMAIL"], user_reply])
 
     send_email(
         rcpt=app.config["CONTENT_REPORT_EMAIL"],
@@ -40,4 +52,5 @@ def report_content(
         reply_to=reply_addresses,
         msg=report_message,
     )
-    return ok_response()
+
+    return json_response({"status": "ok"})

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -1,0 +1,50 @@
+from flask import Response, Blueprint
+
+from timApp.util.flask.requesthelper import use_model
+from timApp.util.flask.responsehelper import ok_response
+from timApp.util.flask.typedblueprint import TypedBlueprint
+from dataclasses import dataclass, field
+from timApp.notification.send_email import send_email
+from timApp.tim_app import app
+
+from marshmallow import Schema, fields
+
+content_report = Blueprint("content_report", __name__, url_prefix="")
+
+
+@dataclass
+class ContentReport:
+    reason: str
+    name: str
+    email: str
+    reportedUrl: str
+
+
+@content_report.post("/report")
+@use_model(ContentReport)
+def report_content(report: ContentReport) -> Response:
+    report_message = f"""
+    User Submitted Content Report for a TIM Page
+    
+    User has reported harmful or inappropriate content in the page: {report.reportedUrl}.
+
+    Description: {report.reason}
+    
+    {'User name: ' + report.name if report.name else 'Name not supplied'}.
+
+    {'User wishes a followup email to address: ' + report.email if report.email else 'Email not supplied'}
+
+    """
+
+    mail_subject = f"Content Report for {report.reportedUrl}"
+    user_email = report.email if report.email else ""
+    reply_addresses = f'{app.config["HELP_EMAIL"]}, ' + user_email
+
+    send_email(
+        rcpt=app.config["HELP_EMAIL"],
+        subject=mail_subject,
+        mail_from=app.config["MAIL_FROM"],
+        reply_to=reply_addresses,
+        msg=report_message,
+    )
+    return ok_response()

--- a/timApp/content_report/content_report.py
+++ b/timApp/content_report/content_report.py
@@ -25,30 +25,37 @@ def report_content(
     if not (reportedUrl is None or reportedUrl == ""):
         # Handle difference in http or https protocols between user and host
 
-        def find_domain(s: str) -> str:
-            alku = s.find(":")
-            alku = alku + 2 if alku > 0 else 0
-            return s[alku : reportedUrl[alku:].find("/") + 1]
+        # def find_domain(s: str) -> str:
+        #     alku = s.find(":")
+        #     alku = alku + 2 if alku > 0 else 0
+        #     return s[alku : reportedUrl[alku:].find("/") + 1]
 
-        host_address = find_domain(request.host_url)
-        user_url_parsed = find_domain(reportedUrl)
+        # host_address = find_domain(request.host_url)
+        # user_url_parsed = find_domain(reportedUrl)
 
-        if not (user_url_parsed.startswith(host_address)):
+        user_url_parts = reportedUrl.strip(" /").partition("://")
+        user_url_parsed = user_url_parts[2] if user_url_parts[2] else user_url_parts[0]
+
+        host_url_parsed = request.host_url.rstrip("/").partition("://")[2]
+
+        # if not (user_url_parsed.startswith(host_address)):
+        if not (user_url_parsed.startswith(host_url_parsed)):
             return json_response(
                 {
                     "status": "error",
                     "description": "invalid_url",
-                    "host": user_url_parsed,
-                    "reportedUrl": host_address,
                 }
             )
 
     sanitized_reason = sanitize_html(reason)
+    sanitized_url = ""
+    if reportedUrl:
+        sanitized_url = sanitize_html(reportedUrl)
 
     report_message = f"""
     User Submitted Content Report for a TIM Page
 
-    User has reported harmful or inappropriate content in the page: {reportedUrl}.
+    User has reported harmful or inappropriate content in the page: {sanitized_url}.
 
     Description: {sanitized_reason}
 

--- a/timApp/defaultconfig.py
+++ b/timApp/defaultconfig.py
@@ -89,6 +89,8 @@ HELP_EMAIL = "tim@jyu.fi"
 # Default sender address for email.
 MAIL_FROM = "tim@jyu.fi"
 
+CONTENT_REPORT_EMAIL = "tim@jyu.fi"
+
 ERROR_EMAIL = "wuff-reports@tim.jyu.fi"
 WUFF_EMAIL = "wuff@tim.jyu.fi"
 NOREPLY_EMAIL = "no-reply@tim.jyu.fi"

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10875,14 +10875,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">61,62</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4890967305882645389" datatype="html">
-        <source>Please check the page address. You can only report addresses from TIM.</source>
-        <target state="translated">Tarkista sivun osoite. Voit antaa ilmoituksen vain TIM:n osoitteista.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">65,66</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5726155981923810218" datatype="html">
         <source>Fill user email</source>
         <target state="translated">Lisää käyttäjän sähköposti</target>
@@ -10921,6 +10913,14 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">213</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3342050790592923737" datatype="html">
+        <source>Please check the page address. You can only report addresses from TIM. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></source>
+        <target state="translated">Ole hyvä ja tarkista osoite. Voit ilmoittaa vain TIM osoitteita. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">67,68</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10755,14 +10755,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="568459468942408959" datatype="html">
-        <source>Report Content</source>
-        <target state="translated">Ilmoita haitallisesta sisällöstä</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4544877121833907946" datatype="html">
         <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></source>
         <target state="translated"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>Tällä lomakkeella voit ilmoittaa haitallisesta tai sopimattomasta sisällöstä, johon olet törmännyt TIM:n käytön aikana. <x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>Jos haluat, että TIM:n ylläpitäjät ottavat sinuun yhteyttä, voit halutessasi ilmoittaa sähköpostiosoitteesi.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></target>
@@ -10805,34 +10797,10 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
       </trans-unit>
       <trans-unit id="6456781411935518667" datatype="html">
         <source>Report content</source>
-        <target state="translated">Ilmoita haitallisesta sisällöstä</target>
+        <target state="translated">Ilmoita asiaton sisältö</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
           <context context-type="linenumber">62,63</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2330390142673252276" datatype="html">
-        <source>Get current url</source>
-        <target state="translated">Hae nykyinen url</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">62,63</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2913965832166752123" datatype="html">
-        <source>Please check the url address. You can only report addresses from TIM.</source>
-        <target state="translated">Ole hyvä ja tarkista url-osoite. Voit ilmoittaa vain TIM:ssä olevia osoitteita.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">66,67</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1872608021372632073" datatype="html">
-        <source>Fill with user email</source>
-        <target state="translated">Täytä käyttäjän sähköpostiosoitteella</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">92,93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2446227100022235850" datatype="html">
@@ -10889,6 +10857,70 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">133,134</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="110871703751109989" datatype="html">
+        <source> Report inappropriate content </source>
+        <target state="translated">Ilmoita asiaton sisältö</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6140792203245567328" datatype="html">
+        <source>Report inappropriate Content</source>
+        <target state="translated">Ilmoita asiaton sisältö</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">36,37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8959949608841060449" datatype="html">
+        <source> Page address <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
+        <target state="translated"> Sivun osoite <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">48,50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5607172656789974207" datatype="html">
+        <source>Fill current address</source>
+        <target state="translated">Täytä nykyisellä osoitteella</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">61,62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4890967305882645389" datatype="html">
+        <source>Please check the page address. You can only report addresses from TIM.</source>
+        <target state="translated">Tarkista sivun osoite. Voit antaa ilmoituksen vain TIM:n osoitteista.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">65,66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5726155981923810218" datatype="html">
+        <source>Fill user email</source>
+        <target state="translated">Lisää käyttäjän sähköposti</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">91,92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3333065049174534332" datatype="html">
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;spa"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="n glyphicon-exclamation-sign&quot;>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="There was a"/> There was an error.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></source>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;spa"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="n glyphicon-exclamation-sign&quot;>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="There was a"/> Tapahtui virhe.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">126,127</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4180813104141834795" datatype="html">
+        <source>Your report was not sent.</source>
+        <target state="translated">Ilmoitusta ei lähetetty.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">128,129</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8897,8 +8897,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="187187500641108332" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="Folder() ?? 'Enter the location or leave empty'}}"/></source>
-        <target state="new"><x id="INTERPOLATION" equiv-text="Folder() ?? 'Enter the location or leave empty'}}"/></target>
+        <source><x id="INTERPOLATION" equiv-text="Folder() ?? &apos;Enter the location or leave empty&apos;}}"/></source>
+        <target state="new"><x id="INTERPOLATION" equiv-text="Folder() ?? &apos;Enter the location or leave empty&apos;}}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/user-group-dialog.component.ts</context>
           <context context-type="linenumber">61,62</context>
@@ -10917,22 +10917,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">120,121</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7271539637870485137" datatype="html">
-        <source>The email address is invalid.</source>
-        <target state="translated">Sähköpostiosoite on virheellinen.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">220</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2801541784998973995" datatype="html">
-        <source>The reported page address is invalid.</source>
-        <target state="translated">Ilmoitettu sivun osoite on virheellinen.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">223</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10723,22 +10723,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">507,508</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1935891093549754733" datatype="html">
-        <source> Report content </source>
-        <target state="translated">Ilmoita haitallisesta sisällöstä</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">16,18</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5382311376767899711" datatype="html">
-        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
-        <target state="translated"> Sivun URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">49,51</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5369335165199679048" datatype="html">
         <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
         <target state="translated"> Sähköpostiosoitteesi <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
@@ -10921,6 +10905,22 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">128,129</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6699791699859977301" datatype="html">
+        <source>Could not connect to server. Check your internet connection and try again.</source>
+        <target state="translated">Palvelimeen ei saatu yhteyttä. Tarkista verkkoyhteytesi ja yritä uudelleen.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">211</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2170321853448003764" datatype="html">
+        <source>There is an issue with the server. Make a copy of your message and refresh the page, or contact TIM support directly at tim@jyu.fi.</source>
+        <target state="translated">Palvelimen kanssa on ongelmia. Tee kopio viestistäsi ja päivitä sivu, tai ota suoraan yhteyttä TIM-tukeen osoitteessa tim@jyu.fi.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10723,6 +10723,102 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">507,508</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1935891093549754733" datatype="html">
+        <source> Report content </source>
+        <target state="translated">Ilmoita haitallisesta sisällöstä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">16,18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5382311376767899711" datatype="html">
+        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
+        <target state="translated"> Mitä sivua ilmoitus koskee <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">29,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5369335165199679048" datatype="html">
+        <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
+        <target state="translated"> Sähköpostiosoite <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">42,44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="452949630448939191" datatype="html">
+        <source>Describe the issue</source>
+        <target state="translated">Ilmoituksen sisältö</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1417693714872528491" datatype="html">
+        <source>This field is required.</source>
+        <target state="translated">Tämä kenttä pakollinen.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="568459468942408959" datatype="html">
+        <source>Report Content</source>
+        <target state="translated">Ilmoita haitallisesta sisällöstä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4544877121833907946" datatype="html">
+        <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></source>
+        <target state="translated"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>Tällä lomakkeella voit ilmoittaa haitallisesta tai sopimattomasta sisällöstä, johon olet törmännyt TIM:n käytön aikana. <x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>Jos haluat, että TIM:n ylläpitäjät ottavat sinuun yhteyttä, voit halutessasi ilmoittaa sähköpostiosoitteesi.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">24,25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8414879883786537714" datatype="html">
+        <source>Please explain what you found harmful or inappropriate. Be as specific as possible.</source>
+        <target state="translated">Selitä, mitä pidit haitallisena tai sopimattomana. Kirjoita mahdollisimman yksityiskohtaisesti.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6151928365554450816" datatype="html">
+        <source>Report Page</source>
+        <target state="translated">Ilmoita sisällöstä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4096818040903036257" datatype="html">
+        <source>This is the page where you encountered the issue. You can change it if you're reporting a different page.</source>
+        <target state="translated">Tämä on sivu, jolla ongelma ilmeni. Voit muuttaa sitä, jos haluat ilmoittaa jostain muusta sivusta.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6860144309922719886" datatype="html">
+        <source>Enter your email if you'd like us to contact you about your report.</source>
+        <target state="translated">Kirjoita sähköpostiosoitteesi, jos haluat, että otamme sinuun yhteyttä ilmoituksestasi.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6456781411935518667" datatype="html">
+        <source>Report content</source>
+        <target state="translated">Ilmoita haitallisesta sisällöstä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
+          <context context-type="linenumber">62,63</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10915,12 +10915,12 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3342050790592923737" datatype="html">
-        <source>Please check the page address. You can only report addresses from TIM. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></source>
-        <target state="translated">Ole hyvä ja tarkista osoite. Voit ilmoittaa vain TIM osoitteita. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></target>
+      <trans-unit id="4890967305882645389" datatype="html">
+        <source>Please check the page address. You can only report addresses from TIM.</source>
+        <target state="translated">Ole hyvä ja tarkista sivun osoite. Voit ilmoittaa vain TIM:ssä olevista sivuista.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">67,68</context>
+          <context context-type="linenumber">65,66</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10739,52 +10739,12 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4544877121833907946" datatype="html">
-        <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></source>
-        <target state="translated"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>Tällä lomakkeella voit ilmoittaa haitallisesta tai sopimattomasta sisällöstä, johon olet törmännyt TIM:n käytön aikana. <x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p>"/>Jos haluat, että TIM:n ylläpitäjät ottavat sinuun yhteyttä, voit halutessasi ilmoittaa sähköpostiosoitteesi.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">24,25</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8414879883786537714" datatype="html">
-        <source>Please explain what you found harmful or inappropriate. Be as specific as possible.</source>
-        <target state="translated">Selitä, mitä pidit haitallisena tai sopimattomana. Kirjoita mahdollisimman yksityiskohtaisesti.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6151928365554450816" datatype="html">
         <source>Report Page</source>
         <target state="translated">Ilmoita sisällöstä</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">76</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4096818040903036257" datatype="html">
-        <source>This is the page where you encountered the issue. You can change it if you're reporting a different page.</source>
-        <target state="translated">Tämä on sivu, jolla ongelma ilmeni. Voit muuttaa sitä, jos haluat ilmoittaa jostain muusta sivusta.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6860144309922719886" datatype="html">
-        <source>Enter your email if you'd like us to contact you about your report.</source>
-        <target state="translated">Kirjoita sähköpostiosoitteesi, jos haluat, että otamme sinuun yhteyttä ilmoituksestasi.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">56</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6456781411935518667" datatype="html">
-        <source>Report content</source>
-        <target state="translated">Ilmoita asiaton sisältö</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
-          <context context-type="linenumber">62,63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2446227100022235850" datatype="html">
@@ -10851,14 +10811,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6140792203245567328" datatype="html">
-        <source>Report inappropriate Content</source>
-        <target state="translated">Ilmoita asiaton sisältö</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">36,37</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8959949608841060449" datatype="html">
         <source> Page address <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
         <target state="translated"> Sivun osoite <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
@@ -10921,6 +10873,66 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">65,66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5227627642850381764" datatype="html">
+        <source>Report inappropriate content</source>
+        <target state="translated">Ilmoita asiaton sisältö</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
+          <context context-type="linenumber">62,63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">40,41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7537003864277929073" datatype="html">
+        <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="Use this"/>Use this form to report any harmful or inappropriate content you encounter on TIM. If you would like a response from the TIM administrators, please provide your email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></source>
+        <target state="translated"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="Use this"/>Tällä lomakkeella voit ilmoittaa TIM-palvelussa havaitsemastasi haitallisesta tai sopimattomasta sisällöstä. Jos haluat TIM-ylläpidon vastaavan sinulle, ole hyvä ja anna sähköpostiosoitteesi.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">43,44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="793497416353063752" datatype="html">
+        <source>This is the page address where you encountered the issue. If you are reporting a problem on a different page, please paste the correct address here.</source>
+        <target state="translated">Tämä on sivun osoite, jossa havaitsit ongelman. Jos ilmoitat ongelmasta jollakin muulla sivulla, liitä oikea osoite tähän.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">70,71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6334384804553156455" datatype="html">
+        <source>Please provide your email address if you wish for the TIM administrators to follow up with you regarding this report.</source>
+        <target state="translated">Anna sähköpostiosoitteesi, jos haluat, että TIM:n ylläpitäjät ottavat sinuun yhteyttä tämän raportin osalta.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">101,102</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4678590939146937144" datatype="html">
+        <source>Explain why you think the content is inappropriate. Be as specific as possible.</source>
+        <target state="translated">Selitä, miksi sisältö on mielestäsi sopimatonta. Kerro mahdollisimman tarkasti.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">120,121</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7271539637870485137" datatype="html">
+        <source>The email address is invalid.</source>
+        <target state="translated">Sähköpostiosoite on virheellinen.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">220</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2801541784998973995" datatype="html">
+        <source>The reported page address is invalid.</source>
+        <target state="translated">Ilmoitettu sivun osoite on virheellinen.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">223</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10732,19 +10732,19 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         </context-group>
       </trans-unit>
       <trans-unit id="5382311376767899711" datatype="html">
-        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
-        <target state="translated"> Mitä sivua ilmoitus koskee <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
+        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
+        <target state="translated"> Sivun URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">29,31</context>
+          <context context-type="linenumber">49,51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5369335165199679048" datatype="html">
-        <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
-        <target state="translated"> Sähköpostiosoite <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
+        <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source>
+        <target state="translated"> Sähköpostiosoitteesi <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>(vapaaehtoinen)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">42,44</context>
+          <context context-type="linenumber">76,78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="452949630448939191" datatype="html">
@@ -10753,14 +10753,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">57</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1417693714872528491" datatype="html">
-        <source>This field is required.</source>
-        <target state="translated">Tämä kenttä pakollinen.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="568459468942408959" datatype="html">
@@ -10817,6 +10809,86 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
           <context context-type="linenumber">62,63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2330390142673252276" datatype="html">
+        <source>Get current url</source>
+        <target state="translated">Hae nykyinen url</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">62,63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2913965832166752123" datatype="html">
+        <source>Please check the url address. You can only report addresses from TIM.</source>
+        <target state="translated">Ole hyvä ja tarkista url-osoite. Voit ilmoittaa vain TIM:ssä olevia osoitteita.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">66,67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1872608021372632073" datatype="html">
+        <source>Fill with user email</source>
+        <target state="translated">Täytä käyttäjän sähköpostiosoitteella</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">92,93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2446227100022235850" datatype="html">
+        <source>Please enter a valid email address.</source>
+        <target state="translated">Syötä oikean muotoinen sähköpostiosoite.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">96,97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6287738615734758922" datatype="html">
+        <source>The email address cannot exceed 256 characters.</source>
+        <target state="translated">Sähköpostiosoite voi olla enintään 256 merkkiä pitkä.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">97,98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5962072938234411707" datatype="html">
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&quot;glyphicon glyphicon-exclamation-sign&quot;>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="This field"/> This field is required.</source>
+        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&quot;glyphicon glyphicon-exclamation-sign&quot;>"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="This field"/> Tämä kenttä vaaditaan.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">115,116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7523042633016688692" datatype="html">
+        <source>The description cannot exceed 2000 characters.</source>
+        <target state="translated">Kuvaus voi olla enintään 2000 merkkiä pitkä.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4120435970812709184" datatype="html">
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Than"/>Thank you for your report.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></source>
+        <target state="translated"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Than"/>Kiitos ilmoituksestasi.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">130,131</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3765149214612773760" datatype="html">
+        <source>Your message has been sent to the TIM administrators. We appreciate your help in keeping our content accurate and safe.</source>
+        <target state="translated">Viestisi on lähetetty TIM:n ylläpitäjille. Arvostamme apuasi sisällön pitämisessä oikeana ja turvallisena.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">131,132</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="397098723873502323" datatype="html">
+        <source>Done</source>
+        <target state="translated">Valmis</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">133,134</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10637,19 +10637,19 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         </context-group>
       </trans-unit>
       <trans-unit id="5382311376767899711" datatype="html">
-        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
-        <target state="new"> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+        <target state="new"> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">29,31</context>
+          <context context-type="linenumber">49,51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5369335165199679048" datatype="html">
-        <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
-        <target state="new"> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+        <target state="new"> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">42,44</context>
+          <context context-type="linenumber">76,78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="452949630448939191" datatype="html">
@@ -10658,14 +10658,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">57</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1417693714872528491" datatype="html">
-        <source>This field is required.</source>
-        <target state="new">This field is required.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">67</context>
         </context-group>
       </trans-unit>
       <trans-unit id="568459468942408959" datatype="html">
@@ -10722,6 +10714,86 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
           <context context-type="linenumber">62,63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2330390142673252276" datatype="html">
+        <source>Get current url</source>
+        <target state="new">Get current url</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">62,63</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2913965832166752123" datatype="html">
+        <source>Please check the url address. You can only report addresses from TIM.</source>
+        <target state="new">Please check the url address. You can only report addresses from TIM.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">66,67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1872608021372632073" datatype="html">
+        <source>Fill with user email</source>
+        <target state="new">Fill with user email</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">92,93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2446227100022235850" datatype="html">
+        <source>Please enter a valid email address.</source>
+        <target state="new">Please enter a valid email address.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">96,97</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6287738615734758922" datatype="html">
+        <source>The email address cannot exceed 256 characters.</source>
+        <target state="new">The email address cannot exceed 256 characters.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">97,98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5962072938234411707" datatype="html">
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&quot;glyphicon glyphicon-exclamation-sign&quot;&gt;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="This field"/> This field is required.</source>
+        <target state="new"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&quot;glyphicon glyphicon-exclamation-sign&quot;&gt;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="This field"/> This field is required.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">115,116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7523042633016688692" datatype="html">
+        <source>The description cannot exceed 2000 characters.</source>
+        <target state="new">The description cannot exceed 2000 characters.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4120435970812709184" datatype="html">
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Than"/>Thank you for your report.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/></source>
+        <target state="new"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="Than"/>Thank you for your report.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">130,131</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3765149214612773760" datatype="html">
+        <source>Your message has been sent to the TIM administrators. We appreciate your help in keeping our content accurate and safe.</source>
+        <target state="new">Your message has been sent to the TIM administrators. We appreciate your help in keeping our content accurate and safe.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">131,132</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="397098723873502323" datatype="html">
+        <source>Done</source>
+        <target state="new">Done</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">133,134</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10660,14 +10660,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="568459468942408959" datatype="html">
-        <source>Report Content</source>
-        <target state="new">Report Content</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">21</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4544877121833907946" datatype="html">
         <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></source>
         <target state="new"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></target>
@@ -10714,30 +10706,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
           <context context-type="linenumber">62,63</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2330390142673252276" datatype="html">
-        <source>Get current url</source>
-        <target state="new">Get current url</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">62,63</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2913965832166752123" datatype="html">
-        <source>Please check the url address. You can only report addresses from TIM.</source>
-        <target state="new">Please check the url address. You can only report addresses from TIM.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">66,67</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="1872608021372632073" datatype="html">
-        <source>Fill with user email</source>
-        <target state="new">Fill with user email</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">92,93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2446227100022235850" datatype="html">
@@ -10794,6 +10762,70 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">133,134</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="110871703751109989" datatype="html">
+        <source> Report inappropriate content </source>
+        <target state="new"> Report inappropriate content </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">32</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6140792203245567328" datatype="html">
+        <source>Report inappropriate Content</source>
+        <target state="new">Report inappropriate Content</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">36,37</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8959949608841060449" datatype="html">
+        <source> Page address <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+        <target state="new"> Page address <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">48,50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5607172656789974207" datatype="html">
+        <source>Fill current address</source>
+        <target state="new">Fill current address</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">61,62</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4890967305882645389" datatype="html">
+        <source>Please check the page address. You can only report addresses from TIM.</source>
+        <target state="new">Please check the page address. You can only report addresses from TIM.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">65,66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5726155981923810218" datatype="html">
+        <source>Fill user email</source>
+        <target state="new">Fill user email</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">91,92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3333065049174534332" datatype="html">
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;spa"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="n glyphicon-exclamation-sign&quot;&gt;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="There was a"/> There was an error.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/></source>
+        <target state="new"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;spa"/><x id="START_TAG_SPAN" ctype="x-span" equiv-text="n glyphicon-exclamation-sign&quot;&gt;"/><x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="There was a"/> There was an error.<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">126,127</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4180813104141834795" datatype="html">
+        <source>Your report was not sent.</source>
+        <target state="new">Your report was not sent.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">128,129</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10628,22 +10628,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">507,508</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1935891093549754733" datatype="html">
-        <source> Report content </source>
-        <target state="new"> Report content </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">16,18</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="5382311376767899711" datatype="html">
-        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
-        <target state="new"> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">49,51</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5369335165199679048" datatype="html">
         <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
         <target state="new"> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
@@ -10826,6 +10810,22 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">128,129</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6699791699859977301" datatype="html">
+        <source>Could not connect to server. Check your internet connection and try again.</source>
+        <target state="new">Could not connect to server. Check your internet connection and try again.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">211</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2170321853448003764" datatype="html">
+        <source>There is an issue with the server. Make a copy of your message and refresh the page, or contact TIM support directly at tim@jyu.fi.</source>
+        <target state="new">There is an issue with the server. Make a copy of your message and refresh the page, or contact TIM support directly at tim@jyu.fi.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10820,12 +10820,12 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="3342050790592923737" datatype="html">
-        <source>Please check the page address. You can only report addresses from TIM. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></source>
-        <target state="new">Please check the page address. You can only report addresses from TIM. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></target>
+      <trans-unit id="4890967305882645389" datatype="html">
+        <source>Please check the page address. You can only report addresses from TIM.</source>
+        <target state="new">Please check the page address. You can only report addresses from TIM.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">67,68</context>
+          <context context-type="linenumber">65,66</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10628,6 +10628,102 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">507,508</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="1935891093549754733" datatype="html">
+        <source> Report content </source>
+        <target state="new"> Report content </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">16,18</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5382311376767899711" datatype="html">
+        <source> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+        <target state="new"> Page URL <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">29,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5369335165199679048" datatype="html">
+        <source> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+        <target state="new"> Your Email <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;label label-info&quot;&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">42,44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="452949630448939191" datatype="html">
+        <source>Describe the issue</source>
+        <target state="new">Describe the issue</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1417693714872528491" datatype="html">
+        <source>This field is required.</source>
+        <target state="new">This field is required.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="568459468942408959" datatype="html">
+        <source>Report Content</source>
+        <target state="new">Report Content</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">21</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4544877121833907946" datatype="html">
+        <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></source>
+        <target state="new"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">24,25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8414879883786537714" datatype="html">
+        <source>Please explain what you found harmful or inappropriate. Be as specific as possible.</source>
+        <target state="new">Please explain what you found harmful or inappropriate. Be as specific as possible.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6151928365554450816" datatype="html">
+        <source>Report Page</source>
+        <target state="new">Report Page</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">76</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4096818040903036257" datatype="html">
+        <source>This is the page where you encountered the issue. You can change it if you&apos;re reporting a different page.</source>
+        <target state="new">This is the page where you encountered the issue. You can change it if you&apos;re reporting a different page.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">40</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6860144309922719886" datatype="html">
+        <source>Enter your email if you&apos;d like us to contact you about your report.</source>
+        <target state="new">Enter your email if you&apos;d like us to contact you about your report.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6456781411935518667" datatype="html">
+        <source>Report content</source>
+        <target state="new">Report content</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
+          <context context-type="linenumber">62,63</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10780,14 +10780,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">61,62</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4890967305882645389" datatype="html">
-        <source>Please check the page address. You can only report addresses from TIM.</source>
-        <target state="new">Please check the page address. You can only report addresses from TIM.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">65,66</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5726155981923810218" datatype="html">
         <source>Fill user email</source>
         <target state="new">Fill user email</target>
@@ -10826,6 +10818,14 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">213</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3342050790592923737" datatype="html">
+        <source>Please check the page address. You can only report addresses from TIM. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></source>
+        <target state="new">Please check the page address. You can only report addresses from TIM. <x id="INTERPOLATION" equiv-text="{{urlMessage}}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">67,68</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10824,22 +10824,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">120,121</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7271539637870485137" datatype="html">
-        <source>The email address is invalid.</source>
-        <target state="new">The email address is invalid.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">220</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="2801541784998973995" datatype="html">
-        <source>The reported page address is invalid.</source>
-        <target state="new">The reported page address is invalid.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">223</context>
-        </context-group>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10644,52 +10644,12 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4544877121833907946" datatype="html">
-        <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></source>
-        <target state="new"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/><x id="START_PARAGRAPH" ctype="x-p" equiv-text="&lt;p&gt;"/>If you would like the TIM administrators to follow up with you, you may optionally include you email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">24,25</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="8414879883786537714" datatype="html">
-        <source>Please explain what you found harmful or inappropriate. Be as specific as possible.</source>
-        <target state="new">Please explain what you found harmful or inappropriate. Be as specific as possible.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6151928365554450816" datatype="html">
         <source>Report Page</source>
         <target state="new">Report Page</target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">76</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4096818040903036257" datatype="html">
-        <source>This is the page where you encountered the issue. You can change it if you&apos;re reporting a different page.</source>
-        <target state="new">This is the page where you encountered the issue. You can change it if you&apos;re reporting a different page.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6860144309922719886" datatype="html">
-        <source>Enter your email if you&apos;d like us to contact you about your report.</source>
-        <target state="new">Enter your email if you&apos;d like us to contact you about your report.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">56</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6456781411935518667" datatype="html">
-        <source>Report content</source>
-        <target state="new">Report content</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
-          <context context-type="linenumber">62,63</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2446227100022235850" datatype="html">
@@ -10756,14 +10716,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6140792203245567328" datatype="html">
-        <source>Report inappropriate Content</source>
-        <target state="new">Report inappropriate Content</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
-          <context context-type="linenumber">36,37</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8959949608841060449" datatype="html">
         <source> Page address <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
         <target state="new"> Page address <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span&gt;"/>(optional)<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
@@ -10826,6 +10778,66 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
           <context context-type="linenumber">65,66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5227627642850381764" datatype="html">
+        <source>Report inappropriate content</source>
+        <target state="new">Report inappropriate content</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/footer.component.ts</context>
+          <context context-type="linenumber">62,63</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">40,41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7537003864277929073" datatype="html">
+        <source><x id="START_PARAGRAPH" ctype="x-p" equiv-text="Use this"/>Use this form to report any harmful or inappropriate content you encounter on TIM. If you would like a response from the TIM administrators, please provide your email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></source>
+        <target state="new"><x id="START_PARAGRAPH" ctype="x-p" equiv-text="Use this"/>Use this form to report any harmful or inappropriate content you encounter on TIM. If you would like a response from the TIM administrators, please provide your email address.<x id="CLOSE_PARAGRAPH" ctype="x-p" equiv-text="&lt;/p&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">43,44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="793497416353063752" datatype="html">
+        <source>This is the page address where you encountered the issue. If you are reporting a problem on a different page, please paste the correct address here.</source>
+        <target state="new">This is the page address where you encountered the issue. If you are reporting a problem on a different page, please paste the correct address here.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">70,71</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6334384804553156455" datatype="html">
+        <source>Please provide your email address if you wish for the TIM administrators to follow up with you regarding this report.</source>
+        <target state="new">Please provide your email address if you wish for the TIM administrators to follow up with you regarding this report.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">101,102</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4678590939146937144" datatype="html">
+        <source>Explain why you think the content is inappropriate. Be as specific as possible.</source>
+        <target state="new">Explain why you think the content is inappropriate. Be as specific as possible.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">120,121</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7271539637870485137" datatype="html">
+        <source>The email address is invalid.</source>
+        <target state="new">The email address is invalid.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">220</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2801541784998973995" datatype="html">
+        <source>The reported page address is invalid.</source>
+        <target state="new">The reported page address is invalid.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/ui/report-content-dialog.component.ts</context>
+          <context context-type="linenumber">223</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -3,6 +3,7 @@ import {getVisibilityVars} from "tim/timRoot";
 import {documentglobals, genericglobals} from "tim/util/globals";
 import {Users} from "tim/user/userService";
 import {showReportContentDialog} from "tim/ui/showReportContentDialog";
+import {to2} from "tim/util/utils";
 
 @Component({
     selector: "tim-footer",
@@ -58,7 +59,7 @@ import {showReportContentDialog} from "tim/ui/showReportContentDialog";
                                         Accessibility statement
                                     </a>
                                     <br>
-                                    <button class="timbutton" (click)="reportContent()">Report content</button>
+                                    <a (click)="reportContent()">Report content</a>
                                 </ng-container>
                             </div>
                         </div>
@@ -87,6 +88,13 @@ export class FooterComponent {
     }
 
     async reportContent() {
-        await showReportContentDialog({});
+        const windowUrl = window.location.href;
+        // TODO: Sanitation. Remove any tokens etc. to protect user
+        const response = await to2(
+            showReportContentDialog({currentUrl: windowUrl})
+        );
+        if (response.ok) {
+            // console.log("Results are in " + JSON.stringify(response.result));
+        }
     }
 }

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -2,6 +2,7 @@ import {Component} from "@angular/core";
 import {getVisibilityVars} from "tim/timRoot";
 import {documentglobals, genericglobals} from "tim/util/globals";
 import {Users} from "tim/user/userService";
+import {showReportContentDialog} from "tim/ui/showReportContentDialog";
 
 @Component({
     selector: "tim-footer",
@@ -56,6 +57,8 @@ import {Users} from "tim/user/userService";
                                        href="/view/{{footerDocs.accessibilityStatement}}" i18n>
                                         Accessibility statement
                                     </a>
+                                    <br>
+                                    <button class="timbutton" (click)="reportContent()">Report content</button>
                                 </ng-container>
                             </div>
                         </div>
@@ -81,5 +84,9 @@ export class FooterComponent {
         }
         // For languages not handled, default to english
         return link + "/en-US";
+    }
+
+    async reportContent() {
+        await showReportContentDialog({});
     }
 }

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -89,8 +89,6 @@ export class FooterComponent {
 
     async reportContent() {
         const windowUrl = window.location.href;
-        await to2(
-            showReportContentDialog({currentUrl: windowUrl})
-        );
+        await to2(showReportContentDialog({currentUrl: windowUrl}));
     }
 }

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -94,7 +94,6 @@ export class FooterComponent {
             showReportContentDialog({currentUrl: windowUrl})
         );
         if (response.ok) {
-            // console.log("Results are in " + JSON.stringify(response.result));
         }
     }
 }

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -59,7 +59,7 @@ import {to2} from "tim/util/utils";
                                         Accessibility statement
                                     </a>
                                     <br>
-                                    <a (click)="reportContent()" role="button" i18n>Report content</a>
+                                    <a (click)="reportContent()" role="button" i18n>Report inappropriate content</a>
                                 </ng-container>
                             </div>
                         </div>

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -59,7 +59,7 @@ import {to2} from "tim/util/utils";
                                         Accessibility statement
                                     </a>
                                     <br>
-                                    <a (click)="reportContent()" i18n>Report content</a>
+                                    <a (click)="reportContent()" role="button" i18n>Report content</a>
                                 </ng-container>
                             </div>
                         </div>

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -89,10 +89,8 @@ export class FooterComponent {
 
     async reportContent() {
         const windowUrl = window.location.href;
-        const response = await to2(
+        await to2(
             showReportContentDialog({currentUrl: windowUrl})
         );
-        if (response.ok) {
-        }
     }
 }

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -89,7 +89,6 @@ export class FooterComponent {
 
     async reportContent() {
         const windowUrl = window.location.href;
-        // TODO: Sanitation. Remove any tokens etc. to protect user
         const response = await to2(
             showReportContentDialog({currentUrl: windowUrl})
         );

--- a/timApp/static/scripts/tim/footer.component.ts
+++ b/timApp/static/scripts/tim/footer.component.ts
@@ -59,7 +59,7 @@ import {to2} from "tim/util/utils";
                                         Accessibility statement
                                     </a>
                                     <br>
-                                    <a (click)="reportContent()">Report content</a>
+                                    <a (click)="reportContent()" i18n>Report content</a>
                                 </ng-container>
                             </div>
                         </div>

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.scss
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.scss
@@ -1,0 +1,3 @@
+tim-dialog-frame ::ng-deep div.modal-dialog {
+  min-width: 300px;
+}

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -1,11 +1,13 @@
-import {Component, DoBootstrap, NgModule} from "@angular/core";
+import {Component, NgModule} from "@angular/core";
 import {AngularDialogComponent} from "./angulardialog/angular-dialog-component.directive";
 import {CommonModule} from "@angular/common";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {DialogModule} from "tim/ui/angulardialog/dialog.module";
 import {FormsModule} from "@angular/forms";
 
-export interface IReportContentParams {}
+export interface IReportContentParams {
+    currentUrl: string;
+}
 
 @Component({
     selector: "report-content-dialog",
@@ -15,16 +17,62 @@ export interface IReportContentParams {}
                 Report content
             </ng-container>
             <ng-container body>
-                <h1>Report Content</h1>
-                <form #form="ngForm">
-                    <fieldset>
-                        <div class="form-group">
+                <div class="page-header">
+                    <h1>Report Content</h1>
+                </div>
+                <div class="help-block">
+                    <p>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.</p>
+                    <p>If you would like the TIM administrators to follow up with you, you may optionally include you email address.</p>
+                </div>
+                <form #reportForm="ngForm">
+                    <div class="form-group">
+                        <label i18n for="idUrl">
+                            Page URL
+                            <span class="label label-info">(optional)</span>
+                        </label>
+                        <input 
+                                class="form-control"
+                                id="idUrl" 
+                                type="url" 
+                                name="url" 
+                                [(ngModel)]="url">
+                        <small class="help-block">This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
+                    </div>
+                    <div class="form-group">
+                        <label i18n for="idEmail">
+                            Your Email
+                            <span class="label label-info">(optional)</span>
+                        </label> 
+                        <input 
+                                class="form-control"
+                                id="idEmail" 
+                                type="email" 
+                                #emailField="ngModel"
+                                name="emailInput" 
+                                [(ngModel)]="email" 
+                                placeholder="Email">
+                        <small class="help-block">Enter your email if you'd like us to contact you about your report.</small>
+                    </div>
+                    <div class="form-group" [ngClass]="{'has-error': reasonfield.invalid && reasonfield.touched}">
+                        <label for="idReportText" i18n>Describe the issue</label>
+                        <textarea 
+                                class="form-control" 
+                                id="idReportText" 
+                                name="reportText" 
+                                rows="5"
+                                [(ngModel)]="reason" 
+                                #reasonfield="ngModel" 
+                                required></textarea>
+                        <div *ngIf="reasonfield.invalid && reasonfield.touched" class="alert alert-danger">
+                            <small *ngIf="reasonfield.errors?.required" i18n>This field is required.</small>    
                         </div>
-                    </fieldset>
+                        <small class="help-block">Please explain what you found harmful or inappropriate. Be as specific as possible.</small>
+                    </div>
                 </form>           
             </ng-container>
             <ng-container footer>
-                <p>Footer</p>
+                <button class="timButton" (click)="sendMail()" [disabled]="reportForm.invalid">Report Page</button>
+                <button class="btn btn-default" (click)="dismiss()">Cancel</button>
             </ng-container>
         </tim-dialog-frame>
     `,
@@ -34,10 +82,30 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
     any
 > {
     protected dialogName = "ReportContent";
+    name = "";
+    email = "";
+    url = "";
+    reason = "";
 
     constructor() {
         super();
     }
+
+    ngOnInit() {
+        this.url = this.data.currentUrl;
+    }
+
+    //TODO: Sanitize user input
+    sendMail() {
+        this.close({
+            name: this.name,
+            email: this.email,
+            url: this.url,
+            reason: this.reason,
+        });
+    }
+
+    protected readonly JSON = JSON;
 }
 
 @NgModule({

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, HostListener, NgModule} from "@angular/core";
+import {Component, NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {DialogModule} from "tim/ui/angulardialog/dialog.module";
@@ -20,6 +20,11 @@ export interface IContentReport {
     reportedUrl: string;
 }
 
+export interface IContentReportResponse {
+    status: string;
+    description?: string;
+}
+
 @Component({
     selector: "report-content-dialog",
     template: `
@@ -36,81 +41,97 @@ export interface IContentReport {
                     <p>If you would like the TIM administrators to follow up with you, you may optionally include you email address.</p>
                 </div>
                 <form #reportForm="ngForm">
-                    <div class="form-group">
-                        <div class="row">
-                            <div class="col-lg-6">
-                                <label i18n for="idUrl">
-                                    Page URL
-                                    <span>(optional)</span>
-                                </label>
-                                <div class="input-group">
-                                    <input 
-                                            class="form-control"
-                                            id="idUrl" 
-                                            type="url" 
-                                            name="url" 
-                                            [(ngModel)]="reportedUrl"
-                                            i18n>
-                                    <span class="input-group-btn">
-                                        <button class="btn btn-info" (click)="getUrl()" tooltip="Retrieve current Url"><span class="glyphicon glyphicon-repeat"></span></button>
-                                    </span>
-                                </div>
-                                <small class="help-block" i18n>This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <div class="row">
-                            <div class="col-lg-6">
-                                <label i18n for="idEmail">
-                                    Your Email
-                                    <span>(optional)</span>
-                                </label>
-                                <div class="input-group">
-                                    <input 
-                                            class="form-control"
-                                            id="idEmail" 
-                                            type="email" 
-                                            #emailField="ngModel"
-                                            name="emailInput" 
-                                            [(ngModel)]="email" 
-                                            placeholder="Email"
-                                            maxlength="256"
-                                            i18n>
-                                    <span class="input-group-btn">
-                                        <button class="btn btn-info" tooltip="Get user email" (click)="getUserMail()">@</button>
-                                    </span>
-                                    <div *ngIf="emailField.invalid && (emailField.dirty || emailField.touched)" class="alert alert-danger">
-                                        <small *ngIf="emailField.errors?.email" i18n>Please enter a valid email address.</small>
-                                        <small *ngIf="emailField.errors?.maxlenght" i18n>The email address cannot exceed 256 characters.</small>
+                    <fieldset [disabled]="showOk" [ngClass]="{'text-muted': showOk}">
+                        <div class="form-group">
+                            <div class="row">
+                                <div class="col-lg-6">
+                                    <label i18n for="idUrl">
+                                        Page URL
+                                        <span>(optional)</span>
+                                    </label>
+                                    <div class="input-group">
+                                        <input 
+                                                class="form-control"
+                                                id="idUrl" 
+                                                type="url" 
+                                                name="url" 
+                                                [(ngModel)]="reportedUrl"
+                                                (ngModelChange)="clearUrlError()"
+                                                i18n>
+                                        <span class="input-group-btn">
+                                            <button class="btn btn-primary" (click)="getUrl()" i18n>Get current url</button>
+                                        </span>
                                     </div>
+                                    <div *ngIf="urlError" class="alert alert-danger">
+                                        <small *ngIf="urlError" i18n>Please check the url address. You can only report addresses from TIM.</small>
+                                    </div>
+                                    <small class="help-block" i18n>This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
                                 </div>
-                                    <small class="help-block" i18n>Enter your email if you'd like us to contact you about your report.</small>
                             </div>
                         </div>
-                    </div>
-                    <div class="form-group" [ngClass]="{'has-error': reasonfield.invalid && reasonfield.touched}">
-                        <label for="idReportText" i18n>Describe the issue</label>
-                        <textarea 
-                                class="form-control" 
-                                id="idReportText" 
-                                name="reportText" 
-                                rows="5"
-                                [(ngModel)]="reason" 
-                                #reasonfield="ngModel"
-                                maxlength="2000"
-                                required></textarea>
-                        <div *ngIf="reasonfield.invalid && (reasonfield.dirty || reasonfield.touched)" class="alert alert-danger">
-                            <small *ngIf="reasonfield.errors?.required" i18n><span class="glyphicon glyphicon-exclamation-sign"></span> This field is required.</small>    
-                            <small *ngIf="reasonfield.errors?.maxlenght" i18n>The description cannot exceed 2000 characters.</small>    
+                        <div class="form-group">
+                            <div class="row">
+                                <div class="col-lg-6">
+                                    <label i18n for="idEmail">
+                                        Your Email
+                                        <span>(optional)</span>
+                                    </label>
+                                    <div class="input-group">
+                                        <input 
+                                                class="form-control"
+                                                id="idEmail" 
+                                                type="email" 
+                                                #emailfield="ngModel"
+                                                name="emailInput" 
+                                                [(ngModel)]="email" 
+                                                placeholder="Email"
+                                                maxlength="256"
+                                                (ngModelChange)="clearEmailError()"
+                                                i18n>
+                                        <span class="input-group-btn">
+                                            <button class="btn btn-primary" (click)="getUserMail()" [disabled]="!isLoggedIn()" i18n>Fill with user email</button>
+                                        </span>
+                                        </div>
+                                        <div *ngIf="emailfield.invalid && (emailfield.dirty || emailfield.touched) || email_error" class="alert alert-danger">
+                                            <small *ngIf="emailfield.errors?.email || email_error" i18n>Please enter a valid email address.</small>
+                                            <small *ngIf="emailfield.errors?.maxlenght" i18n>The email address cannot exceed 256 characters.</small>
+                                    </div>
+                                    <small class="help-block" i18n>Enter your email if you'd like us to contact you about your report.</small>
+                                </div>
+                            </div>
                         </div>
-                        <small class="help-block" i18n>Please explain what you found harmful or inappropriate. Be as specific as possible.</small>
-                    </div>
+                        <div class="form-group" [ngClass]="{'has-error': reasonfield.invalid && reasonfield.touched}">
+                            <label for="idReportText" i18n>Describe the issue</label>
+                            <textarea 
+                                    class="form-control" 
+                                    id="idReportText" 
+                                    name="reportText" 
+                                    rows="5"
+                                    [(ngModel)]="reason" 
+                                    #reasonfield="ngModel"
+                                    maxlength="2000"
+                                    required></textarea>
+                            <div *ngIf="reasonfield.invalid && (reasonfield.dirty || reasonfield.touched)" class="alert alert-danger">
+                                <small *ngIf="reasonfield.errors?.required" i18n><span class="glyphicon glyphicon-exclamation-sign"></span> This field is required.</small>    
+                                <small *ngIf="reasonfield.errors?.maxlenght" i18n>The description cannot exceed 2000 characters.</small>    
+                            </div>
+                            <small class="help-block" i18n>Please explain what you found harmful or inappropriate. Be as specific as possible.</small>
+                        </div>
+                    </fieldset>
                 </form>           
             </ng-container>
             <ng-container footer>
-                <button class="timButton" (click)="sendMail()" [disabled]="reportForm.invalid" i18n>Report Page</button>
-                <button class="btn btn-default" (click)="dismiss()" i18n>Cancel</button>
+                <div *ngIf="!showOk">
+                    <button class="timButton" (click)="sendMail()" [disabled]="reportForm.invalid" i18n>Report Page</button>
+                    <button class="btn btn-default" (click)="dismiss()" i18n>Cancel</button>
+                </div>
+                <div *ngIf="showOk">
+                    <div class="alert alert-success">
+                        <p class="text-left" i18n><strong>Thank you for your report.</strong></p>
+                        <p class="text-left" i18n>Your message has been sent to the TIM administrators. We appreciate your help in keeping our content accurate and safe.</p>
+                    </div>
+                    <button class="timButton" (click)="dismiss()" i18n>Done</button>
+                </div>
             </ng-container>
         </tim-dialog-frame>
     `,
@@ -125,6 +146,9 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
     email: string | null = "";
     reportedUrl = "";
     private currentUser = Users.getCurrent();
+    showOk: boolean = false;
+    email_error: boolean = false;
+    urlError: boolean = false;
 
     constructor(private http: HttpClient) {
         super();
@@ -136,20 +160,27 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
 
     getUrl() {
         this.reportedUrl = window.location.href;
+        this.clearUrlError();
+    }
+
+    protected isLoggedIn(): boolean {
+        return Users.isLoggedIn();
     }
 
     protected getUserMail() {
         this.email = this.currentUser.email;
+        this.clearEmailError();
     }
 
-    // TODO: Sanitize user input
-    async sendMail() {
-        this.close({
-            reason: this.reason,
-            email: this.email,
-            reportedUrl: this.reportedUrl,
-        });
+    clearEmailError() {
+        this.email_error = false;
+    }
 
+    clearUrlError() {
+        this.urlError = false;
+    }
+
+    async sendMail() {
         const json_payload = {
             reason: this.reason,
             email: this.email,
@@ -157,15 +188,24 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
         };
 
         const r = await toPromise(
-            this.http.post<{status: "ok"}>("/report", json_payload)
+            this.http.post<IContentReportResponse>("/report", json_payload)
         );
         if (!r.ok) {
             await showMessageDialog(r.result.error.error);
             return;
         } else {
-            await showMessageDialog(
-                "Thank you for your report. The report has been sent to TIM administrators."
-            );
+            if (r.result.status == "error") {
+                switch (r.result.description) {
+                    case "invalid_email":
+                        this.email_error = true;
+                        break;
+                    case "invalid_url":
+                        this.urlError = true;
+                        break;
+                }
+            } else {
+                this.showOk = true;
+            }
         }
     }
 }

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -27,7 +27,7 @@ export interface IContentReportResponse {
 @Component({
     selector: "report-content-dialog",
     template: `
-        <tim-dialog-frame>
+        <tim-dialog-frame [minimizable]="false">
             <ng-container i18n header>
                 Report inappropriate content
             </ng-container>

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -19,15 +19,6 @@ export interface IContentReport {
     reportedUrl: string;
 }
 
-export interface IContentReportResponse {
-    ok: boolean;
-    result: {
-        data?: string;
-        error?: string;
-        status?: string;
-    };
-}
-
 @Component({
     selector: "report-content-dialog",
     template: `
@@ -205,9 +196,7 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
             reportedUrl: this.reportedUrl,
         };
 
-        const r = await toPromise(
-            this.http.post<IContentReportResponse>("/report", json_payload)
-        );
+        const r = await toPromise(this.http.post("/report", json_payload));
         if (!r.ok) {
             this.showError = true;
             const status = r.result.status ?? 0;

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -44,7 +44,7 @@ export interface IContentReportResponse {
                     <fieldset [disabled]="showOk" [ngClass]="{'text-muted': showOk}">
                         <div class="form-group">
                             <div class="row">
-                                <div class="col-lg-6">
+                                <div class="col-lg-12">
                                     <label i18n for="idUrl">
                                         Page URL
                                         <span>(optional)</span>
@@ -71,7 +71,7 @@ export interface IContentReportResponse {
                         </div>
                         <div class="form-group">
                             <div class="row">
-                                <div class="col-lg-6">
+                                <div class="col-lg-12">
                                     <label i18n for="idEmail">
                                         Your Email
                                         <span>(optional)</span>
@@ -195,13 +195,10 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
             return;
         } else {
             if (r.result.status == "error") {
-                switch (r.result.description) {
-                    case "invalid_email":
-                        this.email_error = true;
-                        break;
-                    case "invalid_url":
-                        this.urlError = true;
-                        break;
+                if (r.result.description == "invalid_email") {
+                    this.email_error = true;
+                } else if (r.result.description == "invalid_url") {
+                    this.urlError = true;
                 }
             } else {
                 this.showOk = true;

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -1,0 +1,48 @@
+import {Component, DoBootstrap, NgModule} from "@angular/core";
+import {AngularDialogComponent} from "./angulardialog/angular-dialog-component.directive";
+import {CommonModule} from "@angular/common";
+import {TimUtilityModule} from "tim/ui/tim-utility.module";
+import {DialogModule} from "tim/ui/angulardialog/dialog.module";
+import {FormsModule} from "@angular/forms";
+
+export interface IReportContentParams {}
+
+@Component({
+    selector: "report-content-dialog",
+    template: `
+        <tim-dialog-frame>
+            <ng-container i18n header>
+                Report content
+            </ng-container>
+            <ng-container body>
+                <h1>Report Content</h1>
+                <form #form="ngForm">
+                    <fieldset>
+                        <div class="form-group">
+                        </div>
+                    </fieldset>
+                </form>           
+            </ng-container>
+            <ng-container footer>
+                <p>Footer</p>
+            </ng-container>
+        </tim-dialog-frame>
+    `,
+})
+export class ReportContentDialogComponent extends AngularDialogComponent<
+    IReportContentParams,
+    any
+> {
+    protected dialogName = "ReportContent";
+
+    constructor() {
+        super();
+    }
+}
+
+@NgModule({
+    declarations: [ReportContentDialogComponent],
+    exports: [ReportContentDialogComponent],
+    imports: [CommonModule, TimUtilityModule, DialogModule, FormsModule],
+})
+export class ReportContentDialogModule {}

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -22,8 +22,6 @@ export interface IContentReport {
 export interface IContentReportResponse {
     status: string;
     description?: string;
-    host?: string;
-    reportedUrl?: string;
 }
 
 @Component({
@@ -64,7 +62,7 @@ export interface IContentReportResponse {
                                         </span>
                                     </div>
                                     <div *ngIf="urlError" class="alert alert-danger">
-                                        <small *ngIf="urlError" i18n>Please check the page address. You can only report addresses from TIM. {{urlMessage}}</small>
+                                        <small *ngIf="urlError" i18n>Please check the page address. You can only report addresses from TIM.</small>
                                     </div>
                                     <small class="help-block" i18n>This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
                                 </div>
@@ -221,11 +219,6 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
                     this.email_error = true;
                 } else if (r.result.description == "invalid_url") {
                     this.urlError = true;
-                    this.urlMessage =
-                        "reported Url: " +
-                        r.result.reportedUrl +
-                        " Host: " +
-                        r.result.host;
                 }
             } else {
                 this.showOk = true;

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -1,4 +1,4 @@
-import {Component, NgModule} from "@angular/core";
+import {Component, HostListener, NgModule} from "@angular/core";
 import {CommonModule} from "@angular/common";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {DialogModule} from "tim/ui/angulardialog/dialog.module";
@@ -7,6 +7,8 @@ import {AngularDialogComponent} from "tim/ui/angulardialog/angular-dialog-compon
 import {HttpClient, HttpClientModule} from "@angular/common/http";
 import {toPromise} from "tim/util/utils";
 import {showMessageDialog} from "tim/ui/showMessageDialog";
+import {TooltipModule} from "ngx-bootstrap/tooltip";
+import {Users} from "tim/user/userService";
 
 export interface IReportContentParams {
     currentUrl: string;
@@ -14,15 +16,13 @@ export interface IReportContentParams {
 
 export interface IContentReport {
     reason: string;
-    name: string;
-    email: string;
+    email: string | null;
     reportedUrl: string;
 }
 
 @Component({
     selector: "report-content-dialog",
     template: `
-        <div class="modal-bg"></div>
         <tim-dialog-frame>
             <ng-container i18n header>
                 Report content
@@ -37,39 +37,57 @@ export interface IContentReport {
                 </div>
                 <form #reportForm="ngForm">
                     <div class="form-group">
-                        <label i18n for="idUrl">
-                            Page URL
-                            <span>(optional)</span>
-                        </label>
-                        <input 
-                                class="form-control"
-                                id="idUrl" 
-                                type="url" 
-                                name="url" 
-                                [(ngModel)]="reportedUrl"
-                                i18n>
-                        <small class="help-block" i18n>This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
+                        <div class="row">
+                            <div class="col-lg-6">
+                                <label i18n for="idUrl">
+                                    Page URL
+                                    <span>(optional)</span>
+                                </label>
+                                <div class="input-group">
+                                    <input 
+                                            class="form-control"
+                                            id="idUrl" 
+                                            type="url" 
+                                            name="url" 
+                                            [(ngModel)]="reportedUrl"
+                                            i18n>
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-info" (click)="getUrl()" tooltip="Retrieve current Url"><span class="glyphicon glyphicon-repeat"></span></button>
+                                    </span>
+                                </div>
+                                <small class="help-block" i18n>This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
+                            </div>
+                        </div>
                     </div>
                     <div class="form-group">
-                        <label i18n for="idEmail">
-                            Your Email
-                            <span>(optional)</span>
-                        </label> 
-                        <input 
-                                class="form-control"
-                                id="idEmail" 
-                                type="email" 
-                                #emailField="ngModel"
-                                name="emailInput" 
-                                [(ngModel)]="email" 
-                                placeholder="Email"
-                                maxlength="256"
-                                i18n>
-                        <div *ngIf="emailField.invalid && (emailField.dirty || emailField.touched)" class="alert alert-danger">
-                            <small *ngIf="emailField.errors?.email" i18n>Please enter a valid email address.</small>
-                            <small *ngIf="emailField.errors?.maxlenght" i18n>The email address cannot exceed 256 characters.</small>
+                        <div class="row">
+                            <div class="col-lg-6">
+                                <label i18n for="idEmail">
+                                    Your Email
+                                    <span>(optional)</span>
+                                </label>
+                                <div class="input-group">
+                                    <input 
+                                            class="form-control"
+                                            id="idEmail" 
+                                            type="email" 
+                                            #emailField="ngModel"
+                                            name="emailInput" 
+                                            [(ngModel)]="email" 
+                                            placeholder="Email"
+                                            maxlength="256"
+                                            i18n>
+                                    <span class="input-group-btn">
+                                        <button class="btn btn-info" tooltip="Get user email" (click)="getUserMail()">@</button>
+                                    </span>
+                                    <div *ngIf="emailField.invalid && (emailField.dirty || emailField.touched)" class="alert alert-danger">
+                                        <small *ngIf="emailField.errors?.email" i18n>Please enter a valid email address.</small>
+                                        <small *ngIf="emailField.errors?.maxlenght" i18n>The email address cannot exceed 256 characters.</small>
+                                    </div>
+                                </div>
+                                    <small class="help-block" i18n>Enter your email if you'd like us to contact you about your report.</small>
+                            </div>
                         </div>
-                        <small class="help-block" i18n>Enter your email if you'd like us to contact you about your report.</small>
                     </div>
                     <div class="form-group" [ngClass]="{'has-error': reasonfield.invalid && reasonfield.touched}">
                         <label for="idReportText" i18n>Describe the issue</label>
@@ -83,7 +101,7 @@ export interface IContentReport {
                                 maxlength="2000"
                                 required></textarea>
                         <div *ngIf="reasonfield.invalid && (reasonfield.dirty || reasonfield.touched)" class="alert alert-danger">
-                            <small *ngIf="reasonfield.errors?.required" i18n>This field is required.</small>    
+                            <small *ngIf="reasonfield.errors?.required" i18n><span class="glyphicon glyphicon-exclamation-sign"></span> This field is required.</small>    
                             <small *ngIf="reasonfield.errors?.maxlenght" i18n>The description cannot exceed 2000 characters.</small>    
                         </div>
                         <small class="help-block" i18n>Please explain what you found harmful or inappropriate. Be as specific as possible.</small>
@@ -104,8 +122,9 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
     protected dialogName = "ReportContent";
     reason = "";
     name = "";
-    email = "";
+    email: string | null = "";
     reportedUrl = "";
+    private currentUser = Users.getCurrent();
 
     constructor(private http: HttpClient) {
         super();
@@ -115,18 +134,24 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
         this.reportedUrl = this.data.currentUrl;
     }
 
+    getUrl() {
+        this.reportedUrl = window.location.href;
+    }
+
+    protected getUserMail() {
+        this.email = this.currentUser.email;
+    }
+
     // TODO: Sanitize user input
     async sendMail() {
         this.close({
             reason: this.reason,
-            name: this.name,
             email: this.email,
             reportedUrl: this.reportedUrl,
         });
 
         const json_payload = {
             reason: this.reason,
-            name: this.name,
             email: this.email,
             reportedUrl: this.reportedUrl,
         };
@@ -154,6 +179,7 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
         DialogModule,
         FormsModule,
         HttpClientModule,
+        TooltipModule,
     ],
 })
 export class ReportContentDialogModule {}

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -208,9 +208,9 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
             this.showError = true;
             const status = r.result.status ?? 0;
             if (status <= 0) {
-                this.errorMsg = $localize`Could not load task data. Check your internet connection and try again.`;
+                this.errorMsg = $localize`Could not connect to server. Check your internet connection and try again.`;
             } else if (status >= 500) {
-                this.errorMsg = $localize`There is an issue with the server. Try to save your work and reload the page.`;
+                this.errorMsg = $localize`There is an issue with the server. Make a copy of your message and refresh the page, or contact TIM support directly at tim@jyu.fi.`;
             }
         } else {
             if (r.result.status == "error") {

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -22,6 +22,8 @@ export interface IContentReport {
 export interface IContentReportResponse {
     status: string;
     description?: string;
+    host?: string;
+    reportedUrl?: string;
 }
 
 @Component({
@@ -62,7 +64,7 @@ export interface IContentReportResponse {
                                         </span>
                                     </div>
                                     <div *ngIf="urlError" class="alert alert-danger">
-                                        <small *ngIf="urlError" i18n>Please check the page address. You can only report addresses from TIM.</small>
+                                        <small *ngIf="urlError" i18n>Please check the page address. You can only report addresses from TIM. {{urlMessage}}</small>
                                     </div>
                                     <small class="help-block" i18n>This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
                                 </div>
@@ -158,6 +160,7 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
     email_error: boolean = false;
     errorMsg: string = "";
     urlError: boolean = false;
+    urlMessage: string = "";
 
     constructor(private http: HttpClient) {
         super();
@@ -218,6 +221,11 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
                     this.email_error = true;
                 } else if (r.result.description == "invalid_url") {
                     this.urlError = true;
+                    this.urlMessage =
+                        "reported Url: " +
+                        r.result.reportedUrl +
+                        " Host: " +
+                        r.result.host;
                 }
             } else {
                 this.showOk = true;

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -142,6 +142,7 @@ export interface IContentReportResponse {
             </ng-container>
         </tim-dialog-frame>
     `,
+    styleUrls: ["./report-content-dialog.component.scss"],
 })
 export class ReportContentDialogComponent extends AngularDialogComponent<
     IReportContentParams,

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -51,7 +51,7 @@ export interface IContentReportResponse {
                                         Page address
                                         <span>(optional)</span>
                                     </label>
-                                    <div class="input-group">
+                                    <div class="input-group" [ngClass]="{'has-error': urlError}">
                                         <input 
                                                 class="form-control"
                                                 id="idUrl" 
@@ -78,7 +78,7 @@ export interface IContentReportResponse {
                                         Your Email
                                         <span>(optional)</span>
                                     </label>
-                                    <div class="input-group">
+                                    <div class="input-group" [ngClass]="{'has-error': email_error}">
                                         <input 
                                                 class="form-control"
                                                 id="idEmail" 
@@ -187,12 +187,10 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
 
     clearEmailError() {
         this.email_error = false;
-        this.showError = false;
     }
 
     clearUrlError() {
         this.urlError = false;
-        this.showError = false;
     }
 
     dismissAlert() {
@@ -216,11 +214,11 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
             if (status <= 0) {
                 this.errorMsg = $localize`Could not connect to server. Check your internet connection and try again.`;
             } else if (r.result.error.error == "invalid_email") {
+                this.showError = false;
                 this.email_error = true;
-                this.errorMsg = $localize`The email address is invalid.`;
             } else if (r.result.error.error == "invalid_url") {
+                this.showError = false;
                 this.urlError = true;
-                this.errorMsg = $localize`The reported page address is invalid.`;
             } else if (status >= 500) {
                 this.errorMsg = $localize`There is an issue with the server. Make a copy of your message and refresh the page, or contact TIM support directly at tim@jyu.fi.`;
             }

--- a/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
+++ b/timApp/static/scripts/tim/ui/report-content-dialog.component.ts
@@ -1,9 +1,9 @@
 import {Component, NgModule} from "@angular/core";
-import {AngularDialogComponent} from "./angulardialog/angular-dialog-component.directive";
 import {CommonModule} from "@angular/common";
 import {TimUtilityModule} from "tim/ui/tim-utility.module";
 import {DialogModule} from "tim/ui/angulardialog/dialog.module";
 import {FormsModule} from "@angular/forms";
+import {AngularDialogComponent} from "tim/ui/angulardialog/angular-dialog-component.directive";
 
 export interface IReportContentParams {
     currentUrl: string;
@@ -18,9 +18,9 @@ export interface IReportContentParams {
             </ng-container>
             <ng-container body>
                 <div class="page-header">
-                    <h1>Report Content</h1>
+                    <h1 i18n>Report Content</h1>
                 </div>
-                <div class="help-block">
+                <div i18n class="help-block">
                     <p>You can use this form to report any harmful or inappropriate content you have encountered while using TIM.</p>
                     <p>If you would like the TIM administrators to follow up with you, you may optionally include you email address.</p>
                 </div>
@@ -28,20 +28,21 @@ export interface IReportContentParams {
                     <div class="form-group">
                         <label i18n for="idUrl">
                             Page URL
-                            <span class="label label-info">(optional)</span>
+                            <span>(optional)</span>
                         </label>
                         <input 
                                 class="form-control"
                                 id="idUrl" 
                                 type="url" 
                                 name="url" 
-                                [(ngModel)]="url">
-                        <small class="help-block">This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
+                                [(ngModel)]="url"
+                                i18n>
+                        <small class="help-block" i18n>This is the page where you encountered the issue. You can change it if you're reporting a different page.</small>
                     </div>
                     <div class="form-group">
                         <label i18n for="idEmail">
                             Your Email
-                            <span class="label label-info">(optional)</span>
+                            <span>(optional)</span>
                         </label> 
                         <input 
                                 class="form-control"
@@ -50,8 +51,9 @@ export interface IReportContentParams {
                                 #emailField="ngModel"
                                 name="emailInput" 
                                 [(ngModel)]="email" 
-                                placeholder="Email">
-                        <small class="help-block">Enter your email if you'd like us to contact you about your report.</small>
+                                placeholder="Email"
+                                i18n>
+                        <small class="help-block" i18n>Enter your email if you'd like us to contact you about your report.</small>
                     </div>
                     <div class="form-group" [ngClass]="{'has-error': reasonfield.invalid && reasonfield.touched}">
                         <label for="idReportText" i18n>Describe the issue</label>
@@ -66,13 +68,13 @@ export interface IReportContentParams {
                         <div *ngIf="reasonfield.invalid && reasonfield.touched" class="alert alert-danger">
                             <small *ngIf="reasonfield.errors?.required" i18n>This field is required.</small>    
                         </div>
-                        <small class="help-block">Please explain what you found harmful or inappropriate. Be as specific as possible.</small>
+                        <small class="help-block" i18n>Please explain what you found harmful or inappropriate. Be as specific as possible.</small>
                     </div>
                 </form>           
             </ng-container>
             <ng-container footer>
-                <button class="timButton" (click)="sendMail()" [disabled]="reportForm.invalid">Report Page</button>
-                <button class="btn btn-default" (click)="dismiss()">Cancel</button>
+                <button class="timButton" (click)="sendMail()" [disabled]="reportForm.invalid" i18n>Report Page</button>
+                <button class="btn btn-default" (click)="dismiss()" i18n>Cancel</button>
             </ng-container>
         </tim-dialog-frame>
     `,
@@ -95,7 +97,7 @@ export class ReportContentDialogComponent extends AngularDialogComponent<
         this.url = this.data.currentUrl;
     }
 
-    //TODO: Sanitize user input
+    // TODO: Sanitize user input
     sendMail() {
         this.close({
             name: this.name,

--- a/timApp/static/scripts/tim/ui/showReportContentDialog.ts
+++ b/timApp/static/scripts/tim/ui/showReportContentDialog.ts
@@ -1,5 +1,5 @@
-import {IReportContentParams} from "./report-content-dialog.component";
-import {angularDialog} from "./angulardialog/dialog.service";
+import type {IReportContentParams} from "tim/ui/report-content-dialog.component";
+import {angularDialog} from "tim/ui/angulardialog/dialog.service";
 
 export async function showReportContentDialog(params?: IReportContentParams) {
     const {ReportContentDialogComponent} = await import(

--- a/timApp/static/scripts/tim/ui/showReportContentDialog.ts
+++ b/timApp/static/scripts/tim/ui/showReportContentDialog.ts
@@ -5,5 +5,7 @@ export async function showReportContentDialog(params?: IReportContentParams) {
     const {ReportContentDialogComponent} = await import(
         "./report-content-dialog.component"
     );
-    return await angularDialog.open(ReportContentDialogComponent, params);
+    return await (
+        await angularDialog.open(ReportContentDialogComponent, params)
+    ).result;
 }

--- a/timApp/static/scripts/tim/ui/showReportContentDialog.ts
+++ b/timApp/static/scripts/tim/ui/showReportContentDialog.ts
@@ -1,0 +1,9 @@
+import {IReportContentParams} from "./report-content-dialog.component";
+import {angularDialog} from "./angulardialog/dialog.service";
+
+export async function showReportContentDialog(params?: IReportContentParams) {
+    const {ReportContentDialogComponent} = await import(
+        "./report-content-dialog.component"
+    );
+    return await angularDialog.open(ReportContentDialogComponent, params);
+}

--- a/timApp/tim.py
+++ b/timApp/tim.py
@@ -35,6 +35,7 @@ from timApp.auth.sessioninfo import (
 from timApp.backup.backup_routes import backup
 from timApp.bookmark.course import update_user_course_bookmarks
 from timApp.bookmark.routes import bookmarks
+from timApp.content_report.content_report import content_report
 from timApp.defaultconfig import SECRET_KEY
 from timApp.document.course.routes import course_blueprint
 from timApp.document.editing.routes import edit_page
@@ -112,6 +113,7 @@ cache.init_app(app)
 blueprints = [
     access,
     admin_bp,
+    content_report,
     annotations,
     answers,
     backup,


### PR DESCRIPTION
This pull request introduces a content reporting dialog, that is openable from the footer of the TIM UI. 

- User can use the dialog to send the report via email to TIM-administrators, and can optionally add their email address for a followup from the admins.
- New mail address variable is added to default_config.py for the content reports
- Dialog has a button for adding current viewed page address to the report.
- User has an option to autofill their email address to the form.
- Currently translated languages are English and Finnish.
- Success and errors are displayed on the dialog.

TODO:
- [ ] check resizing for mobile devices.
- [ ] Use CSS to prevent from overly minimizing the dialog.