### PR TITLE
Feature: option for allowing macros for texplain docs

### DIFF
--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -158,6 +158,7 @@ class DocSettings:
     max_points_key = "max_points"
     nomacros_key = "nomacros"
     texplain_key = "texplain"
+    allow_texplain_macros_key = "allow_texplain_macros"
     textplain_key = "textplain"
     live_updates_key = "live_updates"
     plugin_md_key = "plugin_md"
@@ -509,6 +510,10 @@ class DocSettings:
     def is_texplain(self):
         texplain = self.__dict.get(self.texplain_key, False)
         return texplain
+
+    def allow_texplain_macros(self):
+        texplain_macros_allowed = self.__dict.get(self.allow_texplain_macros_key, False)
+        return texplain_macros_allowed
 
     def is_textplain(self):
         textplain = self.__dict.get(self.textplain_key, False)

--- a/timApp/printing/documentprinter.py
+++ b/timApp/printing/documentprinter.py
@@ -173,6 +173,7 @@ class DocumentPrinter:
         self.textplain = False
         self.texfiles = None
         self.urlroot = urlroot
+        self.allow_texplain_macros = None
 
     def get_template_id(self) -> int | None:
         if self._template_to_use:
@@ -247,6 +248,7 @@ class DocumentPrinter:
         )
         pars_to_print = []
         self.texplain = settings.is_texplain()
+        self.allow_texplain_macros = settings.allow_texplain_macros()
         self.textplain = (
             urlparams.textplain
             if urlparams.textplain is not None
@@ -382,7 +384,9 @@ class DocumentPrinter:
         ) in zip(pars_to_print, par_infos):
             md = p.prepare(view_ctx, use_md=True).output
             if not p.is_plugin() and not p.is_question():
-                if not p.get_nomacros() and not self.texplain and not self.textplain:
+                if (self.texplain and self.allow_texplain_macros) or (
+                    not p.get_nomacros() and not self.texplain and not self.textplain
+                ):
                     env = pdoc_macro_env
                     counters = env.counters
                     if counters:


### PR DESCRIPTION
Sallii makrojen suorittamisen dokumenteissa, joille on annettu seuraavat dokumenttiasetukset

```
texplain: true
allow_texplain_macros: true
```

kun dokumentti tulostetaan käyttäen TIMin LaTeX/PDF-tulostusta. 

Tämä oli aikaisemmin mahdollista asettamalla `nomacros: false` ja `texplain: true`, kuten dokumentoitu virallisissa [TIM-ohjeissa](https://tim.jyu.fi/view/tim/ohjeita/tulostusohje#885vK1R0UCnA), mutta toiminnallisuus katosi myöhemmin tehtyjen koodimuutosten myötä.

Toiminnallisuudelle on kuitenkin edelleen joitakin käyttötapauksia, joten tämä PR lisää dokumenttiasetuksen `allow_texplain_macros`, joka mahdollistaa aikaisemman käytöksen hyödyntämisen.

Huomioita:
Vain 'normaali' makromerkintä `%%` toimii, Jinja2-makrojen käyttämät `{%` ja `%}` rikkovat tulostuksen.
