### PR TITLE
examGroupManager: Fix exam group manager logincode perms

### DIFF
--- a/timApp/static/scripts/tim/plugin/examGroupManager/exam-group-manager.component.ts
+++ b/timApp/static/scripts/tim/plugin/examGroupManager/exam-group-manager.component.ts
@@ -1200,8 +1200,7 @@ export class ExamGroupManagerComponent
         const res = await toPromise(
             this.http.post("/examGroupManager/generateCodes", {
                 group_id: group.id,
-                // only send a list of selected members, empty list if all members are selected
-                users: members.length < group.memberCount ? members : [],
+                users: members.map((m) => m.id),
             })
         );
 


### PR DESCRIPTION
If a user is created while the exam is running, their login code was not activated previously. This fixes the issue by syncing new user's exam state to the state of the entire group by running the same activation/deactivation pipeline as for all users.

Also

- Revert to the previous logic where by default the button resets the codes for all users for the sake of clarity of UI; the checkboxes still allow resetting a specific code
- Send only the user IDs of the users for which to regenerate the login keys instead of sending all the data

@saviit 