### PR TITLE
check target by regexp

### DIFF
--- a/timApp/modules/imagex/imagex.py
+++ b/timApp/modules/imagex/imagex.py
@@ -4,6 +4,7 @@ See: https://tim.jyu.fi/view/tim/TIMin%20kehitys/Plugin%20development
 Serving from local port 5000
 """
 import json
+import re
 
 from geometry import is_inside
 
@@ -227,7 +228,7 @@ class ImagexServer(TimServer):
                 if tries < max_tries:
                     for selectkey in target["points"].keys():
                         for drag in drags:
-                            if drag["id"] == selectkey:
+                            if re.fullmatch(selectkey, drag["id"]):
                                 # Check if needed values exist for target. If they dont, read them from defaults
                                 # or first target. # TODO: NOT FROM FIRST!!!
                                 # Check if image is inside target, award points.


### PR DESCRIPTION
Muutin imagex:ssä sen, millä targetissa annetaan pisteitä regexpiksi jotta voi kirjoittaa

```
targets: 
  -  id: "target1"
    color: "red"
    snapColor: "black"
    position: [100, 300]
    size: [40, 20]
    points: {"kuva.*": 0.5}
```
ja näin voi lyhentää points-attribuuttia joissakin tapauksissa kun nimeään raahattavat fiksusti.