### PR TITLE
Feature warning descriptor in tasks

### DIFF
--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -8897,8 +8897,8 @@
         </context-group>
       </trans-unit>
       <trans-unit id="187187500641108332" datatype="html">
-        <source><x id="INTERPOLATION" equiv-text="Folder() ?? 'Enter the location or leave empty'}}"/></source>
-        <target state="new"><x id="INTERPOLATION" equiv-text="Folder() ?? 'Enter the location or leave empty'}}"/></target>
+        <source><x id="INTERPOLATION" equiv-text="Folder() ?? &apos;Enter the location or leave empty&apos;}}"/></source>
+        <target state="new"><x id="INTERPOLATION" equiv-text="Folder() ?? &apos;Enter the location or leave empty&apos;}}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/user/user-group-dialog.component.ts</context>
           <context context-type="linenumber">61,62</context>
@@ -11155,14 +11155,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">24,25</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7965632846269223613" datatype="html">
-        <source>Could not save the agreement: Anonymous users cannot perform this action.</source>
-        <target state="translated">Hyväksyntää ei voitu tallentaa: Anonyymit käyttäjät eivät voi suorittaa tätä toimintoa.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/tos-dialog.component.ts</context>
-          <context context-type="linenumber">75</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6510841402924705360" datatype="html">
         <source>Could not save the agreement. Try to refresh the page, if the problem persists you can contact TIM support at tim@jyu.fi</source>
         <target state="translated">Hyväksyntää ei voitu tallentaa. Yritä päivittää sivu, jos ongelma jatkuu, voit ottaa yhteyttä TIM tukeen osoitteessa tim@jyu.fi</target>
@@ -11201,30 +11193,6 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/tos-dialog.component.ts</context>
           <context context-type="linenumber">26,27</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3715478772695986047" datatype="html">
-        <source>The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won't be eligible for points or grading.</source>
-        <target state="translated">Tehtävän määräaika on umpeutunut. Voit silti lähettää ratkaisun, mutta se merkitään epävalidiksi eikä siitä anneta pisteitä tai arvosanaa.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
-          <context context-type="linenumber">1593</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
-          <context context-type="linenumber">195</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7941960797047616838" datatype="html">
-        <source>You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.</source>
-        <target state="translated">Olet jo avannut malliratkaisun, joten kaikki uudet lähetetyt vastaukset tallennetaan, mutta niistä ei anneta pisteitä eikä niitä arvioida.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
-          <context context-type="linenumber">1594</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
-          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.fi.xlf
+++ b/timApp/i18n/messages.fi.xlf
@@ -11203,6 +11203,30 @@ Syötä useiden käyttäjien osoitteet allekkain tai pilkulla erotettuina.</targ
           <context context-type="linenumber">26,27</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3715478772695986047" datatype="html">
+        <source>The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won't be eligible for points or grading.</source>
+        <target state="translated">Tehtävän määräaika on umpeutunut. Voit silti lähettää ratkaisun, mutta se merkitään epävalidiksi eikä siitä anneta pisteitä tai arvosanaa.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
+          <context context-type="linenumber">1593</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
+          <context context-type="linenumber">195</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7941960797047616838" datatype="html">
+        <source>You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.</source>
+        <target state="translated">Olet jo avannut malliratkaisun, joten kaikki uudet lähetetyt vastaukset tallennetaan, mutta niistä ei anneta pisteitä eikä niitä arvioida.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
+          <context context-type="linenumber">1594</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
+          <context context-type="linenumber">196</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -11060,14 +11060,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">24,25</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="7965632846269223613" datatype="html">
-        <source>Could not save the agreement: Anonymous users cannot perform this action.</source>
-        <target state="new">Could not save the agreement: Anonymous users cannot perform this action.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/ui/tos-dialog.component.ts</context>
-          <context context-type="linenumber">75</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6510841402924705360" datatype="html">
         <source>Could not save the agreement. Try to refresh the page, if the problem persists you can contact TIM support at tim@jyu.fi</source>
         <target state="new">Could not save the agreement. Try to refresh the page, if the problem persists you can contact TIM support at tim@jyu.fi</target>
@@ -11106,30 +11098,6 @@ Separate multiple addresses with commas or write each address on a new line.</ta
         <context-group purpose="location">
           <context context-type="sourcefile">static/scripts/tim/ui/tos-dialog.component.ts</context>
           <context context-type="linenumber">26,27</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3715478772695986047" datatype="html">
-        <source>The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won&apos;t be eligible for points or grading.</source>
-        <target state="new">The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won&apos;t be eligible for points or grading.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
-          <context context-type="linenumber">1593</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
-          <context context-type="linenumber">195</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7941960797047616838" datatype="html">
-        <source>You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.</source>
-        <target state="new">You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
-          <context context-type="linenumber">1594</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
-          <context context-type="linenumber">196</context>
         </context-group>
       </trans-unit>
     </body>

--- a/timApp/i18n/messages.sv.xlf
+++ b/timApp/i18n/messages.sv.xlf
@@ -11108,6 +11108,30 @@ Separate multiple addresses with commas or write each address on a new line.</ta
           <context context-type="linenumber">26,27</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="3715478772695986047" datatype="html">
+        <source>The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won&apos;t be eligible for points or grading.</source>
+        <target state="new">The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won&apos;t be eligible for points or grading.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
+          <context context-type="linenumber">1593</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
+          <context context-type="linenumber">195</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7941960797047616838" datatype="html">
+        <source>You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.</source>
+        <target state="new">You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">modules/cs/js/csPlugin.ts</context>
+          <context context-type="linenumber">1594</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">static/scripts/tim/plugin/qst/qst.component.ts</context>
+          <context context-type="linenumber">196</context>
+        </context-group>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/timApp/modules/cs/js/csModule.ts
+++ b/timApp/modules/cs/js/csModule.ts
@@ -8,6 +8,7 @@ import {GraphVizComponent} from "tim/plugin/graph-viz/graph-viz.component";
 import {VariablesComponent} from "tim/plugin/variables/variables.component";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
+import {TooltipModule} from "ngx-bootstrap/tooltip";
 import {CsRunnerComponent} from "./csPlugin";
 import {CsTextComponent} from "./text";
 import {CsConsoleComponent} from "./console";
@@ -20,7 +21,6 @@ import {GitRegComponent} from "./gitreg";
 import {CsErrorComponent} from "./language_error";
 import {CsUtilityModule} from "./util/module";
 import {EditorModule} from "./editor/module";
-import {TooltipModule} from "ngx-bootstrap/tooltip";
 
 @NgModule({
     declarations: [

--- a/timApp/modules/cs/js/csModule.ts
+++ b/timApp/modules/cs/js/csModule.ts
@@ -20,6 +20,7 @@ import {GitRegComponent} from "./gitreg";
 import {CsErrorComponent} from "./language_error";
 import {CsUtilityModule} from "./util/module";
 import {EditorModule} from "./editor/module";
+import {TooltipModule} from "ngx-bootstrap/tooltip";
 
 @NgModule({
     declarations: [
@@ -50,6 +51,7 @@ import {EditorModule} from "./editor/module";
         TimUtilityModule,
         CsUtilityModule,
         PurifyModule,
+        TooltipModule,
     ],
 })
 export class CsPluginModule implements DoBootstrap {

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -2100,6 +2100,12 @@ ${fhtml}
         return this.markup.runningText;
     }
 
+    getDeadline(): string | undefined {
+        const name = this.getName();
+
+        return "";
+    }
+
     buttonText() {
         const txt = super.buttonText();
         if (txt) {

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -2439,21 +2439,7 @@ ${fhtml}
         this.showCodeNow();
         this.updateRunChanged();
 
-        this.getInvalidMarkerState().then((markerState) => {
-            if (!markerState) {
-                return;
-            }
-            this.invalidMarkerTooltip = [];
-            const {deadline, modelAnswerLock} = markerState;
-
-            if (deadline) {
-                this.invalidMarkerTooltip.push(deadline);
-            }
-            if (modelAnswerLock) {
-                this.invalidMarkerTooltip.push(modelAnswerLock);
-            }
-            this.invalidMarker = this.invalidMarkerTooltip.length > 0;
-        });
+        this.getInvalidMarkerTooltip();
     }
 
     ngOnDestroy() {
@@ -4161,6 +4147,12 @@ ${fhtml}
         if (save) {
             await this.runCode();
         }
+    }
+
+    private async getInvalidMarkerTooltip() {
+        const result = await this.getInvalidMarkerState();
+        this.invalidMarkerTooltip = result?.toolTipTexts ?? [];
+        this.invalidMarker = result?.invalidMarkerSet ?? false;
     }
 
     updateRunChanged(): boolean {

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -1277,7 +1277,8 @@ export class CsController extends CsBase implements ITimComponent {
     private clearSaved: boolean = false;
     private originalUserInput?: string;
     exportingMD = false;
-    invalidMarker?: InvalidMarkerState;
+    invalidMarkerTooltip?: string[];
+    invalidMarker = false;
 
     @ViewChild("externalEditor")
     set externalEditorViewSetter(newValue: EditorComponent | undefined) {
@@ -2439,10 +2440,20 @@ ${fhtml}
         this.showCodeNow();
         this.updateRunChanged();
 
-        this.getInvalidMarkerState().then((r) => {
-            if (r) {
-                this.invalidMarker = r;
+        this.getInvalidMarkerState().then((markerState) => {
+            if (!markerState) {
+                return;
             }
+            this.invalidMarkerTooltip = [];
+            const {deadline, modelAnswerLock} = markerState;
+
+            if (deadline) {
+                this.invalidMarkerTooltip.push(deadline);
+            }
+            if (modelAnswerLock) {
+                this.invalidMarkerTooltip.push(modelAnswerLock);
+            }
+            this.invalidMarker = this.invalidMarkerTooltip.length > 0;
         });
     }
 
@@ -4431,11 +4442,20 @@ ${fhtml}
                             (click)="runCode()"
                             [innerHTML]="buttonText()"></button>
                     &nbsp;
-                    <span *ngIf="invalidMarker?.deadline" [tooltip]="invalidMarker?.deadline" placement="bottom"
+<!--                    <span *ngIf="invalidMarker?.deadline" [tooltip]="invalidMarker?.deadline" placement="bottom"-->
+<!--                          class="glyphicon glyphicon-lock text-danger"></span>-->
+<!--                    <span *ngIf="invalidMarker?.modelAnswerLock" [tooltip]="invalidMarker?.modelAnswerLock" placement="bottom"-->
+<!--                          class="glyphicon glyphicon-lock text-danger"></span>-->
+<!--                    <ng-container *ngIf="invalidMarker">&nbsp;</ng-container>-->
+                    <span *ngIf="invalidMarker" [tooltip]="poptemplate" placement="bottom"
                           class="glyphicon glyphicon-lock text-danger"></span>
-                    <span *ngIf="invalidMarker?.modelAnswerLock" [tooltip]="invalidMarker?.modelAnswerLock" placement="bottom"
-                          class="glyphicon glyphicon-lock text-danger"></span>
+                    <ng-template #poptemplate>
+                        <div *ngFor="let ttip of invalidMarkerTooltip">
+                            <span [innerText]="ttip"></span>
+                        </div>
+                    </ng-template>
                     <ng-container *ngIf="invalidMarker">&nbsp;</ng-container>
+                    
                     <button *ngIf="mdSaveButton" [disabled]="!mdHtml" class="timButton btn-sm"
                             (click)="exportMDAsImg()">{{ mdSaveButton }}
                     </button>

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -4432,10 +4432,10 @@ ${fhtml}
                             [innerHTML]="buttonText()"></button>
                     &nbsp;
                     <span *ngIf="invalidMarker?.deadline" [tooltip]="invalidMarker?.deadline" placement="bottom"
-                          class="glyphicon glyphicon-hourglass text-danger"></span>
+                          class="glyphicon glyphicon-lock text-danger"></span>
                     <span *ngIf="invalidMarker?.modelAnswerLock" [tooltip]="invalidMarker?.modelAnswerLock" placement="bottom"
                           class="glyphicon glyphicon-lock text-danger"></span>
-                    &nbsp;
+                    <ng-container *ngIf="invalidMarker">&nbsp;</ng-container>
                     <button *ngIf="mdSaveButton" [disabled]="!mdHtml" class="timButton btn-sm"
                             (click)="exportMDAsImg()">{{ mdSaveButton }}
                     </button>

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -84,6 +84,7 @@ import type {FormulaEvent} from "./editor/math-editor/symbol-button-menu.compone
 import {selectFormulaFromPreview} from "./editor/math-editor/formula-utils";
 import {LATEX_BUTTONS} from "./editor/math-editor/default-symbol-buttons";
 import {FormulaEditorComponent} from "./editor/math-editor/formula-editor.component";
+import {InvalidMarkerData} from "tim/answer/answer-browser.component";
 
 // TODO better name?
 interface Vid {
@@ -1276,6 +1277,9 @@ export class CsController extends CsBase implements ITimComponent {
     private clearSaved: boolean = false;
     private originalUserInput?: string;
     exportingMD = false;
+    pluginActivated: boolean = false;
+    taskDeadline?: string;
+    modelAnswerLock?: boolean;
 
     @ViewChild("externalEditor")
     set externalEditorViewSetter(newValue: EditorComponent | undefined) {
@@ -1625,6 +1629,12 @@ export class CsController extends CsBase implements ITimComponent {
         // }
         return getFormBehavior(this.markup.form, FormModeOption.NoForm);
         // return getFormBehavior(this.markup.form, FormModeOption.Undecided);
+    }
+
+    setInvalidMarkerData(data: InvalidMarkerData) {
+        this.pluginActivated = true;
+        this.taskDeadline = data.deadline;
+        this.modelAnswerLock = data.modelAnswerLock;
     }
 
     setAnswer(content: Record<string, unknown>): ISetAnswerResult {
@@ -2098,12 +2108,6 @@ ${fhtml}
 
     get runningText() {
         return this.markup.runningText;
-    }
-
-    getDeadline(): string | undefined {
-        const name = this.getName();
-
-        return "";
     }
 
     buttonText() {
@@ -4427,6 +4431,10 @@ ${fhtml}
                             title="(Ctrl-S)"
                             (click)="runCode()"
                             [innerHTML]="buttonText()"></button>
+                    &nbsp;
+                    <span *ngIf="taskDeadline" class="glyphicon glyphicon-hourglass text-danger"></span>
+                    <span *ngIf="modelAnswerLock" class="glyphicon glyphicon-lock text-danger"></span>
+                    <span>Aktivoitu {{pluginActivated}}</span>
                     &nbsp;
                     <button *ngIf="mdSaveButton" [disabled]="!mdHtml" class="timButton btn-sm"
                             (click)="exportMDAsImg()">{{mdSaveButton}}

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -65,6 +65,7 @@ import {InputDialogKind} from "tim/ui/input-dialog.kind";
 import {showInputDialog} from "tim/ui/showInputDialog";
 import html2canvas from "html2canvas";
 import {vctrlInstance} from "tim/document/viewctrlinstance";
+import type {InvalidMarkerData} from "tim/answer/answer-browser.component";
 import type {
     SimcirConnectorDef,
     SimcirDeviceInstance,
@@ -84,7 +85,6 @@ import type {FormulaEvent} from "./editor/math-editor/symbol-button-menu.compone
 import {selectFormulaFromPreview} from "./editor/math-editor/formula-utils";
 import {LATEX_BUTTONS} from "./editor/math-editor/default-symbol-buttons";
 import {FormulaEditorComponent} from "./editor/math-editor/formula-editor.component";
-import {InvalidMarkerData} from "tim/answer/answer-browser.component";
 
 // TODO better name?
 interface Vid {
@@ -3926,9 +3926,11 @@ ${fhtml}
         }
         await ab.loader.abLoad.promise;
         console.log("Hello", ab.taskInfo);
+        const markerInfo = this.markup.invalidMarker;
         if (
             ab.taskInfo?.deadline &&
-            Date.parse(ab.taskInfo?.deadline) < Date.now()
+            Date.parse(ab.taskInfo?.deadline) < Date.now() &&
+            markerInfo?.deadline
         ) {
             this.taskDeadline = ab.taskInfo?.deadline;
         }

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -55,7 +55,6 @@ import {
 } from "tim/util/utils";
 import {TimDefer} from "tim/util/timdefer";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
-import type {InvalidMarkerState} from "tim/plugin/angular-plugin-base.directive";
 import deepEqual from "deep-equal";
 import type {ITemplateParam} from "tim/ui/showTemplateReplaceDialog";
 import {
@@ -4442,11 +4441,6 @@ ${fhtml}
                             (click)="runCode()"
                             [innerHTML]="buttonText()"></button>
                     &nbsp;
-<!--                    <span *ngIf="invalidMarker?.deadline" [tooltip]="invalidMarker?.deadline" placement="bottom"-->
-<!--                          class="glyphicon glyphicon-lock text-danger"></span>-->
-<!--                    <span *ngIf="invalidMarker?.modelAnswerLock" [tooltip]="invalidMarker?.modelAnswerLock" placement="bottom"-->
-<!--                          class="glyphicon glyphicon-lock text-danger"></span>-->
-<!--                    <ng-container *ngIf="invalidMarker">&nbsp;</ng-container>-->
                     <span *ngIf="invalidMarker" [tooltip]="poptemplate" placement="bottom"
                           class="glyphicon glyphicon-lock text-danger"></span>
                     <ng-template #poptemplate>

--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -55,6 +55,7 @@ import {
 } from "tim/util/utils";
 import {TimDefer} from "tim/util/timdefer";
 import {AngularPluginBase} from "tim/plugin/angular-plugin-base.directive";
+import type {InvalidMarkerState} from "tim/plugin/angular-plugin-base.directive";
 import deepEqual from "deep-equal";
 import type {ITemplateParam} from "tim/ui/showTemplateReplaceDialog";
 import {
@@ -65,7 +66,6 @@ import {InputDialogKind} from "tim/ui/input-dialog.kind";
 import {showInputDialog} from "tim/ui/showInputDialog";
 import html2canvas from "html2canvas";
 import {vctrlInstance} from "tim/document/viewctrlinstance";
-import type {InvalidMarkerData} from "tim/answer/answer-browser.component";
 import type {
     SimcirConnectorDef,
     SimcirDeviceInstance,
@@ -1277,10 +1277,7 @@ export class CsController extends CsBase implements ITimComponent {
     private clearSaved: boolean = false;
     private originalUserInput?: string;
     exportingMD = false;
-    taskDeadline?: string;
-    modelAnswerLock?: boolean;
-    deadlineTooltip?: string;
-    modelAnswerLockTooltip?: string;
+    invalidMarker?: InvalidMarkerState;
 
     @ViewChild("externalEditor")
     set externalEditorViewSetter(newValue: EditorComponent | undefined) {
@@ -1589,9 +1586,6 @@ export class CsController extends CsBase implements ITimComponent {
         this.docLink = "Document";
         this.muokattu = false;
         this.editorIndex = 0;
-
-        this.deadlineTooltip = $localize`The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won't be eligible for points or grading.`;
-        this.modelAnswerLockTooltip = $localize`You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.`;
     }
 
     onIframeLoad(e: Event) {
@@ -2444,7 +2438,12 @@ ${fhtml}
         //  It's unclear if getCode should handle this already.
         this.showCodeNow();
         this.updateRunChanged();
-        this.updateInvalidMarkerData();
+
+        this.getInvalidMarkerState().then((r) => {
+            if (r) {
+                this.invalidMarker = r;
+            }
+        });
     }
 
     ngOnDestroy() {
@@ -3915,41 +3914,6 @@ ${fhtml}
         }
     }
 
-    async updateInvalidMarkerData() {
-        const taskId = this.getTaskId()?.docTask();
-        if (!taskId) {
-            return;
-        }
-        const ab = await this.vctrl.getAnswerBrowserAsync(taskId);
-        if (!ab) {
-            return;
-        }
-        await ab.loader.abLoad.promise;
-        console.log("Hello", ab.taskInfo);
-        const markerInfo = this.markup.invalidMarker;
-        if (
-            ab.taskInfo?.deadline &&
-            Date.parse(ab.taskInfo?.deadline) < Date.now() &&
-            markerInfo?.deadline
-        ) {
-            this.taskDeadline = ab.taskInfo?.deadline;
-        }
-        if (ab.taskInfo?.modelAnswer?.alreadyLocked) {
-            this.modelAnswerLock = ab.taskInfo?.modelAnswer?.lock;
-        }
-    }
-
-    async updateInvalidMarkers() {
-        await this.updateInvalidMarkerData();
-    }
-
-    setInvalidMarkerData(data: InvalidMarkerData) {
-        // this.taskDeadline = data.deadline;
-        // this.modelAnswerLock = data.modelAnswerLock;
-        // PÄivitetään varoitukset
-        this.updateInvalidMarkerData();
-    }
-
     write(s: string) {
         this.result += s;
     }
@@ -4337,16 +4301,16 @@ ${fhtml}
             <h4 class="csHeader" *ngIf="header" [innerHTML]="header | purify"></h4>
             <div class="csAllSelector" *ngIf="isAll">
                 <div>
-                    {{languageText}}
+                    {{ languageText }}
                     <select [(ngModel)]="selectedLanguage" required (ngModelChange)="languageChange()">
-                        <option *ngFor="let o of progLanguages" [value]="o">{{o}}</option>
+                        <option *ngFor="let o of progLanguages" [value]="o">{{ o }}</option>
                     </select>
                 </div>
             </div>
             <p *ngIf="stem" class="stem" [innerHTML]="stem | purify"
                (keydown)="elementSelectAll($event)" tabindex="0"></p>
             <div class="csTaunoContent" *ngIf="isTauno">
-                <p *ngIf="taunoOn" class="pluginHide"><a (click)="hideTauno()">{{hideText}} Tauno</a></p>
+                <p *ngIf="taunoOn" class="pluginHide"><a (click)="hideTauno()">{{ hideText }} Tauno</a></p>
                 <iframe *ngIf="iframesettings"
                         [id]="iframesettings.id"
                         class="showTauno"
@@ -4355,17 +4319,17 @@ ${fhtml}
                         [width]="iframesettings.width"
                         [height]="iframesettings.height"
                         sandbox="allow-scripts"></iframe>
-                <p *ngIf="!taunoOn" class="pluginShow"><a (click)="showTauno()">{{showText}} Tauno</a></p>
+                <p *ngIf="!taunoOn" class="pluginShow"><a (click)="showTauno()">{{ showText }} Tauno</a></p>
                 <p *ngIf="taunoOn" class="pluginHide">
-                    <a (click)="copyTauno()">{{copyFromTaunoText}}</a> |
-                    <a (click)="hideTauno()">{{hideText}} Tauno</a></p>
+                    <a (click)="copyTauno()">{{ copyFromTaunoText }}</a> |
+                    <a (click)="hideTauno()">{{ hideText }} Tauno</a></p>
                 <p *ngIf="taunoOn" class="taunoOhje">
-                    {{taunoOhjeText}}</p>
+                    {{ taunoOhjeText }}</p>
             </div>
             <div class="csSimcirContent" *ngIf="isSimcir">
-                <p *ngIf="simcirOn" class="pluginHide"><a (click)="hideSimcir()">{{hideText}} SimCir</a></p>
+                <p *ngIf="simcirOn" class="pluginHide"><a (click)="hideSimcir()">{{ hideText }} SimCir</a></p>
                 <div class="simcirContainer"><p></p></div>
-                <p *ngIf="!simcirOn" class="pluginShow"><a (click)="showSimcir()">{{showText}} SimCir</a></p>
+                <p *ngIf="!simcirOn" class="pluginShow"><a (click)="showSimcir()">{{ showText }} SimCir</a></p>
                 <p *ngIf="simcirOn && !noeditor" class="pluginHide">
                     <a (click)="copyFromSimcir()">copy from SimCir</a>
                     | <a (click)="copyToSimcir()">copy to SimCir</a> | <a (click)="hideSimcir()">hide SimCir</a>
@@ -4386,19 +4350,19 @@ ${fhtml}
                     </span>
                 </div>
             </div>
-            <pre class="csViewCodeOver" *ngIf="viewCode && codeover">{{code}}</pre>
+            <pre class="csViewCodeOver" *ngIf="viewCode && codeover">{{ code }}</pre>
 
             <div class="csRunCode">
                 <div *ngIf="formulaEditor && editor">
                     <cs-formula-editor
-                            #formulaEditorComponent
-                            (okClose)="toggleFormulaEditor($event)"
-                            (cancelClose)="toggleFormulaEditor($event)"
-                            (toggle)="toggleFormulaEditor()"
-                            [visible]="formulaEditorOpen"
-                            [editor]="editor"
-                            [currentSymbol]="currentSymbol"
-                            [templateButtons]="templateButtons">
+                        #formulaEditorComponent
+                        (okClose)="toggleFormulaEditor($event)"
+                        (cancelClose)="toggleFormulaEditor($event)"
+                        (toggle)="toggleFormulaEditor()"
+                        [visible]="formulaEditorOpen"
+                        [editor]="editor"
+                        [currentSymbol]="currentSymbol"
+                        [templateButtons]="templateButtons">
                         <file-select-manager class="small"
                                              [dragAndDrop]="dragAndDrop"
                                              [uploadUrl]="uploadUrl"
@@ -4409,7 +4373,7 @@ ${fhtml}
                         </file-select-manager>
                     </cs-formula-editor>
                 </div>
-                <pre class="csRunPre" *ngIf="viewCode && !codeunder && !codeover">{{precode}}</pre>
+                <pre class="csRunPre" *ngIf="viewCode && !codeunder && !codeover">{{ precode }}</pre>
                 <div class="csEditorAreaDiv" [hidden]="formulaEditor && formulaEditorOpen">
                     <cs-editor #mainEditor *ngIf="!noeditor || viewCode" class="csrunEditorDiv"
                                [base]="byCode"
@@ -4426,11 +4390,11 @@ ${fhtml}
                     <div class="csRunChanged" *ngIf="runChanged && !hide.changed"></div>
                     <div class="csRunNotSaved" *ngIf="isUnSaved()"></div>
                 </div>
-                <pre class="csRunPost" *ngIf="viewCode && !codeunder && !codeover">{{postcode}}</pre>
+                <pre class="csRunPost" *ngIf="viewCode && !codeunder && !codeover">{{ postcode }}</pre>
             </div>
             <div *ngIf="isSage" class="computeSage no-popup-menu"></div>
             <div class="csInputDiv" *ngIf="showInput && isInput">
-                <p *ngIf="inputstem" class="stem">{{inputstem}}</p>
+                <p *ngIf="inputstem" class="stem">{{ inputstem }}</p>
                 <div class="csRunCode">
             <textarea class="csRunArea csInputArea"
                       [rows]="inputrows"
@@ -4439,7 +4403,7 @@ ${fhtml}
             </textarea>
                 </div>
             </div>
-            <div class="csArgsDiv" *ngIf="showArgs &&!markup['noargs'] && isInput"><label>{{argsstem}} </label>
+            <div class="csArgsDiv" *ngIf="showArgs &&!markup['noargs'] && isInput"><label>{{ argsstem }} </label>
                 <span><input type="text"
                              class="csArgsArea"
                              [(ngModel)]="userargs"
@@ -4457,7 +4421,8 @@ ${fhtml}
                        [maxRows]="maxrows"
                        [disabled]="true">
             </cs-editor>
-            <div class="csRunMenuArea" *ngIf="!forcedupload && !markup['norunmenu']" [hidden]="formulaEditor && formulaEditorOpen">
+            <div class="csRunMenuArea" *ngIf="!forcedupload && !markup['norunmenu']"
+                 [hidden]="formulaEditor && formulaEditorOpen">
                 <p class="csRunMenu">
                     <button *ngIf="isRun && buttonText()"
                             [disabled]="isRunning || preventSave || (disableUnchanged && !isUnSaved() && isText)"
@@ -4466,11 +4431,13 @@ ${fhtml}
                             (click)="runCode()"
                             [innerHTML]="buttonText()"></button>
                     &nbsp;
-                    <span *ngIf="taskDeadline" [tooltip]="deadlineTooltip" placement="bottom" class="glyphicon glyphicon-hourglass text-danger"></span>
-                    <span *ngIf="modelAnswerLock" [tooltip]="modelAnswerLockTooltip" placement="bottom" class="glyphicon glyphicon-lock text-danger"></span>
+                    <span *ngIf="invalidMarker?.deadline" [tooltip]="invalidMarker?.deadline" placement="bottom"
+                          class="glyphicon glyphicon-hourglass text-danger"></span>
+                    <span *ngIf="invalidMarker?.modelAnswerLock" [tooltip]="invalidMarker?.modelAnswerLock" placement="bottom"
+                          class="glyphicon glyphicon-lock text-danger"></span>
                     &nbsp;
                     <button *ngIf="mdSaveButton" [disabled]="!mdHtml" class="timButton btn-sm"
-                            (click)="exportMDAsImg()">{{mdSaveButton}}
+                            (click)="exportMDAsImg()">{{ mdSaveButton }}
                     </button>
                     <tim-loading *ngIf="mdSaveButton && exportingMD"></tim-loading>
                     &nbsp;
@@ -4480,7 +4447,7 @@ ${fhtml}
                             (click)="fetchExternalFiles()"
                             [innerHTML]="externalFetchText()"></button>
                     <a href="#" *ngIf="undoButton && isUnSaved()" [title]="undoTitle"
-                       (click)="tryResetChanges($event)"> &nbsp;{{undoButton}}</a>
+                       (click)="tryResetChanges($event)"> &nbsp;{{ undoButton }}</a>
                     &nbsp;&nbsp;
                     <span *ngIf="savedText"
                           class="savedText"
@@ -4498,28 +4465,28 @@ ${fhtml}
                             (click)="runUnitTest()">UTest
                     </button>
                     <tim-loading *ngIf="isRunning"></tim-loading>
-                    <span class="runningText" *ngIf="isRunning && runningText">{{runningText}}</span>
+                    <span class="runningText" *ngIf="isRunning && runningText">{{ runningText }}</span>
                     &nbsp;&nbsp;
                     <span *ngIf="isDocument">
                 <a href="#" [ngClass]="{'link-disable': isRunning}"
-                   (click)="runDocument(); $event.preventDefault()">{{docLink}}</a>&nbsp;&nbsp;
+                   (click)="runDocument(); $event.preventDefault()">{{ docLink }}</a>&nbsp;&nbsp;
             </span>
                     <a href="#" *ngIf="!nocode && (file || program)"
-                       (click)="showCode(); $event.preventDefault()">{{showCodeLink}}</a>&nbsp;&nbsp;
+                       (click)="showCode(); $event.preventDefault()">{{ showCodeLink }}</a>&nbsp;&nbsp;
                     <a href="#" *ngIf="canReset"
-                       (click)="initCode(true); $event.preventDefault()">{{resetText}} </a>
+                       (click)="initCode(true); $event.preventDefault()">{{ resetText }} </a>
                     <a href="#" *ngIf="toggleEditor"
-                       (click)="hideShowEditor(); $event.preventDefault()">{{toggleEditorText[noeditor ? 0 : 1]}}</a>
+                       (click)="hideShowEditor(); $event.preventDefault()">{{ toggleEditorText[noeditor ? 0 : 1] }}</a>
                     <a href="#" *ngIf="!noeditor && editor && editor.nextModeText"
                        (click)="editor.showOtherEditor(); $event.preventDefault()">
-                        {{editor.nextModeText}}
+                        {{ editor.nextModeText }}
                     </a>&nbsp;&nbsp;
                     <a href="#" *ngIf="copyLink"
-                       (click)="copyCode(); $event.preventDefault()">{{copyLink}}</a>
+                       (click)="copyCode(); $event.preventDefault()">{{ copyLink }}</a>
                     <span *ngIf="showRuntime"
                           class="inputSmall"
                           style="float: right;"
-                          title="Run time in sec {{runtime}}">{{oneruntime}}</span>
+                          title="Run time in sec {{runtime}}">{{ oneruntime }}</span>
                     <span *ngIf="editor && wrap && wrap.n!=-1 && !hide.wrap && editor.mode < 2" class="inputSmall"
                           style="float: right;"
                           title="Put 0 to no wrap">
@@ -4528,10 +4495,10 @@ ${fhtml}
                 </button>
                 &nbsp;
                 <input type="checkbox" title="Check for automatic wrapping" [(ngModel)]="wrap.auto"
-                       style="position: relative;top: 0.3em;"/>
+                       style="position: relative;top: 0.3em;" />
                 &nbsp;
                 <input type="text" title="Choose linelength for text.  0=no wrap" pattern="[0-9]*" [(ngModel)]="wrap.n"
-                       size="2"/>
+                       size="2" />
             </span>
                     <span *ngIf="connectionErrorMessage" class="error" style="font-size: 12px"
                           [innerHTML]="connectionErrorMessage"></span>
@@ -4548,9 +4515,9 @@ ${fhtml}
 
             </div>
             <div *ngIf="isSage" class="outputSage no-popup-menu"></div>
-            <pre class="csViewCodeUnder" *ngIf="viewCode && codeunder">{{code}}</pre>
+            <pre class="csViewCodeUnder" *ngIf="viewCode && codeunder">{{ code }}</pre>
             <p class="unitTestGreen" *ngIf="runTestGreen">&nbsp;ok</p>
-            <pre class="unitTestRed" *ngIf="runTestRed">{{comtestError}}</pre>
+            <pre class="unitTestRed" *ngIf="runTestRed">{{ comtestError }}</pre>
             <div class="csRunErrorClass csRunError" *ngIf="runError">
                 <p class="pull-right" *ngIf="!markup['noclose']">
                     <label class="normalLabel" title="Keep errors until next run">Keep <input type="checkbox"></label>
@@ -4559,8 +4526,8 @@ ${fhtml}
                 <a class="copyErrorLink" *ngIf="markup.copyErrorLink"
                    (click)="copyString(error, $event)"
                    title="Copy text to clipboard"
-                >{{markup.copyErrorLink}}</a>
-                <pre class="csRunError" (keydown)="elementSelectAll($event)" tabindex="0">{{error}}</pre>
+                >{{ markup.copyErrorLink }}</a>
+                <pre class="csRunError" (keydown)="elementSelectAll($event)" tabindex="0">{{ error }}</pre>
                 <p class="pull-right" *ngIf="!markup['noclose']" style="margin-top: -1em">
                     <tim-close-button (click)="closeError()"></tim-close-button>
                 </p>
@@ -4573,8 +4540,8 @@ ${fhtml}
                    (click)="copyString(fetchError, $event)"
                    title="Copy text to clipboard"
                    aria-label="Copy text to clipboard"
-                >{{markup.copyErrorLink}}</a>
-                <pre class="csRunError" (keydown)="elementSelectAll($event)" tabindex="0">{{fetchError}}</pre>
+                >{{ markup.copyErrorLink }}</a>
+                <pre class="csRunError" (keydown)="elementSelectAll($event)" tabindex="0">{{ fetchError }}</pre>
                 <p class="pull-right" *ngIf="!markup['noclose']" style="margin-top: -1em">
                     <tim-close-button (click)="fetchError=undefined"></tim-close-button>
                 </p>
@@ -4584,13 +4551,14 @@ ${fhtml}
                    (click)="copyString(result, $event)"
                    title="Copy console text to clipboard"
                    aria-label="Copy console text to clipboard"
-                >{{markup.copyConsoleLink}}</a>
+                >{{ markup.copyConsoleLink }}</a>
                 <pre id="resultConsole" class="console" (keydown)="elementSelectAll($event)"
-                     tabindex="0" aria-live="assertive">{{result}}</pre>
+                     tabindex="0" aria-live="assertive">{{ result }}</pre>
             </div>
             <div class="htmlresult" *ngIf="htmlresult"><span [innerHTML]="htmlresult | purify"
                                                              aria-live="polite"></span></div>
-            <div #csrunPreview class="csrunPreview" [class.csrun-clicking]="formulaEditor" (keydown)="elementSelectAll($event)"
+            <div #csrunPreview class="csrunPreview" [class.csrun-clicking]="formulaEditor"
+                 (keydown)="elementSelectAll($event)"
                  tabindex="0" aria-live="polite"
                  (dblclick)="handleSelectFormulaFromPreview($event, preview)" #preview>
                 <div *ngIf="iframesettings && !isTauno"
@@ -4600,18 +4568,18 @@ ${fhtml}
                      class="no-popup-menu">
                     <span class="csRunMenu" *ngIf="!markup['noclose']">
                         <tim-close-button
-                                (click)="closeFrame()"
-                                style="float: right">
+                            (click)="closeFrame()"
+                            style="float: right">
                         </tim-close-button>
                     </span>
                     <iframe [id]="iframesettings.id"
-                        class="jsCanvas"
-                        [src]="iframesettings.src"
-                        (load)="onIframeLoad($event)"
-                        [width]="iframesettings.width"
-                        [height]="iframesettings.height"
-                        sandbox="allow-scripts allow-forms"
-                        style="border:0">
+                            class="jsCanvas"
+                            [src]="iframesettings.src"
+                            (load)="onIframeLoad($event)"
+                            [width]="iframesettings.width"
+                            [height]="iframesettings.height"
+                            sandbox="allow-scripts allow-forms"
+                            style="border:0">
                     </iframe>
                 </div>
                 <div class="csMDHTML" #mdHtmlDiv *ngIf="mdHtml" [innerHTML]="mdHtml | purify" aria-live="polite">
@@ -4622,7 +4590,7 @@ ${fhtml}
                            [jsparams]="jsparams"
                            [height]="height"
             ></tim-variables> <!-- TODO: why direct markup.jsparam does not work -->
-            <img *ngIf="imgURL" class="grconsole" [src]="imgURL" alt=""/>
+            <img *ngIf="imgURL" class="grconsole" [src]="imgURL" alt="" />
             <video class="csVideo" *ngIf="videoURL" [src]="videoURL" type="video/mp4" style="width: 100%;" controls=""
                    autoplay></video>
             <video class="csAudio" *ngIf="wavURL" [src]="wavURL" type="video/mp4" controls="" autoplay="true"

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1920,11 +1920,11 @@ export class AnswerBrowserComponent
         if (this.taskInfo.buttonNewTask) {
             this.buttonNewTask = this.taskInfo.buttonNewTask;
         }
-        const plugin = this.getPluginComponent();
-        const markerData: InvalidMarkerData = {
-            deadline: "",
-            modelAnswerLock: false,
-        };
+        // const plugin = this.getPluginComponent();
+        // const markerData: InvalidMarkerData = {
+        //     deadline: "",
+        //     modelAnswerLock: false,
+        // };
         // if (plugin && plugin.setInvalidMarkerData) {
         //     console.log("Nimi:");
         //     console.log(plugin.getName());

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1915,31 +1915,6 @@ export class AnswerBrowserComponent
         if (this.taskInfo.buttonNewTask) {
             this.buttonNewTask = this.taskInfo.buttonNewTask;
         }
-        // const plugin = this.getPluginComponent();
-        // const markerData: InvalidMarkerData = {
-        //     deadline: "",
-        //     modelAnswerLock: false,
-        // };
-        // if (plugin && plugin.setInvalidMarkerData) {
-        //     console.log("Nimi:");
-        //     console.log(plugin.getName());
-        //     console.log("Markup: ");
-        //     console.log(plugin.markup);
-        //     console.log("Taskinfo: ");
-        //     console.log(this.taskInfo);
-        //     if (this.taskInfo.deadline && plugin.markup.invalidMarker) {
-        //         console.log("Deadline asetettu");
-        //         markerData.deadline = this.taskInfo.deadline;
-        //     }
-        //     if (this.taskInfo.modelAnswer && plugin.markup.invalidMarker) {
-        //         console.log("Modelanswerlock asetettu");
-        //         markerData.modelAnswerLock = this.taskInfo.modelAnswer.lock;
-        //     }
-        //
-        //     console.log(markerData);
-        //     plugin.setInvalidMarkerData(markerData);
-        //     console.log("___________________________");
-        // }
     }
 
     async checkUsers(force?: boolean) {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -142,6 +142,11 @@ export type AnswerBrowserData =
           answernr: number | undefined;
       };
 
+export interface InvalidMarkerData {
+    deadline?: string;
+    modelAnswerLock?: boolean;
+}
+
 const DEFAULT_MARKUP_CONFIG: IAnswerBrowserSettings = {
     pointsStep: 0,
     validOnlyText: $localize`Show valid only`,
@@ -1888,18 +1893,6 @@ export class AnswerBrowserComponent
         }
         this.clearError("taskinfo");
         this.taskInfo = r.result.data;
-        const plugin = this.getPluginComponent();
-        if (plugin && plugin.setInvalidMarkerData()) {
-            if (this.pluginMarkup()?.invalidMarker?.deadline) {
-                plugin.setInvalidMarkerData(
-                    this.pluginMarkup()?.invalidMarker?.deadline
-                );
-            }
-            if (this.pluginMarkup()?.invalidMarker?.modelAnswerLock) {
-            }
-            this.pluginMarkup()?.invalidMarker?.modelAnswerLock;
-            // plugin.setDeadline(this.taskInfo.
-        }
         if (r.result.data.modelAnswer) {
             this.modelAnswer = r.result.data.modelAnswer;
             // Don't show "Show model answer" when it's disabled for viewers
@@ -1922,6 +1915,31 @@ export class AnswerBrowserComponent
         this.showNewTask = this.isAndSetShowNewTask();
         if (this.taskInfo.buttonNewTask) {
             this.buttonNewTask = this.taskInfo.buttonNewTask;
+        }
+        const plugin = this.getPluginComponent();
+        const markerData: InvalidMarkerData = {
+            deadline: "",
+            modelAnswerLock: false,
+        };
+        if (plugin && plugin.setInvalidMarkerData) {
+            console.log("Nimi:");
+            console.log(plugin.getName());
+            console.log("Markup: ");
+            console.log(plugin.markup);
+            console.log("Taskinfo: ");
+            console.log(this.taskInfo);
+            if (this.taskInfo.deadline && plugin.markup.invalidMarker) {
+                console.log("Deadline asetettu");
+                markerData.deadline = this.taskInfo.deadline;
+            }
+            if (this.taskInfo.modelAnswer && plugin.markup.invalidMarker) {
+                console.log("Modelanswerlock asetettu");
+                markerData.modelAnswerLock = this.taskInfo.modelAnswer.lock;
+            }
+
+            console.log(markerData);
+            plugin.setInvalidMarkerData(markerData);
+            console.log("___________________________");
         }
     }
 

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -142,11 +142,6 @@ export type AnswerBrowserData =
           answernr: number | undefined;
       };
 
-export interface InvalidMarkerData {
-    deadline?: string;
-    modelAnswerLock?: boolean;
-}
-
 const DEFAULT_MARKUP_CONFIG: IAnswerBrowserSettings = {
     pointsStep: 0,
     validOnlyText: $localize`Show valid only`,
@@ -1433,8 +1428,8 @@ export class AnswerBrowserComponent
             this.modelAnswer.alreadyLocked = true;
             this.viewctrl.informAboutLock(this.taskId);
             const plugin = this.getPluginComponent();
-            if (plugin?.updateInvalidMarkers) {
-                await plugin.updateInvalidMarkers();
+            if (plugin?.getInvalidMarkerState?.()) {
+                await plugin?.getInvalidMarkerState();
             }
         }
         if (r.result.data.points_map) {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1432,6 +1432,10 @@ export class AnswerBrowserComponent
         if (this.modelAnswer?.lock) {
             this.modelAnswer.alreadyLocked = true;
             this.viewctrl.informAboutLock(this.taskId);
+            const plugin = this.getPluginComponent();
+            if (plugin?.updateInvalidMarkers) {
+                await plugin.updateInvalidMarkers();
+            }
         }
         if (r.result.data.points_map) {
             this.setPointsToAnswers(r.result.data.points_map);
@@ -1921,26 +1925,26 @@ export class AnswerBrowserComponent
             deadline: "",
             modelAnswerLock: false,
         };
-        if (plugin && plugin.setInvalidMarkerData) {
-            console.log("Nimi:");
-            console.log(plugin.getName());
-            console.log("Markup: ");
-            console.log(plugin.markup);
-            console.log("Taskinfo: ");
-            console.log(this.taskInfo);
-            if (this.taskInfo.deadline && plugin.markup.invalidMarker) {
-                console.log("Deadline asetettu");
-                markerData.deadline = this.taskInfo.deadline;
-            }
-            if (this.taskInfo.modelAnswer && plugin.markup.invalidMarker) {
-                console.log("Modelanswerlock asetettu");
-                markerData.modelAnswerLock = this.taskInfo.modelAnswer.lock;
-            }
-
-            console.log(markerData);
-            plugin.setInvalidMarkerData(markerData);
-            console.log("___________________________");
-        }
+        // if (plugin && plugin.setInvalidMarkerData) {
+        //     console.log("Nimi:");
+        //     console.log(plugin.getName());
+        //     console.log("Markup: ");
+        //     console.log(plugin.markup);
+        //     console.log("Taskinfo: ");
+        //     console.log(this.taskInfo);
+        //     if (this.taskInfo.deadline && plugin.markup.invalidMarker) {
+        //         console.log("Deadline asetettu");
+        //         markerData.deadline = this.taskInfo.deadline;
+        //     }
+        //     if (this.taskInfo.modelAnswer && plugin.markup.invalidMarker) {
+        //         console.log("Modelanswerlock asetettu");
+        //         markerData.modelAnswerLock = this.taskInfo.modelAnswer.lock;
+        //     }
+        //
+        //     console.log(markerData);
+        //     plugin.setInvalidMarkerData(markerData);
+        //     console.log("___________________________");
+        // }
     }
 
     async checkUsers(force?: boolean) {

--- a/timApp/static/scripts/tim/answer/answer-browser.component.ts
+++ b/timApp/static/scripts/tim/answer/answer-browser.component.ts
@@ -1888,6 +1888,18 @@ export class AnswerBrowserComponent
         }
         this.clearError("taskinfo");
         this.taskInfo = r.result.data;
+        const plugin = this.getPluginComponent();
+        if (plugin && plugin.setInvalidMarkerData()) {
+            if (this.pluginMarkup()?.invalidMarker?.deadline) {
+                plugin.setInvalidMarkerData(
+                    this.pluginMarkup()?.invalidMarker?.deadline
+                );
+            }
+            if (this.pluginMarkup()?.invalidMarker?.modelAnswerLock) {
+            }
+            this.pluginMarkup()?.invalidMarker?.modelAnswerLock;
+            // plugin.setDeadline(this.taskInfo.
+        }
         if (r.result.data.modelAnswer) {
             this.modelAnswer = r.result.data.modelAnswer;
             // Don't show "Show model answer" when it's disabled for viewers

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -43,7 +43,10 @@ import {
     getParContainerElem,
 } from "tim/document/structure/create";
 import type {UserListController} from "tim/answer/userlistController";
-import type {AnswerBrowserComponent} from "tim/answer/answer-browser.component";
+import type {
+    AnswerBrowserComponent,
+    InvalidMarkerData,
+} from "tim/answer/answer-browser.component";
 import type {PluginLoaderComponent} from "tim/plugin/plugin-loader.component";
 import type {IAnswer} from "tim/answer/IAnswer";
 import type {IPluginInfoResponse} from "tim/editor/parCompiler";
@@ -129,7 +132,7 @@ export interface ITimComponent extends IUnsavedComponent {
     resetChanges: () => void;
     setAnswer: (content: Record<string, unknown>) => ISetAnswerResult;
     setData?(data: unknown, save: boolean): void;
-    setInvalidMarkerData?: (data: string) => void;
+    setInvalidMarkerData?: (data: InvalidMarkerData) => void;
 }
 
 /**

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -129,6 +129,7 @@ export interface ITimComponent extends IUnsavedComponent {
     resetChanges: () => void;
     setAnswer: (content: Record<string, unknown>) => ISetAnswerResult;
     setData?(data: unknown, save: boolean): void;
+    setInvalidMarkerData?: (data: string) => void;
 }
 
 /**

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -133,6 +133,7 @@ export interface ITimComponent extends IUnsavedComponent {
     setAnswer: (content: Record<string, unknown>) => ISetAnswerResult;
     setData?(data: unknown, save: boolean): void;
     setInvalidMarkerData?: (data: InvalidMarkerData) => void;
+    updateInvalidMarkers?: () => Promise<void>;
 }
 
 /**

--- a/timApp/static/scripts/tim/document/viewctrl.ts
+++ b/timApp/static/scripts/tim/document/viewctrl.ts
@@ -43,10 +43,7 @@ import {
     getParContainerElem,
 } from "tim/document/structure/create";
 import type {UserListController} from "tim/answer/userlistController";
-import type {
-    AnswerBrowserComponent,
-    InvalidMarkerData,
-} from "tim/answer/answer-browser.component";
+import type {AnswerBrowserComponent} from "tim/answer/answer-browser.component";
 import type {PluginLoaderComponent} from "tim/plugin/plugin-loader.component";
 import type {IAnswer} from "tim/answer/IAnswer";
 import type {IPluginInfoResponse} from "tim/editor/parCompiler";
@@ -91,6 +88,7 @@ import type {
 import type {ReviewCanvasComponent} from "tim/plugin/reviewcanvas/review-canvas.component";
 import type {IRight} from "tim/item/access-role.service";
 import {UnbrokenSelection} from "tim/document/editing/unbrokenSelection";
+import type {InvalidMarkerState} from "tim/plugin/angular-plugin-base.directive";
 
 markAsUsed(interceptor);
 
@@ -132,8 +130,7 @@ export interface ITimComponent extends IUnsavedComponent {
     resetChanges: () => void;
     setAnswer: (content: Record<string, unknown>) => ISetAnswerResult;
     setData?(data: unknown, save: boolean): void;
-    setInvalidMarkerData?: (data: InvalidMarkerData) => void;
-    updateInvalidMarkers?: () => Promise<void>;
+    getInvalidMarkerState?(): Promise<InvalidMarkerState | undefined>;
 }
 
 /**

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -293,7 +293,6 @@ export abstract class AngularPluginBase<
             return undefined;
         }
         await ab.loader.abLoad.promise;
-        console.log("Hello", ab.taskInfo);
         const markerInfo = this.markup.invalidMarker;
         if (
             ab.taskInfo?.deadline &&

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -35,8 +35,10 @@ export interface PluginJson {
 }
 
 export interface InvalidMarkerState {
-    deadline?: string;
-    modelAnswerLock?: string;
+    // deadline?: string;
+    // modelAnswerLock?: string;
+    toolTipTexts: string[];
+    invalidMarkerSet: boolean;
 }
 
 /**
@@ -295,19 +297,23 @@ export abstract class AngularPluginBase<
         if (!markerInfo) {
             return undefined;
         }
-        const result: InvalidMarkerState = {};
+        const toolTips: string[] = [];
         const deadlineTooltip = markerInfo.deadline;
         if (
             ab.taskInfo?.deadline &&
             Date.parse(ab.taskInfo.deadline) < Date.now() &&
             deadlineTooltip
         ) {
-            result.deadline = deadlineTooltip;
+            toolTips.push(deadlineTooltip);
         }
         const modelAnswerLock = markerInfo.modelAnswerLock;
         if (ab.taskInfo?.modelAnswer?.alreadyLocked && modelAnswerLock) {
-            result.modelAnswerLock = modelAnswerLock;
+            toolTips.push(modelAnswerLock);
         }
-        return result;
+        const showInvalidMarker = toolTips.length > 0;
+        return {
+            toolTipTexts: toolTips,
+            invalidMarkerSet: showInvalidMarker,
+        };
     }
 }

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -35,8 +35,6 @@ export interface PluginJson {
 }
 
 export interface InvalidMarkerState {
-    // deadline?: string;
-    // modelAnswerLock?: string;
     toolTipTexts: string[];
     invalidMarkerSet: boolean;
 }

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -283,8 +283,6 @@ export abstract class AngularPluginBase<
 
     async getInvalidMarkerState(): Promise<InvalidMarkerState | undefined> {
         const taskId = this.getTaskId()?.docTask();
-        // defaultDeadlineTooltip = $localize`The task deadline has passed. You may still submit a solution, but it will be marked as invalid and won't be eligible for points or grading.`;
-        // defaultModelAnswerLockTooltip = $localize`You’ve already unlocked the model solution, so any further submissions will be saved but won’t earn points or be graded.`;
         if (!taskId) {
             return undefined;
         }

--- a/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
+++ b/timApp/static/scripts/tim/plugin/angular-plugin-base.directive.ts
@@ -294,17 +294,22 @@ export abstract class AngularPluginBase<
         }
         await ab.loader.abLoad.promise;
         const markerInfo = this.markup.invalidMarker;
+        if (!markerInfo) {
+            return undefined;
+        }
+        const result: InvalidMarkerState = {};
+        const deadlineTooltip = markerInfo.deadline;
         if (
             ab.taskInfo?.deadline &&
-            Date.parse(ab.taskInfo?.deadline) < Date.now() &&
-            markerInfo?.deadline
+            Date.parse(ab.taskInfo.deadline) < Date.now() &&
+            deadlineTooltip
         ) {
-            const deadlineTooltip = markerInfo.deadline;
-            return {deadline: deadlineTooltip};
+            result.deadline = deadlineTooltip;
         }
-        if (ab.taskInfo?.modelAnswer?.alreadyLocked) {
-            const modelAnswerLock = markerInfo?.modelAnswerLock;
-            return {modelAnswerLock: modelAnswerLock};
+        const modelAnswerLock = markerInfo.modelAnswerLock;
+        if (ab.taskInfo?.modelAnswer?.alreadyLocked && modelAnswerLock) {
+            result.modelAnswerLock = modelAnswerLock;
         }
+        return result;
     }
 }

--- a/timApp/static/scripts/tim/plugin/attributes.ts
+++ b/timApp/static/scripts/tim/plugin/attributes.ts
@@ -13,6 +13,11 @@ export const PointsLimiterSettings = t.partial({
 export interface IPointsLimiterSettings
     extends t.TypeOf<typeof PointsLimiterSettings> {}
 
+export const InvalidMarkerSettings = t.partial({
+    deadline: t.string,
+    modelAnswerLock: t.string,
+});
+
 export const AnswerBrowserSettings = t.partial({
     pointsStep: nullable(t.number),
     validOnlyText: t.string,
@@ -75,6 +80,7 @@ export const GenericPluginMarkup = t.partial({
     saveTeacher: t.boolean,
     spellcheck: t.boolean,
     eagerlyLoadState: t.boolean,
+    invalidMarker: nullable(InvalidMarkerSettings),
 });
 
 export const Info = nullable(

--- a/timApp/static/scripts/tim/plugin/qst/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst/qst.component.ts
@@ -196,27 +196,19 @@ export class QstComponent
             enabled: this.enabled,
         });
         this.button = this.buttonText() ?? $localize`Save`;
-        this.getInvalidMarkerState().then((markerState) => {
-            if (!markerState) {
-                return;
-            }
-            this.invalidMarkerTooltip = [];
-            const {deadline, modelAnswerLock} = markerState;
-
-            if (deadline) {
-                this.invalidMarkerTooltip.push(deadline);
-            }
-            if (modelAnswerLock) {
-                this.invalidMarkerTooltip.push(modelAnswerLock);
-            }
-            this.invalidMarker = this.invalidMarkerTooltip.length > 0;
-        });
+        this.getInvalidMarkerTooltip();
     }
 
     ngOnDestroy() {
         if (!this.pluginMeta.isPreview()) {
             this.vctrl.removeTimComponent(this);
         }
+    }
+
+    private async getInvalidMarkerTooltip() {
+        const result = await this.getInvalidMarkerState();
+        this.invalidMarkerTooltip = result?.toolTipTexts ?? [];
+        this.invalidMarker = result?.invalidMarkerSet ?? false;
     }
 
     getHeader() {

--- a/timApp/static/scripts/tim/plugin/qst/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst/qst.component.ts
@@ -80,9 +80,9 @@ const PluginFields = t.intersection([
                        (click)="tryResetChanges($event)">
                         &nbsp;{{ undoButton }}
                     </a>
-                    &nbsp;
+                    <ng-container *ngIf="invalidMarker">&nbsp;</ng-container>
                     <span *ngIf="invalidMarker?.deadline" [tooltip]="invalidMarker?.deadline" placement="bottom"
-                          class="glyphicon glyphicon-hourglass text-danger"></span>
+                          class="glyphicon glyphicon-lock text-danger"></span>
                     <span *ngIf="invalidMarker?.modelAnswerLock" [tooltip]="invalidMarker?.modelAnswerLock"
                           placement="bottom"
                           class="glyphicon glyphicon-lock text-danger"></span>

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -297,7 +297,6 @@
     <ng-container *ngIf="taskInfo">
                 <span class="triesLeft"
                       *ngIf="taskInfo.answerLimit && triesTextVisible()">{{ getTriesText() }} {{ getTriesLeft() }}</span>
-                &nbsp;
             <span class="answeringTime" *ngIf="taskInfo.starttime || taskInfo.deadline">
         <ng-container i18n>Answering time:</ng-container>
         <span *ngIf="taskInfo.starttime && !taskInfo.deadline">

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -297,6 +297,7 @@
     <ng-container *ngIf="taskInfo">
                 <span class="triesLeft"
                       *ngIf="taskInfo.answerLimit && triesTextVisible()">{{ getTriesText() }} {{ getTriesLeft() }}</span>
+
             <span class="answeringTime" *ngIf="taskInfo.starttime || taskInfo.deadline">
         <ng-container i18n>Answering time:</ng-container>
         <span *ngIf="taskInfo.starttime && !taskInfo.deadline">

--- a/timApp/static/templates/answerBrowser.html
+++ b/timApp/static/templates/answerBrowser.html
@@ -297,7 +297,7 @@
     <ng-container *ngIf="taskInfo">
                 <span class="triesLeft"
                       *ngIf="taskInfo.answerLimit && triesTextVisible()">{{ getTriesText() }} {{ getTriesLeft() }}</span>
-
+                &nbsp;
             <span class="answeringTime" *ngIf="taskInfo.starttime || taskInfo.deadline">
         <ng-container i18n>Answering time:</ng-container>
         <span *ngIf="taskInfo.starttime && !taskInfo.deadline">

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -280,6 +280,12 @@ class AnswerBrowserInfo:
 
 
 @dataclass
+class InvalidMarkerSettings:
+    deadline: str | None | Missing = missing
+    modelAnswerLock: str | None | Missing = missing
+
+
+@dataclass
 class GenericMarkupModel(KnownMarkupFields):
     """Specifies which fields the editor can use in the plugin markup.
     This base class defines some fields that are applicable to all plugins.
@@ -309,6 +315,7 @@ class GenericMarkupModel(KnownMarkupFields):
     answerBrowser: AnswerBrowserInfo | Missing | None = missing
     spellcheck: bool | None | Missing = missing
     warningFilter: str | Missing | None = missing
+    invalidMarker: InvalidMarkerSettings | Missing | None = missing
 
     def get_visible_data(self) -> dict:
         assert isinstance(self.hidden_keys, list)


### PR DESCRIPTION
This pull request adds a warning icon to the csplugin and qst tasks to help users see which tasks are already invalid. The icon is displayed when the task has invalidMarker attribute set in YAML along with "deadline:" or "modelAnswerLock:" attributes, and has the deadline passed or model answer already opened.
 
- The logic is in angular-plugin-base.directive
- Components use ngFor to display different warnings in the tooltip, if they occur simultaneously