### PR TITLE
Feature better exclude to copy-folder component

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -10943,6 +10943,178 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9054131468802299331" datatype="html">
+        <source>You can copy all documents and folders in this folder to another folder.</source>
+        <target state="translated">Voit kopioida kaikki tässä kansiossa olevat asiakirjat ja kansiot toiseen kansioon.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">29,30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8724125301600901569" datatype="html">
+        <source>Copy options</source>
+        <target state="translated">Kopiointiasetukset</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">30,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5122641209934306863" datatype="html">
+        <source> Copy active access rights</source>
+        <target state="translated"> Kopioi aktiiviset käyttöoikeudet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3134631678726108556" datatype="html">
+        <source> Copy expired access rights</source>
+        <target state="translated"> Kopioi vanhentuneet käyttöoikeudet</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7005994245870834103" datatype="html">
+        <source> Stop copying on errors</source>
+        <target state="translated"> Lopeta kopiointi virheiden yhteydessä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7918852881700996328" datatype="html">
+        <source>You can optionally enter a regular expression to exclude specific documents or folders from being copied.</source>
+        <target state="translated">Voit halutessasi syöttää säännöllisen lausekkeen, jolla voit sulkea tietyt asiakirjat tai kansiot kopioinnin ulkopuolelle.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">48,49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6819973710480044605" datatype="html">
+        <source>For more information on copying see the </source>
+        <target state="translated">Lisätietoja kopioinnista on </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6225170388354110007" datatype="html">
+        <source>help page</source>
+        <target state="translated">ohjesivulla</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7648491229604756233" datatype="html">
+        <source>Exclude documents/folders that match:</source>
+        <target state="translated">Jätä pois asiakirjat/kansiot, jotka sisältävät vastaavuuden:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">51,52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7259476176756479954" datatype="html">
+        <source>Copy preview... </source>
+        <target state="translated">Kopioinnin esikatselu...</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">59,60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5166214964122035544" datatype="html">
+        <source>These are the items that will be copied. Select the items you want to exclude from being copied.</source>
+        <target state="translated">Nämä kohteet kopioidaan. Valitse kohteet, jotka haluat jättää kopioinnin ulkopuolelle.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">65,66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4467315881384291593" datatype="html">
+        <source> The destination folder already exists. Make sure this is intended before copying. </source>
+        <target state="translated"> Kohdekansio on jo olemassa. Ennen kopioimista varmista, että tämä on aiottua. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2996339800309212628" datatype="html">
+        <source>The following errors occurred while copying:</source>
+        <target state="translated">Kopioinnin aikana tapahtui seuraavat virheet:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">105,106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5646035883377382015" datatype="html">
+        <source>Destination:</source>
+        <target state="translated">Kohdekansio:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">43,44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3400430107547156831" datatype="html">
+        <source> Copying, this might take a while...</source>
+        <target state="translated"> Kopioidaan. Tämä voi kestää hetken aikaa...</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3224778871824337213" datatype="html">
+        <source>Folder </source>
+        <target state="translated">Kansio </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1040341291976790929" datatype="html">
+        <source> copied to</source>
+        <target state="translated"> Kopioitiin kansioon</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8982532068172415683" datatype="html">
+        <source>Exclude folder or document items</source>
+        <target state="translated">Kansioiden tai asiakirjojen kohteiden rajaaminen ulkopuolelle</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">63,64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5351591262168826856" datatype="html">
+        <source>Copy </source>
+        <target state="translated">Kopioi </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5234854445110707803" datatype="html">
+        <source>From</source>
+        <target state="translated">Mistä</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">73,75</context>
+        </context-group>
+        <note priority="1" from="description">tableHeader</note>
+        <note priority="1" from="meaning">Column name for source folders</note>
+      </trans-unit>
+      <trans-unit id="9059588518991956593" datatype="html">
+        <source>To</source>
+        <target state="translated">Mihin</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">76,77</context>
+        </context-group>
+        <note priority="1" from="description">tableHeader</note>
+        <note priority="1" from="meaning">Column name for target folders</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10848,6 +10848,178 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">224</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="9054131468802299331" datatype="html">
+        <source>You can copy all documents and folders in this folder to another folder.</source>
+        <target state="new">You can copy all documents and folders in this folder to another folder.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">29,30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8724125301600901569" datatype="html">
+        <source>Copy options</source>
+        <target state="new">Copy options</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">30,31</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5122641209934306863" datatype="html">
+        <source> Copy active access rights</source>
+        <target state="new"> Copy active access rights</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">33</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3134631678726108556" datatype="html">
+        <source> Copy expired access rights</source>
+        <target state="new"> Copy expired access rights</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">36</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7005994245870834103" datatype="html">
+        <source> Stop copying on errors</source>
+        <target state="new"> Stop copying on errors</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7918852881700996328" datatype="html">
+        <source>You can optionally enter a regular expression to exclude specific documents or folders from being copied.</source>
+        <target state="new">You can optionally enter a regular expression to exclude specific documents or folders from being copied.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">48,49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6819973710480044605" datatype="html">
+        <source>For more information on copying see the </source>
+        <target state="new">For more information on copying see the </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6225170388354110007" datatype="html">
+        <source>help page</source>
+        <target state="new">help page</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">49</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7648491229604756233" datatype="html">
+        <source>Exclude documents/folders that match:</source>
+        <target state="new">Exclude documents/folders that match:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">51,52</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7259476176756479954" datatype="html">
+        <source>Copy preview... </source>
+        <target state="new">Copy preview... </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">59,60</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5166214964122035544" datatype="html">
+        <source>These are the items that will be copied. Select the items you want to exclude from being copied.</source>
+        <target state="new">These are the items that will be copied. Select the items you want to exclude from being copied.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">65,66</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4467315881384291593" datatype="html">
+        <source> The destination folder already exists. Make sure this is intended before copying. </source>
+        <target state="new"> The destination folder already exists. Make sure this is intended before copying. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">92</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="2996339800309212628" datatype="html">
+        <source>The following errors occurred while copying:</source>
+        <target state="new">The following errors occurred while copying:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">105,106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5646035883377382015" datatype="html">
+        <source>Destination:</source>
+        <target state="new">Destination:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">43,44</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3400430107547156831" datatype="html">
+        <source> Copying, this might take a while...</source>
+        <target state="new"> Copying, this might take a while...</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">99</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3224778871824337213" datatype="html">
+        <source>Folder </source>
+        <target state="new">Folder </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1040341291976790929" datatype="html">
+        <source> copied to</source>
+        <target state="new"> copied to</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">101</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="8982532068172415683" datatype="html">
+        <source>Exclude folder or document items</source>
+        <target state="new">Exclude folder or document items</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">63,64</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5351591262168826856" datatype="html">
+        <source>Copy </source>
+        <target state="new">Copy </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">98</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5234854445110707803" datatype="html">
+        <source>From</source>
+        <target state="new">From</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">73,75</context>
+        </context-group>
+        <note priority="1" from="description">tableHeader</note>
+        <note priority="1" from="meaning">Column name for source folders</note>
+      </trans-unit>
+      <trans-unit id="9059588518991956593" datatype="html">
+        <source>To</source>
+        <target state="new">To</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">76,77</context>
+        </context-group>
+        <note priority="1" from="description">tableHeader</note>
+        <note priority="1" from="meaning">Column name for target folders</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/static/scripts/tim/folder/copy-folder.component.scss
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.scss
@@ -1,3 +1,8 @@
 .cb-group {
   margin-left: 1em;
 }
+
+.scrollable-table {
+  overflow-x: auto;
+  width: 100%;
+}

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -65,15 +65,15 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
                     <table class="table table-hover">
                     <thead>
                         <tr>
-                            <th><input type="{{ alldeselect ? 'Select all' : 'Deselect all' }}" [checked]="alldeselect" (change)="toggleAll($event)"></th>
+                            <th><input title="{{ alldeselect ? 'Select all' : 'Deselect all' }}" type="checkbox" [checked]="alldeselect" (change)="toggleAll($event)"></th>
                             <th>From</th>
                             <th></th>
                             <th>To</th>
                         </tr>
                     </thead>
                     <tbody>
-                        <tr *ngFor="let listItem of copyPreviewList; let i = index" (click)="toggleCheckbox($event)">
-                            <td><input type="checkbox" name="{{'chb' + i}}" (change)="checkboxToggleChange(listItem)"></td>
+                        <tr *ngFor="let listItem of copyPreviewList; let i = index" (click)="handleCheckboxOrRowToggle($event, listItem)" [ngClass]="{'text-muted': !checkbox.checked, 'active': !checkbox.checked}">
+                            <td><input type="checkbox" name="{{'chb' + i}}" #checkbox checked></td>
                             <td><span [innerText]="listItem.from"></span></td>
                             <td><i class="glyphicon glyphicon-arrow-right"></i></td>
                             <td><span [innerText]="listItem.to"></span></td>
@@ -117,11 +117,13 @@ export class CopyFolderComponent implements OnInit {
     copyOptions: CopyOptions = {...DEFAULT_COPY_OPTIONS};
     copyErrors?: string[];
     alldeselect: boolean;
+    excludedItems: string[];
 
     constructor(private http: HttpClient) {
         this.copyingFolder = "notcopying";
         this.copyFolderExclude = "";
         this.alldeselect = false;
+        this.excludedItems = [];
     }
 
     get previewLength() {
@@ -188,10 +190,15 @@ export class CopyFolderComponent implements OnInit {
         this.copyErrors = undefined;
     }
 
-    toggleCheckbox(event: MouseEvent) {
+    handleCheckboxOrRowToggle(
+        event: MouseEvent,
+        item: {from: string; to: string}
+    ) {
+        let changeCheckedState: boolean = true;
         const eventTarget = event.target as HTMLElement;
         if (eventTarget.tagName.toLowerCase() === "input") {
-            return;
+            // If checkbox is pressed directly, prevent double checking
+            changeCheckedState = false;
         }
         const row = eventTarget.closest("tr");
         if (!row) {
@@ -201,13 +208,16 @@ export class CopyFolderComponent implements OnInit {
             "input[type='checkbox']"
         ) as HTMLInputElement;
         if (checkbox) {
-            checkbox.checked = !checkbox.checked;
+            if (changeCheckedState) {
+                checkbox.checked = !checkbox.checked;
+            }
+            if (!checkbox.checked) {
+                this.excludedItems.push(item.from);
+            }
         }
     }
 
-    toggleAll(event: Event) {}
-
-    checkboxToggleChange(listItem: {from: string; to: string}) {
-        let escapedItemRegexp: string = "";
+    toggleAll(event: Event) {
+        console.log(this.excludedItems);
     }
 }

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -64,26 +64,28 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
                     <div class="panel-body">
                         <p>These are the items that will be copied. To exclude an item, simply check its corresponding checkbox.</p>
                     </div>
-                <table class="table-responsive">
-                    <table class="table table-hover">
-                    <thead>
-                        <tr>
-                            <th><input type="checkbox" [checked]="allSelected()" (change)="toggleAll($event)"></th>
-                            <th>From</th>
-                            <th></th>
-                            <th>To</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr *ngFor="let listItem of copyPreviewList" (click)="toggleItem(listItem)" [ngClass]="{'active text-muted': isSelected(listItem)}">
-                            <td><input type="checkbox" [checked]="isSelected(listItem)" (click)="toggleItem(listItem); $event.stopPropagation()"></td>
-                            <td><span [innerText]="listItem.from"></span></td>
-                            <td><i class="glyphicon glyphicon-arrow-right"></i></td>
-                            <td><span [innerText]="listItem.to"></span></td>
-                        </tr>
-                    </tbody>
+                <div class="scrollable-table">
+                    <table class="table-responsive">
+                        <table class="table table-hover">
+                        <thead>
+                            <tr>
+                                <th><input type="checkbox" [checked]="allSelected()" (change)="toggleAll($event)"></th>
+                                <th>From</th>
+                                <th></th>
+                                <th>To</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr *ngFor="let listItem of copyPreviewList" (click)="toggleItem(listItem)" [ngClass]="{'active text-muted': isSelected(listItem)}">
+                                <td><input type="checkbox" [checked]="isSelected(listItem)" (click)="toggleItem(listItem); $event.stopPropagation()"></td>
+                                <td><span [innerText]="listItem.from"></span></td>
+                                <td><i class="glyphicon glyphicon-arrow-right"></i></td>
+                                <td><span [innerText]="listItem.to"></span></td>
+                            </tr>
+                        </tbody>
+                        </table>
                     </table>
-                </table>
+                </div>
             </div>
             <p *ngIf="previewLength == 0 || allSelected()">Nothing would be copied.</p>
             <tim-alert severity="warning" *ngIf="destExists">

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -61,6 +61,32 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
                     <span [innerText]="p.to"></span>
                 </li>
             </ul>
+            <div class="panel panel-default" *ngIf="previewLength > 0">
+                <div class="panel-heading">Exclude folder or document items</div>
+                    <div class="panel-body">
+                        <p>These are the items that will be copied. To exclude an item, simply uncheck its corresponding checkbox.</p>
+                    </div>
+                <table class="table-responsive">
+                    <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Select</th>
+                            <th>From</th>
+                            <th></th>
+                            <th>To</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr *ngFor="let i of copyPreviewList">
+                            <td><input type="checkbox"></td>
+                            <td><span [innerText]="i.from"></span></td>
+                            <td><i class="glyphicon glyphicon-arrow-right"></i></td>
+                            <td><span [innerText]="i.to"></span></td>
+                        </tr>
+                    </tbody>
+                    </table>
+                </table>
+            </div>
             <p *ngIf="previewLength == 0">Nothing would be copied.</p>
             <tim-alert severity="warning" *ngIf="destExists">
                 The destination folder already exists. Make sure this is intended before copying.

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -197,16 +197,33 @@ export class CopyFolderComponent implements OnInit {
         this.excludedItems.clear();
     }
 
+    private getSubFolders(path: string) {
+        const splitPath = path.split("/");
+        const subFolders = [];
+        let current = "";
+        for (let i = 0; i < splitPath.length - 1; i++) {
+            current = current ? current + "/" + splitPath[i] : splitPath[i];
+            subFolders.push(current);
+        }
+        // remove the root folder
+        subFolders.shift();
+        return subFolders;
+    }
+
     toggleItem(item: {from: string; to: string}) {
         const path = item.from;
         if (this.excludedItems.has(path)) {
             this.excludedItems.delete(path);
+            const subFolders = this.getSubFolders(path);
+            subFolders.forEach((item) => {
+                this.excludedItems.delete(item);
+            });
         } else {
             this.excludedItems.add(path);
             // Any items that are children of this item are also excluded
-            this.copyPreviewList?.forEach((prevItem) => {
-                if (prevItem.from.startsWith(path)) {
-                    this.excludedItems.add(prevItem.from);
+            this.copyPreviewList?.forEach((previewItem) => {
+                if (previewItem.from.startsWith(path)) {
+                    this.excludedItems.add(previewItem.from);
                 }
             });
         }
@@ -235,8 +252,9 @@ export class CopyFolderComponent implements OnInit {
         const escapedCharacters = /[\-\[\]\/{}.()*+?\\^$|]/g;
         for (const item of names) {
             const escapedItem = item.replace(escapedCharacters, "\\$&");
-            expression = expression + "|\\b" + escapedItem + "\\b";
+            expression = expression + "|^" + escapedItem + "$";
         }
+        console.log(expression);
         return expression.startsWith("|")
             ? expression.substring(1)
             : expression;

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -50,24 +50,19 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
                        [(ngModel)]="copyFolderExclude" (ngModelChange)="copyParamChanged()">
                 <tim-error-message></tim-error-message>
             </div>
-            <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude)" class="timButton"
-                    [disabled]="copyFolderPath == item.path || copyPath.invalid"
-                    *ngIf="copyingFolder == 'notcopying'">Copy preview...
-            </button>
-            <ul *ngIf="previewLength > 0">
-                <li *ngFor="let p of copyPreviewList">
-                    <span [innerText]="p.from"></span>
-                    <i class="glyphicon glyphicon-arrow-right"></i>
-                    <span [innerText]="p.to"></span>
-                </li>
-            </ul>
+            <div class="form-group">
+                <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude)" class="timButton"
+                        [disabled]="copyFolderPath == item.path || copyPath.invalid"
+                        *ngIf="copyingFolder == 'notcopying'">Copy preview...
+                </button>
+            </div>
             <div class="panel panel-default" *ngIf="previewLength > 0">
                 <div class="panel-heading">Exclude folder or document items</div>
                     <div class="panel-body">
                         <p>These are the items that will be copied. To exclude an item, simply uncheck its corresponding checkbox.</p>
                     </div>
                 <table class="table-responsive">
-                    <table class="table">
+                    <table class="table table-hover">
                     <thead>
                         <tr>
                             <th>Select</th>
@@ -77,11 +72,11 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
                         </tr>
                     </thead>
                     <tbody>
-                        <tr *ngFor="let i of copyPreviewList">
-                            <td><input type="checkbox"></td>
-                            <td><span [innerText]="i.from"></span></td>
+                        <tr *ngFor="let listItem of copyPreviewList; let i = index" (click)="toggleCheckbox($event)">
+                            <td><input type="checkbox" name="{{'chb' + i}}"></td>
+                            <td><span [innerText]="listItem.from"></span></td>
                             <td><i class="glyphicon glyphicon-arrow-right"></i></td>
-                            <td><span [innerText]="i.to"></span></td>
+                            <td><span [innerText]="listItem.to"></span></td>
                         </tr>
                     </tbody>
                     </table>
@@ -189,5 +184,25 @@ export class CopyFolderComponent implements OnInit {
         this.copyPreviewList = undefined;
         this.destExists = undefined;
         this.copyErrors = undefined;
+    }
+
+    toggleCheckbox(event: MouseEvent) {
+        const eventTarget = event.target as HTMLElement;
+
+        if (eventTarget.tagName.toLowerCase() === "input") {
+            return;
+        }
+
+        const row = eventTarget.closest("tr");
+        if (!row) {
+            return;
+        }
+
+        const checkbox = row.querySelector(
+            "input[type='checkbox']"
+        ) as HTMLInputElement;
+        if (checkbox) {
+            checkbox.checked = !checkbox.checked;
+        }
     }
 }

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -65,7 +65,7 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
                     <table class="table table-hover">
                     <thead>
                         <tr>
-                            <th>Select</th>
+                            <th><input type="{{ alldeselect ? 'Select all' : 'Deselect all' }}" [checked]="alldeselect" (change)="toggleAll($event)"></th>
                             <th>From</th>
                             <th></th>
                             <th>To</th>
@@ -73,7 +73,7 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
                     </thead>
                     <tbody>
                         <tr *ngFor="let listItem of copyPreviewList; let i = index" (click)="toggleCheckbox($event)">
-                            <td><input type="checkbox" name="{{'chb' + i}}"></td>
+                            <td><input type="checkbox" name="{{'chb' + i}}" (change)="checkboxToggleChange(listItem)"></td>
                             <td><span [innerText]="listItem.from"></span></td>
                             <td><i class="glyphicon glyphicon-arrow-right"></i></td>
                             <td><span [innerText]="listItem.to"></span></td>
@@ -116,10 +116,12 @@ export class CopyFolderComponent implements OnInit {
     newFolder?: IFolder;
     copyOptions: CopyOptions = {...DEFAULT_COPY_OPTIONS};
     copyErrors?: string[];
+    alldeselect: boolean;
 
     constructor(private http: HttpClient) {
         this.copyingFolder = "notcopying";
         this.copyFolderExclude = "";
+        this.alldeselect = false;
     }
 
     get previewLength() {
@@ -188,21 +190,24 @@ export class CopyFolderComponent implements OnInit {
 
     toggleCheckbox(event: MouseEvent) {
         const eventTarget = event.target as HTMLElement;
-
         if (eventTarget.tagName.toLowerCase() === "input") {
             return;
         }
-
         const row = eventTarget.closest("tr");
         if (!row) {
             return;
         }
-
         const checkbox = row.querySelector(
             "input[type='checkbox']"
         ) as HTMLInputElement;
         if (checkbox) {
             checkbox.checked = !checkbox.checked;
         }
+    }
+
+    toggleAll(event: Event) {}
+
+    checkboxToggleChange(listItem: {from: string; to: string}) {
+        let escapedItemRegexp: string = "";
     }
 }

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -194,10 +194,17 @@ export class CopyFolderComponent implements OnInit {
     }
 
     toggleItem(item: {from: string; to: string}) {
-        if (this.excludedItems.has(item.from)) {
-            this.excludedItems.delete(item.from);
+        const path = item.from;
+        if (this.excludedItems.has(path)) {
+            this.excludedItems.delete(path);
         } else {
-            this.excludedItems.add(item.from);
+            this.excludedItems.add(path);
+            // Any items that are children of this item are also excluded
+            this.copyPreviewList?.forEach((prevItem) => {
+                if (prevItem.from.startsWith(path)) {
+                    this.excludedItems.add(prevItem.from);
+                }
+            });
         }
     }
 
@@ -221,8 +228,9 @@ export class CopyFolderComponent implements OnInit {
     }
 
     makeRegularExpressionFromSet(names: Set<string>, expression: string) {
+        const escapedCharacters = /[\-\[\]\/{}.()*+?\\^$|]/g;
         for (const item of names) {
-            const escapedItem = item.replace(/[./]/g, "\\$&");
+            const escapedItem = item.replace(escapedCharacters, "\\$&");
             expression = expression + "|\\b" + escapedItem + "\\b";
         }
         return expression.startsWith("|")

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -20,6 +20,8 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
     stop_on_errors: true,
 };
 
+const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
+
 @Component({
     selector: "tim-copy-folder",
     template: `
@@ -43,7 +45,8 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
                        [(ngModel)]="copyFolderPath" (ngModelChange)="copyParamChanged()" #copyPath="ngModel">
                 <tim-error-message></tim-error-message>
             </div>
-            <p>You can optionally exclude some documents/folders from being copied.</p>
+            <p>You can optionally enter a regular expression to exclude specific documents or folders from being copied.</p> 
+            <p *ngIf="copyHelp">For more information on copying see the <a [href]="copyHelp">help page</a>.</p>
             <div class="form-group" timErrorState>
                 <label for="exclude" class="control-label">Exclude documents/folders that match:</label>
                 <input name="exclude" class="form-control" id="exclude" type="text" autocomplete="off"
@@ -117,6 +120,7 @@ export class CopyFolderComponent implements OnInit {
     copyOptions: CopyOptions = {...DEFAULT_COPY_OPTIONS};
     copyErrors?: string[];
     excludedItems: Set<string>;
+    copyHelp: string = COPY_HELP_ADDRESS;
 
     constructor(private http: HttpClient) {
         this.copyingFolder = "notcopying";

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -62,7 +62,7 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
             <div class="panel panel-default" *ngIf="previewLength > 0">
                 <div class="panel-heading">Exclude folder or document items</div>
                     <div class="panel-body">
-                        <p>These are the items that will be copied. To exclude an item, simply check its corresponding checkbox.</p>
+                        <p>These are the items that will be copied. Select the items you want to exclude from being copied.</p>
                     </div>
                 <div class="scrollable-table">
                     <table class="table-responsive">
@@ -256,7 +256,6 @@ export class CopyFolderComponent implements OnInit {
             const escapedItem = item.replace(escapedCharacters, "\\$&");
             expression = expression + "|^" + escapedItem + "$";
         }
-        console.log(expression);
         return expression.startsWith("|")
             ? expression.substring(1)
             : expression;

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -26,29 +26,29 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
     selector: "tim-copy-folder",
     template: `
         <form>
-            <p>You can copy all documents and folders in this folder to another folder.</p>
-            <p>Copy options</p>
+            <p i18n>You can copy all documents and folders in this folder to another folder.</p>
+            <p i18n>Copy options</p>
             <div class="cb-group">
                 <div class="checkbox">
-                    <label><input type="checkbox" name="copy-active-rights" [(ngModel)]="copyOptions.copy_active_rights"> Copy active access rights</label>
+                    <label><input type="checkbox" name="copy-active-rights" [(ngModel)]="copyOptions.copy_active_rights"><ng-container i18n> Copy active access rights</ng-container></label>
                 </div>
                 <div class="checkbox">
-                    <label><input type="checkbox" name="copy-expired-rights" [(ngModel)]="copyOptions.copy_expired_rights"> Copy expired access rights</label>
+                    <label><input type="checkbox" name="copy-expired-rights" [(ngModel)]="copyOptions.copy_expired_rights"><ng-container i18n> Copy expired access rights</ng-container></label>
                 </div>
                 <div class="checkbox">
-                    <label><input type="checkbox" name="stop-errors" [(ngModel)]="copyOptions.stop_on_errors"> Stop copying on errors</label>
+                    <label><input type="checkbox" name="stop-errors" [(ngModel)]="copyOptions.stop_on_errors"><ng-container i18n> Stop copying on errors</ng-container></label>
                 </div>
             </div>
             <div class="form-group" timErrorState>
-                <label for="destination" class="control-label">Destination:</label>
+                <label for="destination" class="control-label" i18n>Destination:</label>
                 <input name="copyPath" class="form-control" timLocation id="destination" type="text" autocomplete="off"
                        [(ngModel)]="copyFolderPath" (ngModelChange)="copyParamChanged()" #copyPath="ngModel">
                 <tim-error-message></tim-error-message>
             </div>
-            <p>You can optionally enter a regular expression to exclude specific documents or folders from being copied.</p> 
-            <p *ngIf="copyHelp">For more information on copying see the <a [href]="copyHelp">help page</a>.</p>
+            <p i18n>You can optionally enter a regular expression to exclude specific documents or folders from being copied.</p> 
+            <p *ngIf="copyHelp"><ng-container i18n>For more information on copying see the </ng-container><a [href]="copyHelp"><ng-container i18n>help page</ng-container></a>.</p>
             <div class="form-group" timErrorState>
-                <label for="exclude" class="control-label">Exclude documents/folders that match:</label>
+                <label for="exclude" class="control-label" i18n>Exclude documents/folders that match:</label>
                 <input name="exclude" class="form-control" id="exclude" type="text" autocomplete="off"
                        [(ngModel)]="copyFolderExclude" (ngModelChange)="copyParamChanged()">
                 <tim-error-message></tim-error-message>
@@ -56,13 +56,13 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
             <div class="form-group">
                 <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude)" class="timButton"
                         [disabled]="copyFolderPath == item.path || copyPath.invalid"
-                        *ngIf="copyingFolder == 'notcopying'">Copy preview...
+                        *ngIf="copyingFolder == 'notcopying'" i18n>Copy preview...
                 </button>
             </div>
             <div class="panel panel-default" *ngIf="previewLength > 0">
-                <div class="panel-heading">Exclude folder or document items</div>
+                <div class="panel-heading" i18n>Exclude folder or document items</div>
                     <div class="panel-body">
-                        <p>These are the items that will be copied. Select the items you want to exclude from being copied.</p>
+                        <p i18n>These are the items that will be copied. Select the items you want to exclude from being copied.</p>
                     </div>
                 <div class="scrollable-table">
                     <table class="table-responsive">
@@ -70,9 +70,9 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
                         <thead>
                             <tr>
                                 <th><input type="checkbox" [checked]="allSelected()" (change)="toggleAll($event)"></th>
-                                <th>From</th>
+                                <th i18n="Column name for source folders|tableHeader">From</th>
                                 <th></th>
-                                <th>To</th>
+                                <th i18n="Column name for target folders|tableHeader">To</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -88,21 +88,21 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
                 </div>
             </div>
             <p *ngIf="previewLength == 0 || allSelected()">Nothing would be copied.</p>
-            <tim-alert severity="warning" *ngIf="destExists">
+            <tim-alert severity="warning" *ngIf="destExists" i18n>
                 The destination folder already exists. Make sure this is intended before copying.
             </tim-alert>
             <button (click)="copyFolder(copyFolderPath, copyFolderExclude)" class="timButton"
                     *ngIf="copyFolderPath != item.path &&
                      previewLength > 0 &&
-                     copyingFolder == 'notcopying'" [disabled]="allSelected()">Copy
+                     copyingFolder == 'notcopying'" [disabled]="allSelected()" i18n>Copy
             </button>
-            <span *ngIf="copyingFolder == 'copying'"><tim-loading></tim-loading> Copying, this might take a while...</span>
+            <span *ngIf="copyingFolder == 'copying'"><tim-loading></tim-loading><ng-container i18n> Copying, this might take a while...</ng-container></span>
             <span *ngIf="copyingFolder == 'finished'">
-                Folder {{ item.name }} copied to
+                <ng-container i18n>Folder </ng-container>{{ item.name }}<ng-container i18n> copied to</ng-container>
                 <a href="/manage/{{ newFolder?.path }}" [innerText]="newFolder?.path"></a>.
             </span>
             <div *ngIf="copyErrors">
-                <p>The following errors occurred while copying:</p>
+                <p i18n>The following errors occurred while copying:</p>
                 <ul>
                     <li *ngFor="let e of copyErrors">{{e}}</li>
                 </ul>

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -215,8 +215,8 @@ export class CopyFolderComponent implements OnInit {
         if (this.excludedItems.has(path)) {
             this.excludedItems.delete(path);
             const subFolders = this.getSubFolders(path);
-            subFolders.forEach((item) => {
-                this.excludedItems.delete(item);
+            subFolders.forEach((subFolderItem) => {
+                this.excludedItems.delete(subFolderItem);
             });
         } else {
             this.excludedItems.add(path);


### PR DESCRIPTION
This pull request changes how copy preview items are displayed in the copy-folder component. With this feature, the copy preview is presented in a table, from which items can be manually excluded by checking checkboxes. The items selected manually by the user are passed to the backend as a regular expression containing exact matches to the selected documents or folders.

Additionally, when user checks a parent folder, all the sub items are excluded as well. Currently unchecking an item that is under an excluded parent folder does end up being not copied. This is not necessarily clear from the UI.

There is a checkbox on the top row of the table, that allows user to check and uncheck all of the checkboxes.

Finally, this pull request changes the help text for the input field for the regular expression. A link to a TIM-help page on copying is added to the help text.

Solves the issue #3672 