### PR TITLE
docinfo: add extraGroupPreambleFolder setting

### DIFF
--- a/timApp/document/docinfo.py
+++ b/timApp/document/docinfo.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import re
+from heapq import heappush, heappop
 from itertools import accumulate
-from typing import Iterable, Generator, TYPE_CHECKING, Optional
+from typing import Iterable, Generator, TYPE_CHECKING, Optional, Collection
 
-from sqlalchemy import select, Result
+import sqlalchemy
+from sqlalchemy import select, Result, String
+from sqlalchemy.dialects.postgresql import array, ARRAY
 from sqlalchemy.orm import selectinload
 
 from timApp.document.docparagraph import DocParagraph
@@ -19,12 +23,18 @@ from timApp.item.item import Item
 from timApp.markdown.markdownconverter import expand_macros_info
 from timApp.notification.notification import Notification
 from timApp.timdb.sqa import db, run_sql
+from timApp.user.usergroup import UserGroup
 from timApp.util.utils import get_current_time, partition
 from tim_common.utils import safe_parse_item_list
 
 if TYPE_CHECKING:
     from timApp.document.translation.translation import Translation
     from timApp.document.docentry import DocEntry
+
+GROUP_PREAMBLE_PREFIX = "preamble"
+GROUP_PREAMBLE_PATTERN = re.compile(
+    rf"^{GROUP_PREAMBLE_PREFIX}-(?P<group_name>.+?)-(?P<priority>\d+)$"
+)
 
 
 class DocInfo(Item):
@@ -190,6 +200,8 @@ class DocInfo(Item):
                 self._load_extra_preambles(d, user_ctx, preamble_path_part)
             )
 
+            preamble_docs.extend(self._load_extra_group_preambles(d, user_ctx))
+
         return preamble_docs
 
     def _load_preamble_docs(
@@ -234,49 +246,155 @@ class DocInfo(Item):
 
     def _load_extra_preambles(
         self,
-        from_doc: DocInfo,
+        preamble_doc: DocInfo,
         user_ctx: UserContext,
         preamble_path_part: str,
     ) -> list[DocInfo]:
         result = []
         cur_doc_path = self.path_without_lang
-        settings = from_doc.document.get_settings()
+        settings = preamble_doc.document.get_settings()
+
         extra_preambles = settings.extra_preambles()
-        if extra_preambles:
-            macro_info = settings.get_macroinfo(default_view_ctx, user_ctx)
-            macro_info.macro_map.update(
-                {
-                    "ref_docid": self.id,
-                    "ref_docpath": cur_doc_path,
-                }
+        if not extra_preambles:
+            return result
+
+        macro_info = settings.get_macroinfo(default_view_ctx, user_ctx)
+        macro_info.macro_map.update(
+            {
+                "ref_docid": self.id,
+                "ref_docpath": cur_doc_path,
+            }
+        )
+
+        if isinstance(extra_preambles, str):
+            extra_preamble_doc_paths = safe_parse_item_list(
+                expand_macros_info(extra_preambles, macro_info, ignore_errors=True)
+            )
+        else:
+            extra_preamble_doc_paths = [
+                expand_macros_info(ep, macro_info, ignore_errors=True)
+                for ep in extra_preambles
+            ]
+        # Strip any extra spaces and remove any falsy values (empty strings) if they get evaluated as such
+        # Also remove any self-references
+        extra_preamble_doc_paths = list(
+            dict.fromkeys(
+                edp_t
+                for edp in extra_preamble_doc_paths
+                if (edp_t := edp.strip()) and edp_t != cur_doc_path
+            )
+        )
+        # TODO: Should extraPreambles be recursive?
+        extra_docs = self._load_preamble_docs(
+            extra_preamble_doc_paths, user_ctx, preamble_path_part
+        )
+        for edr, etr in extra_docs:  # type: DocEntry, Translation | None
+            ed = etr or edr
+            result.append(ed)
+            ed.document.ref_doc_cache = self.document.ref_doc_cache
+
+        return result
+
+    def _load_extra_group_preambles(
+        self,
+        preamble_doc: DocInfo,
+        user_ctx: UserContext,
+    ) -> list[DocInfo]:
+        from timApp.document.docentry import DocEntry
+
+        result = []
+        settings = preamble_doc.document.get_settings()
+        extra_group_preambles_folder = settings.extra_group_preambles_folder()
+
+        if not extra_group_preambles_folder:
+            return result
+
+        # Normalize; the path is always assumed to be relative to the root
+        extra_group_preambles_folder = extra_group_preambles_folder.strip("/")
+
+        # If the current doc is in the extra group preambles folder, we don't need to load anything
+        # to prevent recursion.
+        if self.path.startswith(f"{extra_group_preambles_folder}/"):
+            return result
+
+        # Fetch all potential group preamble documents
+        #  1. Get the groups that the current user belongs to
+        #  2. Find all documents that have the path of "extra_group_preambles_folder/<group_name>-"
+        #  3. Process the document paths
+        #     - Check the doc path is of format <group_name>-<priority>
+        # In general, we expect N(groups) << N(documents), so we separately fetch groups and construct
+        # a custom OR query to find the potential group preamble documents.
+        # This way we can make use of DocEntry.name being indexed.
+        user_group_names: set[str] = set(
+            run_sql(
+                user_ctx.user.get_groups(
+                    include_special=False, include_expired=False
+                ).with_only_columns(UserGroup.name)
+            )
+            .scalars()
+            .all()
+        )
+        group_preamble_candidates_condition = DocEntry.name.like(
+            sqlalchemy.any_(
+                sqlalchemy.cast(
+                    [
+                        f"{extra_group_preambles_folder}/{GROUP_PREAMBLE_PREFIX}-{group_name}-%"
+                        for group_name in user_group_names
+                    ],
+                    ARRAY(String),
+                )
+            )
+        )
+        potential_group_preamble_doc_paths_query = select(DocEntry.name).filter(
+            group_preamble_candidates_condition
+        )
+        potential_group_preamble_doc_paths = (
+            run_sql(potential_group_preamble_doc_paths_query).scalars().unique()
+        )
+
+        group_preamble_docs_queue = []
+
+        for doc_path in potential_group_preamble_doc_paths:  # type: str
+            last_part = doc_path.rsplit("/", 1)[-1]
+            match = GROUP_PREAMBLE_PATTERN.match(last_part)
+            if not match:
+                continue
+            group_name = match.group("group_name")
+            if group_name not in user_group_names:
+                continue
+            # We have a valid group preamble document
+            # Add it to the list of group preamble docs by its priority
+            # Note: Python's priority queue is a min-heap, so we use negative priority
+            heappush(
+                group_preamble_docs_queue, (-int(match.group("priority")), doc_path)
             )
 
-            if isinstance(extra_preambles, str):
-                extra_preamble_doc_paths = safe_parse_item_list(
-                    expand_macros_info(extra_preambles, macro_info, ignore_errors=True)
-                )
-            else:
-                extra_preamble_doc_paths = [
-                    expand_macros_info(ep, macro_info, ignore_errors=True)
-                    for ep in extra_preambles
-                ]
-            # Strip any extra spaces and remove any falsy values (empty strings) if they get evaluated as such
-            # Also remove any self-references
-            extra_preamble_doc_paths = list(
-                dict.fromkeys(
-                    edp_t
-                    for edp in extra_preamble_doc_paths
-                    if (edp_t := edp.strip()) and edp_t != cur_doc_path
-                )
-            )
-            # TODO: Should extraPreambles be recursive?
-            extra_docs = self._load_preamble_docs(
-                extra_preamble_doc_paths, user_ctx, preamble_path_part
-            )
-            for edr, etr in extra_docs:  # type: DocEntry, Translation | None
-                ed = etr or edr
-                result.append(ed)
-                ed.document.ref_doc_cache = self.document.ref_doc_cache
+        if not group_preamble_docs_queue:
+            return result
+
+        # Now, pick the preambles with the top priority
+        final_group_preamble_paths = []
+        priority, doc_path = heappop(group_preamble_docs_queue)
+        final_group_preamble_paths.append(doc_path)
+        # If there are multiple preambles with the same priority, we pick them all;
+        # this is why we peek the element before popping it.
+        while group_preamble_docs_queue:
+            next_priority, doc_path = heappop(group_preamble_docs_queue)
+            if next_priority != priority:
+                break
+            final_group_preamble_paths.append(doc_path)
+
+        # The final list has the group preamble document paths
+        # We can finally load the documents, but in reverse to ensure those with the higher priority apply last.
+        group_preamble_docs = self._load_preamble_docs(
+            final_group_preamble_paths[::-1],
+            user_ctx,
+            preamble_path_part="",  # Empty, because the check has already been done while fetching
+        )
+        for edr, etr in group_preamble_docs:  # type: DocEntry, Translation | None
+            ed = etr or edr
+            result.append(ed)
+            ed.document.ref_doc_cache = self.document.ref_doc_cache
 
         return result
 

--- a/timApp/document/docinfo.py
+++ b/timApp/document/docinfo.py
@@ -214,9 +214,14 @@ class DocInfo(Item):
         )
 
         docs = []
+        doc_ids: set[int] = set()
 
         for de, tr in docs_q:  # type: DocEntry, Translation | None
             d = tr or de
+            # Technically, we can have duplicates through aliases, so we need to dedupe here
+            if d.id in doc_ids:
+                continue
+            doc_ids.add(d.id)
             path = d.path_without_lang
             if preamble_path_part not in path and not user_ctx.user.has_view_access(d):
                 continue

--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -120,6 +120,7 @@ class DocSettingTypes:
     loginCodes: bool
     loginMessage: str
     customIndex: list[tuple[Any, Any]]
+    extraGroupPreambleFolder: str | None = None
 
 
 doc_setting_field_map: dict[str, Field] = {
@@ -703,6 +704,9 @@ class DocSettings:
 
     def extra_preambles(self) -> list[str] | str | None:
         return self.get_setting_or_default("extraPreambles", None)
+
+    def extra_group_preambles_folder(self) -> str | None:
+        return self.get_setting_or_default("extraGroupPreambleFolder", None)
 
     def lazy_answers(self) -> bool:
         return self.get_setting_or_default("lazyAnswers", False)


### PR DESCRIPTION
The `extraGroupPreambleFolder` preamble document setting allows loading preambles based on what groups a user belongs to.

The setting takes a TIM path and only functions within a preamble. When a document is loaded with a preamble that includes the option, the following occurs:

1. The path in `extraGroupPreambleFolder` is searched for any documents with the short name of form `preamble-<group_name>-<priority>` where `<group_name>` is a name of a user group that the current user loading the page is a member of and `<priority>` is an integer.
2. The documents with the highest priority are loaded as preambles. If multiple documents have the same priority, they all are loaded in lexicographical order.

The group preambles are loaded in an inverse order; that is, the document with the highest priority is loaded last and it thus overrides the settings of the other group preambles.

The normal preamble loading order still applies; the most local preamble is always loaded last.

---
Esimerkki/testi: <https://timbeta02.tim.education/view/users/dz-dz/test-group-preambles/test-doc> (testuser1, testuser2, testuser3; jokaisella eri preamblet)

Ryhmäpreamblet: <https://timbeta02.tim.education/view/users/dz-dz/test-group-preambles/group-preambles> (admin1)

Esimerkin selitys:

- `testuser1`
   - Kuuluu ryhmiin `testgroup1`, `testgroup2`.
   - Latautuu `preamble-testgroup2-2`, koska sillä on korkeampi prioriteetti kuin `preamble-testgroup1-1`
- `testuser2`
   - Kuuluu ryhmään `testgroup2`.
   - Latautuu `preamble-testgroup2-2`, koska käyttäja kuuluu vain tähän ryhmään.
- `testuser3`
   - Kuuluu ryhmiin `testgroup1`, `testgroup3`.
   - Latautuu `preamble-testgroup1-1` ja `preamble-testgroup3-1`, koska niillä on sama prioriteetti.