### PR TITLE
New filter tz,  to add timezone information to given datetime

### DIFF
--- a/timApp/markdown/markdownconverter.py
+++ b/timApp/markdown/markdownconverter.py
@@ -6,6 +6,7 @@ import random
 import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from dateutil import parser
 from re import Pattern
 from typing import TYPE_CHECKING, Iterable, Any
@@ -434,6 +435,20 @@ def preinc(v, delta=1):
     return v[0]
 
 
+def timezone_filter(s: Any, timezone: Any = None) -> Any:
+    if timezone is None:
+        return s
+    try:
+        dt = datetime.fromisoformat(str(s))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=ZoneInfo(timezone))
+        return dt
+    except ValueError:
+        return s
+    except ZoneInfoNotFoundError:
+        return s
+
+
 # ------------------------ Jinja filters end ---------------------------------------------------------------
 
 
@@ -729,6 +744,7 @@ tim_filters = {
     "endvalue": end_value,
     "shuffle": shuffle,
     "hasrights": placeholder_filter("hasrights"),
+    "tz": timezone_filter,
     "userdata": placeholder_filter("userdata"),
 }
 


### PR DESCRIPTION
This pull request adds a new filter **tz**,  for converting a given datetime to contain timezone information. The filter uses a given timezone to return a new datetime isostring. It can take into account the daylight saving time.

Usage example:
```
"2026-03-11" | tz("Europe/Helsinki")
>> 2026-03-11 10:00:00+02:00

"2026-04-11 10:00" | tz("Europe/Helsinki")
>> 2026-04-11 10:00:00+03:00
```
Returns the original string if datetime is not in isoformat, or timezone is not found.