### PR TITLE
Feature copy folder to documentlevel component

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -11071,14 +11071,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1040341291976790929" datatype="html">
-        <source> copied to</source>
-        <target state="translated"> Kopioitiin kansioon</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
-          <context context-type="linenumber">101</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8982532068172415683" datatype="html">
         <source>Exclude folder or document items</source>
         <target state="translated">Kansioiden tai asiakirjojen kohteiden rajaaminen ulkopuolelle</target>
@@ -11114,6 +11106,38 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         </context-group>
         <note priority="1" from="description">tableHeader</note>
         <note priority="1" from="meaning">Column name for target folders</note>
+      </trans-unit>
+      <trans-unit id="491697219808104137" datatype="html">
+        <source>You can copy all documents and folders from folder </source>
+        <target state="translated">Voit kopioida kaikki asiakirjat ja kansiot kansiosta </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">38,39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6021380561456852386" datatype="html">
+        <source>to another folder.</source>
+        <target state="translated">toiseen kansioon.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">40,41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1201994481266057161" datatype="html">
+        <source>Nothing would be copied.</source>
+        <target state="translated">Mitään ei kopioitaisi.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">108,109</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4460586915252709323" datatype="html">
+        <source> copied to </source>
+        <target state="translated"> Kopioitiin kansioon </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
       </trans-unit>
     </body>
   </file>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -10976,14 +10976,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">101</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1040341291976790929" datatype="html">
-        <source> copied to</source>
-        <target state="new"> copied to</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
-          <context context-type="linenumber">101</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="8982532068172415683" datatype="html">
         <source>Exclude folder or document items</source>
         <target state="new">Exclude folder or document items</target>
@@ -11019,6 +11011,38 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         </context-group>
         <note priority="1" from="description">tableHeader</note>
         <note priority="1" from="meaning">Column name for target folders</note>
+      </trans-unit>
+      <trans-unit id="491697219808104137" datatype="html">
+        <source>You can copy all documents and folders from folder </source>
+        <target state="new">You can copy all documents and folders from folder </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">38,39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6021380561456852386" datatype="html">
+        <source>to another folder.</source>
+        <target state="new">to another folder.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">40,41</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1201994481266057161" datatype="html">
+        <source>Nothing would be copied.</source>
+        <target state="new">Nothing would be copied.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">108,109</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4460586915252709323" datatype="html">
+        <source> copied to </source>
+        <target state="new"> copied to </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/folder/copy-folder.component.ts</context>
+          <context context-type="linenumber">128</context>
+        </context-group>
       </trans-unit>
     </body>
   </file>

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -2,7 +2,7 @@ import type {OnInit} from "@angular/core";
 import {Component, Input} from "@angular/core";
 import {showMessageDialog} from "tim/ui/showMessageDialog";
 import {HttpClient} from "@angular/common/http";
-import type {DocumentOrFolder, IDocument, IFolder} from "tim/item/IItem";
+import type {DocumentOrFolder, IFolder} from "tim/item/IItem";
 import {toPromise} from "tim/util/utils";
 import {itemglobals} from "tim/util/globals";
 
@@ -35,8 +35,8 @@ interface IBasicInfo {
     template: `
         <form>
             <div *ngIf="copyFrom && sourceInfo; else sourceNotGiven">
-                <p>You can copy all documents and folders from </p>
-                <pre>{{ copyFrom }}</pre>
+                <p>You can copy all documents and folders from folder </p>
+                <pre>{{ sourcePath }}</pre>
                 <p>to another folder.</p>
             </div>
             <ng-template #sourceNotGiven>
@@ -73,7 +73,7 @@ interface IBasicInfo {
             </div>
             <div class="form-group">
                 <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude, sourceInfo ? sourceInfo.id : undefined)" class="timButton"
-                        [disabled]="copyFolderPath == currentItem.path || copyPath.invalid"
+                        [disabled]="copyFolderPath == (sourcePath ? sourcePath : currentItem.path) || copyPath.invalid"
                         *ngIf="copyingFolder == 'notcopying'" i18n>Copy preview...
                 </button>
             </div>
@@ -110,17 +110,17 @@ interface IBasicInfo {
                 The destination folder already exists. Make sure this is intended before copying.
             </tim-alert>
             <div *ngIf="!sourceInfo">
-            <button (click)="copyFolder(copyFolderPath, copyFolderExclude)" class="timButton"
-                    *ngIf="copyFolderPath != currentItem.path &&
-                     previewLength > 0 &&
-                     copyingFolder == 'notcopying' && !sourceInfo">Copy
-            </button>
+                <button (click)="copyFolder(copyFolderPath, copyFolderExclude)" class="timButton"
+                        *ngIf="copyFolderPath != currentItem.path &&
+                         previewLength > 0 &&
+                         copyingFolder == 'notcopying' ">Copy
+                </button>
             </div>
             <div *ngIf="sourceInfo">
                 <button (click)="copyFolder(copyFolderPath, copyFolderExclude, sourceInfo.id)" class="timButton"
-                    *ngIf="copyFolderPath != currentItem.path &&
-                     previewLength > 0 &&
-                     copyingFolder == 'notcopying' && sourceInfo" [disabled]="allSelected()" i18n>Copy
+                        *ngIf="copyFolderPath != sourcePath &&
+                         previewLength > 0 &&
+                         copyingFolder == 'notcopying' " [disabled]="allSelected()" i18n>Copy
                 </button>
             </div>
             <span *ngIf="copyingFolder == 'copying'"><tim-loading></tim-loading><ng-container i18n> Copying, this might take a while...</ng-container></span>
@@ -141,7 +141,7 @@ interface IBasicInfo {
 export class CopyFolderComponent implements OnInit {
     copyingFolder: "notcopying" | "copying" | "finished";
     @Input() copyFrom?: string;
-    @Input() copyTo!: string;
+    @Input() copyTo?: string;
     currentItem: DocumentOrFolder;
     copyPreviewList?: PreviewList;
     destExists?: boolean;
@@ -151,6 +151,7 @@ export class CopyFolderComponent implements OnInit {
     copyOptions: CopyOptions = {...DEFAULT_COPY_OPTIONS};
     copyErrors?: string[];
     sourceInfo?: IBasicInfo;
+    sourcePath?: string;
     excludedItems: Set<string>;
     copyHelp: string = COPY_HELP_ADDRESS;
 
@@ -184,6 +185,8 @@ export class CopyFolderComponent implements OnInit {
             return;
         } else {
             this.sourceInfo = r.result;
+            this.sourcePath =
+                this.sourceInfo?.location + "/" + this.sourceInfo?.short_name;
         }
     }
 

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -180,16 +180,12 @@ export class CopyFolderComponent implements OnInit {
         }
     }
 
-    async copyFolderPreview(
-        path: string,
-        exclude: string,
-        itemId: number = this.currentItem.id
-    ) {
+    async copyFolderPreview(path: string, exclude: string) {
         this.copyingFolder = "notcopying";
 
         const r = await toPromise(
             this.http.post<{preview: PreviewList; dest_exists: boolean}>(
-                `/copy/${itemId}/preview`,
+                `/copy/${this.currentItem.id}/preview`,
                 {
                     destination: path,
                     exclude: exclude,
@@ -204,11 +200,7 @@ export class CopyFolderComponent implements OnInit {
         }
     }
 
-    async copyFolder(
-        path: string,
-        exclude: string,
-        itemId: number = this.currentItem.id
-    ) {
+    async copyFolder(path: string, exclude: string) {
         this.copyingFolder = "copying";
         const excludingRe = this.makeRegularExpressionFromSet(
             this.excludedItems,
@@ -216,7 +208,7 @@ export class CopyFolderComponent implements OnInit {
         );
         const r = await toPromise(
             this.http.post<{new_folder?: IFolder; errors: string[]}>(
-                `/copy/${itemId}`,
+                `/copy/${this.currentItem.id}`,
                 {
                     destination: path,
                     exclude: excludingRe,

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -2,9 +2,9 @@ import type {OnInit} from "@angular/core";
 import {Component, Input} from "@angular/core";
 import {showMessageDialog} from "tim/ui/showMessageDialog";
 import {HttpClient} from "@angular/common/http";
-import type {IFolder} from "tim/item/IItem";
-import {IItem} from "tim/item/IItem";
+import type {DocumentOrFolder, IDocument, IFolder} from "tim/item/IItem";
 import {toPromise} from "tim/util/utils";
+import {itemglobals} from "tim/util/globals";
 
 type PreviewList = {from: string; to: string}[];
 
@@ -22,21 +22,39 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
 
 const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
 
+interface IBasicInfo {
+    id: number;
+    type: string;
+    title: string;
+    location: string;
+    short_name: string;
+}
+
 @Component({
     selector: "tim-copy-folder",
     template: `
         <form>
-            <p i18n>You can copy all documents and folders in this folder to another folder.</p>
+            <div *ngIf="copyFrom && sourceInfo; else sourceNotGiven">
+                <p>You can copy all documents and folders from </p>
+                <pre>{{ copyFrom }}</pre>
+                <p>to another folder.</p>
+            </div>
+            <ng-template #sourceNotGiven>
+                <p i18n>You can copy all documents and folders in this folder to another folder.</p>
+            </ng-template>
             <p i18n>Copy options</p>
             <div class="cb-group">
                 <div class="checkbox">
-                    <label><input type="checkbox" name="copy-active-rights" [(ngModel)]="copyOptions.copy_active_rights"><ng-container i18n> Copy active access rights</ng-container></label>
+                    <label><input type="checkbox" name="copy-active-rights"
+                                  [(ngModel)]="copyOptions.copy_active_rights"><ng-container i18n> Copy active access rights</ng-container></label>
                 </div>
                 <div class="checkbox">
-                    <label><input type="checkbox" name="copy-expired-rights" [(ngModel)]="copyOptions.copy_expired_rights"><ng-container i18n> Copy expired access rights</ng-container></label>
+                    <label><input type="checkbox" name="copy-expired-rights"
+                                  [(ngModel)]="copyOptions.copy_expired_rights"><ng-container i18n> Copy expired access rights</ng-container></label>
                 </div>
                 <div class="checkbox">
-                    <label><input type="checkbox" name="stop-errors" [(ngModel)]="copyOptions.stop_on_errors"><ng-container i18n> Stop copying on errors</ng-container></label>
+                    <label><input type="checkbox" name="stop-errors" [(ngModel)]="copyOptions.stop_on_errors"><ng-container i18n> Stop
+                        copying on errors</ng-container></label>
                 </div>
             </div>
             <div class="form-group" timErrorState>
@@ -54,8 +72,8 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
                 <tim-error-message></tim-error-message>
             </div>
             <div class="form-group">
-                <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude)" class="timButton"
-                        [disabled]="copyFolderPath == item.path || copyPath.invalid"
+                <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude, sourceInfo ? sourceInfo.id : undefined)" class="timButton"
+                        [disabled]="copyFolderPath == currentItem.path || copyPath.invalid"
                         *ngIf="copyingFolder == 'notcopying'" i18n>Copy preview...
                 </button>
             </div>
@@ -91,20 +109,29 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
             <tim-alert severity="warning" *ngIf="destExists" i18n>
                 The destination folder already exists. Make sure this is intended before copying.
             </tim-alert>
+            <div *ngIf="!sourceInfo">
             <button (click)="copyFolder(copyFolderPath, copyFolderExclude)" class="timButton"
-                    *ngIf="copyFolderPath != item.path &&
+                    *ngIf="copyFolderPath != currentItem.path &&
                      previewLength > 0 &&
-                     copyingFolder == 'notcopying'" [disabled]="allSelected()" i18n>Copy
+                     copyingFolder == 'notcopying' && !sourceInfo">Copy
             </button>
+            </div>
+            <div *ngIf="sourceInfo">
+                <button (click)="copyFolder(copyFolderPath, copyFolderExclude, sourceInfo.id)" class="timButton"
+                    *ngIf="copyFolderPath != currentItem.path &&
+                     previewLength > 0 &&
+                     copyingFolder == 'notcopying' && sourceInfo" [disabled]="allSelected()" i18n>Copy
+                </button>
+            </div>
             <span *ngIf="copyingFolder == 'copying'"><tim-loading></tim-loading><ng-container i18n> Copying, this might take a while...</ng-container></span>
             <span *ngIf="copyingFolder == 'finished'">
-                <ng-container i18n>Folder </ng-container>{{ item.name }}<ng-container i18n> copied to</ng-container>
+                <ng-container i18n>Folder </ng-container>{{ currentItem.name }}<ng-container i18n> copied to</ng-container>
                 <a href="/manage/{{ newFolder?.path }}" [innerText]="newFolder?.path"></a>.
             </span>
             <div *ngIf="copyErrors">
                 <p i18n>The following errors occurred while copying:</p>
                 <ul>
-                    <li *ngFor="let e of copyErrors">{{e}}</li>
+                    <li *ngFor="let e of copyErrors">{{ e }}</li>
                 </ul>
             </div>
         </form>
@@ -113,7 +140,9 @@ const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
 })
 export class CopyFolderComponent implements OnInit {
     copyingFolder: "notcopying" | "copying" | "finished";
-    @Input() item!: IItem;
+    @Input() copyFrom?: string;
+    @Input() copyTo!: string;
+    currentItem: DocumentOrFolder;
     copyPreviewList?: PreviewList;
     destExists?: boolean;
     copyFolderPath!: string;
@@ -121,12 +150,14 @@ export class CopyFolderComponent implements OnInit {
     newFolder?: IFolder;
     copyOptions: CopyOptions = {...DEFAULT_COPY_OPTIONS};
     copyErrors?: string[];
+    sourceInfo?: IBasicInfo;
     excludedItems: Set<string>;
     copyHelp: string = COPY_HELP_ADDRESS;
 
     constructor(private http: HttpClient) {
         this.copyingFolder = "notcopying";
         this.copyFolderExclude = "";
+        this.currentItem = itemglobals().curr_item;
         this.excludedItems = new Set<string>();
     }
 
@@ -135,14 +166,37 @@ export class CopyFolderComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.copyFolderPath = this.item.path;
+        if (this.copyTo) {
+            this.copyFolderPath = this.copyTo;
+        } else {
+            this.copyFolderPath = this.currentItem.path;
+        }
+        if (this.copyFrom) {
+            this.fetchItemBasicInfo(this.copyFrom);
+        }
     }
 
-    async copyFolderPreview(path: string, exclude: string) {
+    private async fetchItemBasicInfo(itemPath: string) {
+        const r = await toPromise(
+            this.http.get<IBasicInfo>(`/itemInfo/${itemPath}`)
+        );
+        if (!r.ok) {
+            return;
+        } else {
+            this.sourceInfo = r.result;
+        }
+    }
+
+    async copyFolderPreview(
+        path: string,
+        exclude: string,
+        itemId: number = this.currentItem.id
+    ) {
         this.copyingFolder = "notcopying";
+
         const r = await toPromise(
             this.http.post<{preview: PreviewList; dest_exists: boolean}>(
-                `/copy/${this.item.id}/preview`,
+                `/copy/${itemId}/preview`,
                 {
                     destination: path,
                     exclude: exclude,
@@ -157,7 +211,11 @@ export class CopyFolderComponent implements OnInit {
         }
     }
 
-    async copyFolder(path: string, exclude: string) {
+    async copyFolder(
+        path: string,
+        exclude: string,
+        itemId: number = this.currentItem.id
+    ) {
         this.copyingFolder = "copying";
         const excludingRe = this.makeRegularExpressionFromSet(
             this.excludedItems,
@@ -165,7 +223,7 @@ export class CopyFolderComponent implements OnInit {
         );
         const r = await toPromise(
             this.http.post<{new_folder?: IFolder; errors: string[]}>(
-                `/copy/${this.item.id}`,
+                `/copy/${itemId}`,
                 {
                     destination: path,
                     exclude: excludingRe,

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -35,9 +35,9 @@ interface IBasicInfo {
     template: `
         <form>
             <div *ngIf="copyFrom && sourceInfo; else sourceNotGiven">
-                <p>You can copy all documents and folders from folder </p>
+                <p i18n>You can copy all documents and folders from folder </p>
                 <pre>{{ sourcePath }}</pre>
-                <p>to another folder.</p>
+                <p i18n>to another folder.</p>
             </div>
             <ng-template #sourceNotGiven>
                 <p i18n>You can copy all documents and folders in this folder to another folder.</p>
@@ -105,7 +105,7 @@ interface IBasicInfo {
                     </table>
                 </div>
             </div>
-            <p *ngIf="previewLength == 0 || allSelected()">Nothing would be copied.</p>
+            <p *ngIf="previewLength == 0 || allSelected()" i18n>Nothing would be copied.</p>
             <tim-alert severity="warning" *ngIf="destExists" i18n>
                 The destination folder already exists. Make sure this is intended before copying.
             </tim-alert>

--- a/timApp/static/scripts/tim/folder/copy-folder.component.ts
+++ b/timApp/static/scripts/tim/folder/copy-folder.component.ts
@@ -2,7 +2,7 @@ import type {OnInit} from "@angular/core";
 import {Component, Input} from "@angular/core";
 import {showMessageDialog} from "tim/ui/showMessageDialog";
 import {HttpClient} from "@angular/common/http";
-import type {DocumentOrFolder, IFolder} from "tim/item/IItem";
+import type {IFolder} from "tim/item/IItem";
 import {toPromise} from "tim/util/utils";
 import {itemglobals} from "tim/util/globals";
 
@@ -22,19 +22,11 @@ const DEFAULT_COPY_OPTIONS: CopyOptions = {
 
 const COPY_HELP_ADDRESS: string = "/view/tim/TIM-ohjeet#hakemistonkopionti";
 
-interface IBasicInfo {
-    id: number;
-    type: string;
-    title: string;
-    location: string;
-    short_name: string;
-}
-
 @Component({
     selector: "tim-copy-folder",
     template: `
         <form>
-            <div *ngIf="copyFrom && sourceInfo; else sourceNotGiven">
+            <div *ngIf="copyFrom && sourcePath; else sourceNotGiven">
                 <p i18n>You can copy all documents and folders from folder </p>
                 <pre>{{ sourcePath }}</pre>
                 <p i18n>to another folder.</p>
@@ -72,8 +64,8 @@ interface IBasicInfo {
                 <tim-error-message></tim-error-message>
             </div>
             <div class="form-group">
-                <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude, sourceInfo ? sourceInfo.id : undefined)" class="timButton"
-                        [disabled]="copyFolderPath == (sourcePath ? sourcePath : currentItem.path) || copyPath.invalid"
+                <button (click)="copyFolderPreview(copyFolderPath, copyFolderExclude)" class="timButton"
+                        [disabled]="copyFolderPath == currentItem.path || copyPath.invalid"
                         *ngIf="copyingFolder == 'notcopying'" i18n>Copy preview...
                 </button>
             </div>
@@ -109,23 +101,16 @@ interface IBasicInfo {
             <tim-alert severity="warning" *ngIf="destExists" i18n>
                 The destination folder already exists. Make sure this is intended before copying.
             </tim-alert>
-            <div *ngIf="!sourceInfo">
+            <div>
                 <button (click)="copyFolder(copyFolderPath, copyFolderExclude)" class="timButton"
                         *ngIf="copyFolderPath != currentItem.path &&
-                         previewLength > 0 &&
-                         copyingFolder == 'notcopying' ">Copy
-                </button>
-            </div>
-            <div *ngIf="sourceInfo">
-                <button (click)="copyFolder(copyFolderPath, copyFolderExclude, sourceInfo.id)" class="timButton"
-                        *ngIf="copyFolderPath != sourcePath &&
                          previewLength > 0 &&
                          copyingFolder == 'notcopying' " [disabled]="allSelected()" i18n>Copy
                 </button>
             </div>
             <span *ngIf="copyingFolder == 'copying'"><tim-loading></tim-loading><ng-container i18n> Copying, this might take a while...</ng-container></span>
             <span *ngIf="copyingFolder == 'finished'">
-                <ng-container i18n>Folder </ng-container>{{ currentItem.name }}<ng-container i18n> copied to</ng-container>
+                <ng-container i18n>Folder </ng-container>{{ currentItem.name }}<ng-container i18n> copied to </ng-container>
                 <a href="/manage/{{ newFolder?.path }}" [innerText]="newFolder?.path"></a>.
             </span>
             <div *ngIf="copyErrors">
@@ -142,7 +127,7 @@ export class CopyFolderComponent implements OnInit {
     copyingFolder: "notcopying" | "copying" | "finished";
     @Input() copyFrom?: string;
     @Input() copyTo?: string;
-    currentItem: DocumentOrFolder;
+    currentItem: {name: string; path: string; id: number};
     copyPreviewList?: PreviewList;
     destExists?: boolean;
     copyFolderPath!: string;
@@ -150,7 +135,6 @@ export class CopyFolderComponent implements OnInit {
     newFolder?: IFolder;
     copyOptions: CopyOptions = {...DEFAULT_COPY_OPTIONS};
     copyErrors?: string[];
-    sourceInfo?: IBasicInfo;
     sourcePath?: string;
     excludedItems: Set<string>;
     copyHelp: string = COPY_HELP_ADDRESS;
@@ -179,14 +163,20 @@ export class CopyFolderComponent implements OnInit {
 
     private async fetchItemBasicInfo(itemPath: string) {
         const r = await toPromise(
-            this.http.get<IBasicInfo>(`/itemInfo/${itemPath}`)
+            this.http.get<{id: number; location: string; short_name: string}>(
+                `/itemInfo/${itemPath}`
+            )
         );
         if (!r.ok) {
             return;
         } else {
-            this.sourceInfo = r.result;
+            this.currentItem = {
+                id: r.result.id,
+                name: r.result.short_name,
+                path: r.result.location,
+            };
             this.sourcePath =
-                this.sourceInfo?.location + "/" + this.sourceInfo?.short_name;
+                this.currentItem?.path + "/" + this.currentItem?.name;
         }
     }
 

--- a/timApp/static/templates/manage.html
+++ b/timApp/static/templates/manage.html
@@ -450,7 +450,7 @@
         </div>
     </div>
     <bootstrap-panel title="Copy contents" ng-if="$ctrl.item.rights.copy" show-heading-anchors="true" anchor-id="copy">
-        <tim-copy-folder [item]="$ctrl.item"></tim-copy-folder>
+        <tim-copy-folder></tim-copy-folder>
     </bootstrap-panel>
     <div ng-if="$ctrl.item.rights.manage" class="panel panel-default">
         <div class="panel-heading" id="misc">Other actions

--- a/tim_common/html_sanitize.py
+++ b/tim_common/html_sanitize.py
@@ -128,7 +128,6 @@ TIM_SAFE_ATTRS_MAP = {
     "acronym": ["title"],
     "img": ["src", "width", "height"],
     "a": ["href", "title", "target"],
-    "tim-copy-folder": ["copy-from", "copy-to"],
 }
 
 TIM_SAFE_ATTRS = frozenset(

--- a/tim_common/html_sanitize.py
+++ b/tim_common/html_sanitize.py
@@ -118,6 +118,7 @@ TIM_SAFE_TAGS = [
     "tim-steps",
     "tim-participant-list",
     "tim-course-manager",
+    "tim-copy-folder",
 ]
 
 TIM_SAFE_ATTRS_MAP = {
@@ -127,6 +128,7 @@ TIM_SAFE_ATTRS_MAP = {
     "acronym": ["title"],
     "img": ["src", "width", "height"],
     "a": ["href", "title", "target"],
+    "tim-copy-folder": ["copy-from", "copy-to"],
 }
 
 TIM_SAFE_ATTRS = frozenset(
@@ -154,6 +156,8 @@ TIM_SAFE_ATTRS = frozenset(
         "color",
         "compact",
         "coords",
+        "copy-from",
+        "copy-to",
         "datetime",
         "dir",
         "disabled",


### PR DESCRIPTION
This pull request adds support for using copy-folder component as a document level element. It can be used as before or using a new feature, where the component can be initialized with copyFrom and copyTo attributes.

Pull request #3867 Makes some translations in this obsolete. 

This pull request aims to solve issue #2497.

TODO:
- [x] Check are html-sanitize properties properly set