### PR TITLE
upload name can be fixed

### DIFF
--- a/timApp/modules/cs/js/csPlugin.ts
+++ b/timApp/modules/cs/js/csPlugin.ts
@@ -776,6 +776,7 @@ const CsMarkupOptional = t.partial({
     resetUserInput: t.boolean,
     uploadAcceptPattern: t.string,
     uploadAcceptMaxSize: t.number,
+    forceUploadName: t.string,
     showAlwaysSavedText: t.boolean,
     startLineNumber: t.number,
     targetCanvas: t.string,
@@ -1513,6 +1514,7 @@ export class CsController extends CsBase implements ITimComponent {
         component.allowMultiple = this.markup.allowMultipleFiles;
         component.accept = this.markup.uploadAcceptPattern;
         component.maxSize = this.markup.uploadAcceptMaxSize;
+        component.forceUploadName = this.markup.forceUploadName;
         component.multipleElements = this.markup.multipleUploadElements;
         component.files = files;
     }

--- a/timApp/modules/cs/js/util/file-select.ts
+++ b/timApp/modules/cs/js/util/file-select.ts
@@ -13,6 +13,7 @@ import {
 import type {HttpErrorResponse} from "@angular/common/http";
 import {HttpClient, HttpEventType} from "@angular/common/http";
 import {defaultWuffMessage} from "tim/util/utils";
+import {HttpParams} from "@angular/common/http";
 import {NotificationComponent} from "./notification";
 import {sizeString, timeString} from "./util";
 import {Set} from "./set";
@@ -123,6 +124,7 @@ export class FileSelectComponent {
     @Input() dragAndDrop: boolean = true;
     @Input() stem?: string;
     @Input() uploadUrl?: string;
+    @Input() forceUploadName?: string;
     @Input() maxSize: number = -1;
     @Input() mappingFunction?: MappingFunction;
     @Output("file") fileEmitter: EventEmitter<IFile> = new EventEmitter(true);
@@ -222,10 +224,17 @@ export class FileSelectComponent {
                         10000
                     );
                 }
+                let params = new HttpParams();
+                if (this.forceUploadName) {
+                    params = params
+                        .set("index", String(i))
+                        .set("forceUploadName", this.forceUploadName);
+                }
                 const _ = this.http
                     .post(this.uploadUrl!, formdata, {
                         reportProgress: true,
                         observe: "events",
+                        params: params,
                     })
                     .subscribe(
                         (event) => {
@@ -424,6 +433,7 @@ export class FileSelectComponent {
             [id]="info.id"
             [multiple]="allowMultiple || (fileInfo.length > 1 && (files.length > 1 || files[0].paths.length > 1))"
             [uploadUrl]="uploadUrl"
+            [forceUploadName]="forceUploadName"
             (file)="onFileLoad($event)"
             (files)="filesEmitter.emit($event)"
             (upload)="uploadEmitter.emit($event)"
@@ -438,6 +448,7 @@ export class FileSelectManagerComponent {
     @Input() allowMultiple: boolean = true;
     @Input() dragAndDrop: boolean = true;
     @Input() uploadUrl?: string;
+    @Input() forceUploadName?: string;
     @Input() stem?: string;
     @Input() maxSize: number = -1;
     @Input() accept?: string;

--- a/timApp/upload/upload.py
+++ b/timApp/upload/upload.py
@@ -272,13 +272,24 @@ def pluginupload_file(doc_id: int, task_id: str):
     file = request.files.get("file")
     if file is None:
         raise RouteException("Missing file")
+    force_upload_name = request.args.get("forceUploadName")
+    force_index = request.args.get("index")
     content = file.read()
     u = get_current_user_object()
+    filename = file.filename
+    if force_upload_name:
+        file_extension = Path(filename).suffix
+        filename = force_upload_name
+        if force_index and force_index != "0":
+            filename += f"_{force_index}"
+        filename += file_extension
+
     f = UploadedFile.save_new(
-        file.filename,
+        filename,
         BlockType.Upload,
         file_data=content,
         upload_info=PluginUploadInfo(task_id_name=task_id, user=u, doc=d),
+        forced_name=bool(force_upload_name),
     )
     f.block.set_owner(u.get_personal_group())
     grant_access_to_session_users(f)


### PR DESCRIPTION
Antaa mahdollisuuden pakottaa tietty tiedoston nimi kun tiedostoja ladataan.
Käyttötapaus esimerkiksi kun valintojen haastatteludokumentissa on

      forceUploadName: %%group%%

ja group edustaa yhtä opiskelijaa.  Silloin kun ladataan haastatteluvideo opettajannäkymässä, niin
sille saadaan aina oikea nimi ilman haastattelijan lisätoimia riippumatta siitä, mikä nimi tiedostolla
on alunperin.

