### PR TITLE
Feature par edit user list

### DIFF
--- a/timApp/document/changelog.py
+++ b/timApp/document/changelog.py
@@ -24,6 +24,7 @@ class AuthorInfo:
         self,
         user_map: dict[int, Union["User", "UserGroup"]],
         entries: dict[int, list[ChangelogEntry]],
+        hide: bool = False,
     ) -> None:
         self.authors: dict[Union["User", "UserGroup"], list[ChangelogEntry]] = {}
         for k, v in entries.items():

--- a/timApp/document/docsettings.py
+++ b/timApp/document/docsettings.py
@@ -165,6 +165,7 @@ class DocSettings:
     print_settings_key = "print_settings"
     preamble_key = "preamble"
     show_authors_key = "show_authors"
+    par_author_only_edit_key = "parAuthorOnlyEdit"
     read_expiry_key = "read_expiry"
     add_par_button_text_key = "add_par_button_text"
     mathtype_key = "math_type"
@@ -521,6 +522,9 @@ class DocSettings:
 
     def show_authors(self, default=False):
         return self.__dict.get(self.show_authors_key, default)
+
+    def par_author_only_edit(self, default=False):
+        return self.__dict.get(self.par_author_only_edit_key, default)
 
     def read_expiry(self, default=timedelta(weeks=9999)) -> timedelta:
         r = self.__dict.get(self.read_expiry_key)

--- a/timApp/document/editing/routes.py
+++ b/timApp/document/editing/routes.py
@@ -23,6 +23,7 @@ from timApp.auth.accesshelper import (
     has_edit_access,
     verify_route_access,
     verify_logged_in,
+    verify_copy_access,
 )
 from timApp.auth.get_user_rights_for_item import get_user_rights_for_item
 from timApp.auth.sessioninfo import (
@@ -338,14 +339,28 @@ def modify_paragraph():
 
 
 def verify_par_edit_access(par: DocParagraph):
-    """Verifies that the current user has edit access to the specified DocParagraph."""
+    """
+    Verifies that the current user has edit access
+    to the specified DocParagraph.
+    User can edit if
+      - he is owner of the document
+      - in edit attribute there is a group that the user is in
+      - in edit attribute there is a right that the user has
+      - document is set to parAuthorOnlyEdit and the user
+        is the author of the paragraph
+    Else: Even the user has normal edit right, if the document is set to
+    parAuthorOnlyEdit and the user is not the author of the paragraph,
+    he can't edit.
+    :param par: The DocParagraph for which to verify edit access.
+    :raises AccessDenied: If the user does not have edit access to the paragraph.
+    """
     d = par.doc.get_docinfo()
     if verify_ownership(d, require=False):  # Owners can always edit
         return
 
     edit_attrs = par.get_attr("edit", "edit")
     attrs = [a.strip() for a in edit_attrs.split(",")] if edit_attrs else []
-    known = {"view", "edit", "teacher", "see_answers", "manage", "owner"}
+    known = {"view", "copy", "edit", "teacher", "see_answers", "manage", "owner"}
     access_attrs = [a for a in attrs if a in known]
     group_attrs = [a for a in attrs if a not in known]
     groups = []
@@ -365,6 +380,7 @@ def verify_par_edit_access(par: DocParagraph):
     # can edit it. This overrides any other access attributes.
     doc = par.doc
     settings = doc.get_settings()
+    par_author_needed = False
     if settings and settings.par_author_only_edit():
         authors = doc.get_changelog(-1).get_authorinfo([par])
         par_authors_info = authors.get(par.get_id(), None)
@@ -372,9 +388,7 @@ def verify_par_edit_access(par: DocParagraph):
             par_authors = par_authors_info.username_list
             if get_current_user_object().name in par_authors:
                 return
-            raise RouteException(
-                f"Not the original editor for paragraph {par.get_id()}!"
-            )
+            par_author_needed = True
 
     if not access_attrs:
         access_attrs = ["owner"]
@@ -382,6 +396,9 @@ def verify_par_edit_access(par: DocParagraph):
         message = f"Only users with {edit_attr} access can edit this paragraph ({par.get_id()})."
         if edit_attr == "view":
             verify_view_access(d, message=message)
+            return
+        if edit_attr == "copy":
+            verify_copy_access(d, message=message)
             return
         if edit_attr == "edit":
             verify_edit_access(d, message=message)
@@ -399,8 +416,10 @@ def verify_par_edit_access(par: DocParagraph):
             verify_ownership(d, message=message)
             return
 
+    if par_author_needed:
+        raise RouteException(f"Not the original editor for paragraph {par.get_id()}!")
     if not group_access:
-        raise RouteException(f"No edit access")
+        raise RouteException(f"No edit access for paragraph {par.get_id()}!")
 
 
 def modify_paragraph_common(doc_id: int, md: str, par_id: str, par_next_id: str | None):

--- a/timApp/document/editing/routes.py
+++ b/timApp/document/editing/routes.py
@@ -339,26 +339,73 @@ def modify_paragraph():
 
 def verify_par_edit_access(par: DocParagraph):
     """Verifies that the current user has edit access to the specified DocParagraph."""
-    edit_attr = par.get_attr("edit", "edit")
-    message = (
-        f"Only users with {edit_attr} access can edit this paragraph ({par.get_id()})."
-    )
     d = par.doc.get_docinfo()
-    if edit_attr == "edit":
-        verify_edit_access(d, message=message)
-    elif edit_attr == "teacher":
-        verify_teacher_access(d, message=message)
-    elif edit_attr == "see_answers":
-        verify_seeanswers_access(d, message=message)
-    elif edit_attr == "manage":
-        verify_manage_access(d, message=message)
-    elif edit_attr == "owner":
-        verify_ownership(d, message=message)
+    if verify_ownership(d, require=False):  # Owners can always edit
+        return
+
+    edit_attrs = par.get_attr("edit", "edit")
+    attrs = [a.strip() for a in edit_attrs.split(",")] if edit_attrs else []
+    known = {"view", "edit", "teacher", "see_answers", "manage", "owner"}
+    access_attrs = [a for a in attrs if a in known]
+    group_attrs = [a for a in attrs if a not in known]
+    groups = []
+    group_access = True
+    if group_attrs:
+        group_access = False
+        groups = get_current_user_object().effective_groups
+
+    # If the user has at least one of the group accesses, they have
+    # edit access to the paragraph. Otherwise, we check the other access attributes.
+    for edit_attr in group_attrs:
+        b = any(gr.name == edit_attr for gr in groups)
+        if b:
+            return
+
+    # If parAuthorOnlyEdit is set, only the owner of the paragraph
+    # can edit it. This overrides any other access attributes.
+    doc = par.doc
+    settings = doc.get_settings()
+    if settings and settings.par_author_only_edit():
+        authors = doc.get_changelog(-1).get_authorinfo([par])
+        par_authors_info = authors.get(par.get_id(), None)
+        if par_authors_info:
+            par_authors = par_authors_info.username_list
+            if get_current_user_object().name in par_authors:
+                return
+            raise RouteException(
+                f"Not the original editor for paragraph {par.get_id()}!"
+            )
+
+    if not access_attrs:
+        access_attrs = ["owner"]
+    for edit_attr in access_attrs:
+        message = f"Only users with {edit_attr} access can edit this paragraph ({par.get_id()})."
+        if edit_attr == "view":
+            verify_view_access(d, message=message)
+            return
+        if edit_attr == "edit":
+            verify_edit_access(d, message=message)
+            return
+        elif edit_attr == "teacher":
+            verify_teacher_access(d, message=message)
+            return
+        elif edit_attr == "see_answers":
+            verify_seeanswers_access(d, message=message)
+            return
+        elif edit_attr == "manage":
+            verify_manage_access(d, message=message)
+            return
+        elif edit_attr == "owner":
+            verify_ownership(d, message=message)
+            return
+
+    if not group_access:
+        raise RouteException(f"No edit access")
 
 
 def modify_paragraph_common(doc_id: int, md: str, par_id: str, par_next_id: str | None):
     docinfo = get_doc_or_abort(doc_id)
-    verify_edit_access(docinfo)
+    # verify_edit_access(docinfo)
 
     doc = docinfo.document_as_current_user
 

--- a/timApp/document/post_process.py
+++ b/timApp/document/post_process.py
@@ -121,7 +121,8 @@ def post_process_pars(
             has_plugin_errors=presult.has_errors,
         )
 
-    if settings.show_authors():
+    if settings.show_authors() or settings.par_author_only_edit():
+        hide = not settings.show_authors()
         hide_authors = view_ctx.hide_names_requested
         authors = doc.get_changelog(-1).get_authorinfo(pars)
         if hide_authors:
@@ -132,6 +133,8 @@ def post_process_pars(
         for p in final_pars:
             ppar = p.prepare(view_ctx)
             ppar.authorinfo = authors.get(ppar.id)
+            if hide:
+                ppar.authorinfo.hide = True
     # There can be several references of the same paragraph in the document, which is why we need a dict of lists
     pars_dict: DefaultDict[tuple[str, int], list[PreparedPar]] = defaultdict(list)
 

--- a/timApp/document/routes.py
+++ b/timApp/document/routes.py
@@ -106,7 +106,12 @@ def get_block_2(args: GetBlockModel):
         try:
             p = d.document.get_paragraph(args.par_id)
             if not can_see_par_source(get_current_user_object(), p):
-                raise AccessDenied()
+                try:
+                    from timApp.document.editing.routes import verify_par_edit_access
+
+                    verify_par_edit_access(p)
+                except AccessDenied:
+                    raise AccessDenied()
             if args.par_hash:
                 par = DocParagraph.get(
                     d.document, args.par_id, args.par_hash or p.get_hash()

--- a/timApp/static/scripts/tim/document/editing/editing.ts
+++ b/timApp/static/scripts/tim/document/editing/editing.ts
@@ -738,7 +738,10 @@ auto_number_headings: 0${CURSOR}
         return this.viewctrl.getParMenuEntry(par)?.getMenuEntry();
     }
 
-    getViewSourceEditorMenuEntry(par: ParContext): IMenuFunctionEntry {
+    getViewSourceEditorMenuEntry(
+        par: ParContext,
+        parEditable: boolean = false
+    ): IMenuFunctionEntry {
         return {
             desc: "View source",
             func: async () => {
@@ -755,7 +758,7 @@ auto_number_headings: 0${CURSOR}
                     await showMessageDialog("Failed to get paragraph markdown");
                 }
             },
-            show: canSeeSource(this.viewctrl.item, par),
+            show: parEditable || canSeeSource(this.viewctrl.item, par),
         };
     }
 
@@ -771,7 +774,7 @@ auto_number_headings: 0${CURSOR}
         const qstPar = this.isQST(par);
         const customParMenuEntry = this.getParMenuEntry(par, parEditable);
         const fns: MenuFunctionList = [];
-        fns.push(this.getViewSourceEditorMenuEntry(par));
+        fns.push(this.getViewSourceEditorMenuEntry(par, parEditable));
         const showSingleParFns = par.isDeletableOnItsOwn();
         const isTranslation = this.viewctrl.isTranslation();
         const {areasBeforeRef, areasAfterRef, refAreaInclusion} =

--- a/timApp/static/scripts/tim/document/parhelpers.ts
+++ b/timApp/static/scripts/tim/document/parhelpers.ts
@@ -43,7 +43,7 @@ export function addElementToParagraphMargin(par: ParContext, el: Element) {
  */
 export function canEditPar(item: IItem, par: ParContext) {
     if (item.rights.owner) {
-        return true; // Owner is allways allowed to edit
+        return true; // Owner is always allowed to edit
     }
     let res: boolean = false;
     const editRaw = par.par.attrs.edit ?? "";

--- a/timApp/static/scripts/tim/document/parhelpers.ts
+++ b/timApp/static/scripts/tim/document/parhelpers.ts
@@ -25,20 +25,52 @@ export function addElementToParagraphMargin(par: ParContext, el: Element) {
     container.appendChild(el);
 }
 
+/**
+ * Checks if the user can edit the paragraph based on the
+ * edit attribute and document settings.
+ *
+ * @param item - The item containing the paragraph
+ * @param par - The paragraph context to check
+ * @returns true if the user can edit the paragraph, false otherwise
+ */
 export function canEditPar(item: IItem, par: ParContext) {
-    const edit = par.par.attrs.edit;
-    let res: boolean;
-    if (!RightNames.is(edit)) {
-        res = item.rights.editable;
-    } else {
-        res = item.rights[edit];
+    const editRaw = par.par.attrs.edit ?? "edit";
+    const edits = editRaw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+    const user = Users.getCurrent();
+    const groups = user.groups;
+    let res: boolean = false;
+    for (const edit of edits) {
+        if (!RightNames.is(edit)) {
+            res = item.rights.editable;
+        } else {
+            res = item.rights[edit];
+        }
+        if (edit === "view") {
+            res = true;
+        }
+        if (res) {
+            break;
+        }
+
+        if (groups.some((g) => g.name === edit)) {
+            return true;
+        }
     }
 
     const globals = someglobals();
     if (isDocumentGlobals(globals) && globals.docSettings.parAuthorOnlyEdit) {
         const authorInfo = par.getAuthorInfo();
-        const userName = Users.getCurrent().name;
-        if (!item.rights.owner && !authorInfo?.usernames?.includes(userName)) {
+        if (!authorInfo) {
+            return res;
+        }
+        if (authorInfo?.usernames?.includes(user.name)) {
+            return true;
+        }
+        if (!item.rights.owner) {
             res = false;
         }
     }

--- a/timApp/static/scripts/tim/document/parhelpers.ts
+++ b/timApp/static/scripts/tim/document/parhelpers.ts
@@ -28,39 +28,77 @@ export function addElementToParagraphMargin(par: ParContext, el: Element) {
 /**
  * Checks if the user can edit the paragraph based on the
  * edit attribute and document settings.
- *
+ * User can edit if
+ *   - he is owner of the document
+ *   - in edit attribute there is a group that the user is in
+ *   - in edit attribute there is a right that the user has
+ *   - document is set to parAuthorOnlyEdit and the user
+ *     is the author of the paragraph
+ * Else: Even the user has normal edit right, if the document is set to
+ * parAuthorOnlyEdit and the user is not the author of the paragraph,
+ * he can't edit.
  * @param item - The item containing the paragraph
  * @param par - The paragraph context to check
  * @returns true if the user can edit the paragraph, false otherwise
  */
 export function canEditPar(item: IItem, par: ParContext) {
-    const editRaw = par.par.attrs.edit ?? "edit";
-    const edits = editRaw
-        .split(",")
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-
-    const user = Users.getCurrent();
-    const groups = user.groups;
+    if (item.rights.owner) {
+        return true; // Owner is allways allowed to edit
+    }
     let res: boolean = false;
-    for (const edit of edits) {
-        if (!RightNames.is(edit)) {
-            res = item.rights.editable;
-        } else {
-            res = item.rights[edit];
+    const editRaw = par.par.attrs.edit ?? "";
+    const user = Users.getCurrent();
+    res = item.rights.editable;
+    if (editRaw !== "") {
+        const edits = editRaw
+            .split(",")
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+
+        const knownEdits: string[] = [];
+        const groupEdits: string[] = [];
+        for (const e of edits) {
+            if (RightNames.is(e) || e === "view" || e === "edit") {
+                knownEdits.push(e);
+            } else {
+                groupEdits.push(e);
+            }
         }
-        if (edit === "view") {
-            res = true;
-        }
-        if (res) {
-            break;
+        const groups = user.groups;
+        for (const edit of groupEdits) {
+            // groups are checked first, because if the user is in a group
+            // that has edit rights,
+            // they should be able to edit even if they don't have the right directly
+            if (groups.some((g) => g.name === edit)) {
+                return true;
+            }
         }
 
-        if (groups.some((g) => g.name === edit)) {
-            return true;
+        // if there are no group edits, check the known edits
+        for (const edit of knownEdits) {
+            if (RightNames.is(edit)) {
+                res = item.rights[edit];
+            }
+            if (edit === "view") {
+                // if the user can view, he has view right
+                res = true;
+            }
+            if (edit === "edit" && item.rights.editable) {
+                // if the user can edit, he has edit right
+                res = true;
+            }
+            if (res) {
+                return true;
+            }
         }
+        res = false;
     }
 
+    // If the document is set to parAuthorOnlyEdit,
+    // only the author of the paragraph can edit it.
+    // The author can edit even there is no edit right,
+    // but if the user is not the author, they can't edit
+    // even if they have the edit right.
     const globals = someglobals();
     if (isDocumentGlobals(globals) && globals.docSettings.parAuthorOnlyEdit) {
         const authorInfo = par.getAuthorInfo();

--- a/timApp/templates/partials/paragraphs.jinja2
+++ b/timApp/templates/partials/paragraphs.jinja2
@@ -108,9 +108,11 @@
         </div>
         {%- if t.authorinfo -%}
         <div class="authorinfo" data-usernames="{{ t.authorinfo.username_list }}">
+        {%- if not t.authorinfo.hide -%}
         <i class="glyphicon glyphicon-pencil"></i>
         <span class="username">{{t.authorinfo.display_name}}</span>
         <span class="timestamp">{{ t.authorinfo.time|datestr_to_relative }}</span>
+        {%- endif -%}
         </div>
         {%- endif -%}
 


### PR DESCRIPTION
Lisää seuraavat ominaisuudet:

lohko edit attribtuuttii voi luetella oikeuksien lisäksi myös ryhmiä (ja koska jokainen
on oman ryhmänsä jäsne, myös henkilöitä):

      #- {edit="teacher, vesal, akankka}
     
Oikeus voittaa dokumentin asetuksen, eli vaikka ei olisi edit oikeutta, voi tuollaista lohkoa muokata.

 Dokumentin asetus:
 
      parAuthorOnlyEdit: true       
      
toimii myös ilman nimein näyttämistä (tosin kuten nimiennäyttämisessä, vuotaa muokkaijien tietoja
selaimeen, josa tämän haluaisi  pois, pitäisi oikeus kysyä aina palvelimelta).  Tosin nyt myös palvelimella
tarkistetaan oikeus vaikka olisi selaimessa "huijannut".   Myös tässä jos on lohoa muokannut ja dokun
edit oikeus otetaan pois, voi vielä omaansa muokata. Jos tuo parAuthorOnlyEdit: true otetaan
pois, sitten ei voi enää muokata jos ei ole dokun edit-oikeutta.

Käyttötapauksia:

- keskustelupalstat
- ehkä tuleva graduohjaajien ja aiheiden sivusto

Voi kokeilla esim:  <https://tim02.it.jyu.fi/view/users/vesal/koe/editor/editrules>
      