### PR TITLE
Feature: add transcript search feature for videos with timestamp jumps

### DIFF
--- a/timApp/modules/svn/js/video.component.scss
+++ b/timApp/modules/svn/js/video.component.scss
@@ -207,9 +207,18 @@
     margin-top: 0.5em;
 }
 
-.transcript-search-input {
-    max-width: 400px;
+.transcript-search-row {
+    display: flex;
+    gap: 0.5em;
     margin-bottom: 0.5em;
+}
+
+.transcript-search-input {
+    max-width: 300px;
+}
+
+.transcript-subtitle-select {
+    max-width: 200px;
 }
 
 .transcript-search-results {

--- a/timApp/modules/svn/js/video.component.scss
+++ b/timApp/modules/svn/js/video.component.scss
@@ -188,3 +188,60 @@
         height: 40px;
     }
 }
+
+.transcript-search {
+    margin-top: 0.5em;
+}
+
+.transcript-toggle {
+    cursor: pointer;
+    user-select: none;
+
+    .glyphicon {
+        font-size: 0.8em;
+        margin-right: 0.3em;
+    }
+}
+
+.transcript-search-panel {
+    margin-top: 0.5em;
+}
+
+.transcript-search-input {
+    max-width: 400px;
+    margin-bottom: 0.5em;
+}
+
+.transcript-search-results {
+    max-height: 300px;
+    overflow-y: auto;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+.transcript-result-item {
+    padding: 0.4em 0.6em;
+    cursor: pointer;
+    border-bottom: 1px solid #eee;
+
+    &:last-child {
+        border-bottom: none;
+    }
+
+    &:hover {
+        background-color: #f5f5f5;
+    }
+}
+
+.transcript-search .timestamp {
+    font-family: monospace;
+    color: #337ab7;
+    margin-right: 0.6em;
+    white-space: nowrap;
+}
+
+.transcript-no-results {
+    color: #999;
+    font-style: italic;
+    padding: 0.4em 0;
+}

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -122,7 +122,7 @@ const ShowFileMarkup = t.intersection([
         endJSRunner: t.string,
         audio: t.boolean,
         nolimits: t.boolean,
-        transcriptFile: nullable(t.string),
+        transcriptSearch: t.boolean,
         transcriptPlaceholder: nullable(t.string),
         transcriptMaxResults: nullable(t.number),
     }),
@@ -334,13 +334,22 @@ const ShowFileAll = t.type({
                     Transcript Search
                 </a>
                 <div *ngIf="transcriptOpen" class="transcript-search-panel">
-                    <input type="text"
-                           class="form-control transcript-search-input"
-                           [(ngModel)]="transcriptQuery"
-                           (ngModelChange)="onTranscriptSearch()"
-                           (keydown)="$event.stopPropagation()"
-                           [attr.placeholder]="markup.transcriptPlaceholder ?? 'Search transcript...'"
-                    >
+                    <div class="transcript-search-row">
+                        <input type="text"
+                               class="form-control transcript-search-input"
+                               [(ngModel)]="transcriptQuery"
+                               (ngModelChange)="onTranscriptSearch()"
+                               (keydown)="$event.stopPropagation()"
+                               [attr.placeholder]="markup.transcriptPlaceholder ?? 'Search transcript...'"
+                        >
+                        <select *ngIf="transcriptSubtitleMap.size > 1"
+                                class="form-control transcript-subtitle-select"
+                                [(ngModel)]="selectedTranscriptName"
+                                (ngModelChange)="onTranscriptSubtitleChange()"
+                                (keydown)="$event.stopPropagation()">
+                            <option *ngFor="let name of transcriptSubtitleMap.keys()" [value]="name">{{name}}</option>
+                        </select>
+                    </div>
                     <div class="transcript-search-results" *ngIf="filteredCues.length > 0">
                         <div class="transcript-result-item"
                              *ngFor="let cue of filteredCues"
@@ -437,7 +446,8 @@ export class VideoComponent extends AngularPluginBase<
     hidetext: string = "Hide file";
     srcUrl!: URL;
     src: string = "";
-    transcriptCues: VttCue[] = [];
+    transcriptSubtitleMap = new Map<string, VttCue[]>();
+    selectedTranscriptName = "";
     transcriptQuery = "";
     filteredCues: VttCue[] = [];
     transcriptOpen = false;
@@ -515,12 +525,29 @@ export class VideoComponent extends AngularPluginBase<
             this.videoName = $localize`Open embedded content`;
         }
 
-        if (this.markup.transcriptFile) {
+        if (this.markup.transcriptSearch === false) {
+            return;
+        }
+        for (const subtitle of this.markup.subtitles) {
+            if (!subtitle.file) {
+                continue;
+            }
             this.http
-                .get(this.markup.transcriptFile, {responseType: "text"})
+                .get(subtitle.file, {responseType: "text"})
                 .subscribe((content) => {
-                    this.transcriptCues = parseVtt(content);
-                    this.transcriptLoaded = true;
+                    const label = subtitle.name || subtitle.file;
+                    this.transcriptSubtitleMap.set(label, parseVtt(content));
+                    if (!this.transcriptLoaded) {
+                        const defaultMatch = this.markup.subtitles.find(
+                            (s) =>
+                                s.name === this.markup.defaultSubtitles ||
+                                s.file === this.markup.defaultSubtitles
+                        );
+                        this.selectedTranscriptName =
+                            (defaultMatch?.name || defaultMatch?.file) ??
+                            label;
+                        this.transcriptLoaded = true;
+                    }
                 });
         }
     }
@@ -895,11 +922,13 @@ export class VideoComponent extends AngularPluginBase<
             this.filteredCues = [];
             return;
         }
+        const cues =
+            this.transcriptSubtitleMap.get(this.selectedTranscriptName) ?? [];
         const maxResults = this.markup.transcriptMaxResults ?? 50;
         const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const re = new RegExp(escaped, "gi");
         const results: VttCue[] = [];
-        for (const cue of this.transcriptCues) {
+        for (const cue of cues) {
             if (results.length >= maxResults) {
                 break;
             }
@@ -914,6 +943,11 @@ export class VideoComponent extends AngularPluginBase<
             }
         }
         this.filteredCues = results;
+    }
+
+    onTranscriptSubtitleChange() {
+        this.transcriptQuery = "";
+        this.filteredCues = [];
     }
 
     seekTo(seconds: number) {

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -544,7 +544,7 @@ export class VideoComponent extends AngularPluginBase<
                                 s.file === this.markup.defaultSubtitles
                         );
                         this.selectedTranscriptName =
-                            (defaultMatch?.name || defaultMatch?.file) ??
+                            (defaultMatch?.name ?? defaultMatch?.file) ??
                             label;
                         this.transcriptLoaded = true;
                     }

--- a/timApp/modules/svn/js/video.component.ts
+++ b/timApp/modules/svn/js/video.component.ts
@@ -28,6 +28,8 @@ import {Users} from "tim/user/userService";
 import type {IUser} from "tim/user/IUser";
 import type {Iframesettings} from "../../cs/js/jsframe";
 import {VideoLinkComponent} from "./video-link.component";
+import type {VttCue} from "./vtt-parser";
+import {parseVtt} from "./vtt-parser";
 
 function toSeconds(value: string | number | undefined): number | undefined {
     if (value === null || value === undefined) {
@@ -120,6 +122,9 @@ const ShowFileMarkup = t.intersection([
         endJSRunner: t.string,
         audio: t.boolean,
         nolimits: t.boolean,
+        transcriptFile: nullable(t.string),
+        transcriptPlaceholder: nullable(t.string),
+        transcriptMaxResults: nullable(t.number),
     }),
     GenericPluginMarkup,
     t.type({
@@ -321,6 +326,34 @@ const ShowFileAll = t.type({
                 <a (click)="copyStartEnd()" title="Copy start/end to clipboard (c)">Copy</a>
             </div>
             <p class="plgfooter" *ngIf="footer" [innerHtml]="footer | purify"></p>
+            <div *ngIf="transcriptLoaded" class="transcript-search">
+                <a class="transcript-toggle" (click)="transcriptOpen = !transcriptOpen">
+                    <i class="glyphicon"
+                       [class.glyphicon-chevron-right]="!transcriptOpen"
+                       [class.glyphicon-chevron-down]="transcriptOpen"></i>
+                    Transcript Search
+                </a>
+                <div *ngIf="transcriptOpen" class="transcript-search-panel">
+                    <input type="text"
+                           class="form-control transcript-search-input"
+                           [(ngModel)]="transcriptQuery"
+                           (ngModelChange)="onTranscriptSearch()"
+                           (keydown)="$event.stopPropagation()"
+                           [attr.placeholder]="markup.transcriptPlaceholder ?? 'Search transcript...'"
+                    >
+                    <div class="transcript-search-results" *ngIf="filteredCues.length > 0">
+                        <div class="transcript-result-item"
+                             *ngFor="let cue of filteredCues"
+                             (click)="seekTo(cue.startSeconds)">
+                            <span class="timestamp">{{cue.startTime}}</span>
+                            <span [innerHTML]="cue.highlightedText | purify"></span>
+                        </div>
+                    </div>
+                    <div *ngIf="transcriptQuery && filteredCues.length === 0" class="transcript-no-results">
+                        No results found.
+                    </div>
+                </div>
+            </div>
         </div>
     `,
     styleUrls: ["./video.component.scss"],
@@ -404,6 +437,11 @@ export class VideoComponent extends AngularPluginBase<
     hidetext: string = "Hide file";
     srcUrl!: URL;
     src: string = "";
+    transcriptCues: VttCue[] = [];
+    transcriptQuery = "";
+    filteredCues: VttCue[] = [];
+    transcriptOpen = false;
+    transcriptLoaded = false;
 
     onAdvVideoStateChange(newValue: boolean) {
         this.advVideoState.set(newValue);
@@ -475,6 +513,15 @@ export class VideoComponent extends AngularPluginBase<
             this.toggleVideo();
         } else if (!this.videoName && !this.doctext) {
             this.videoName = $localize`Open embedded content`;
+        }
+
+        if (this.markup.transcriptFile) {
+            this.http
+                .get(this.markup.transcriptFile, {responseType: "text"})
+                .subscribe((content) => {
+                    this.transcriptCues = parseVtt(content);
+                    this.transcriptLoaded = true;
+                });
         }
     }
 
@@ -840,6 +887,46 @@ export class VideoComponent extends AngularPluginBase<
             );
         }
         // this.vctrl.runJsRunner();
+    }
+
+    onTranscriptSearch() {
+        const query = this.transcriptQuery.trim().toLowerCase();
+        if (!query) {
+            this.filteredCues = [];
+            return;
+        }
+        const maxResults = this.markup.transcriptMaxResults ?? 50;
+        const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const re = new RegExp(escaped, "gi");
+        const results: VttCue[] = [];
+        for (const cue of this.transcriptCues) {
+            if (results.length >= maxResults) {
+                break;
+            }
+            if (cue.text.toLowerCase().includes(query)) {
+                results.push({
+                    ...cue,
+                    highlightedText: cue.text.replace(
+                        re,
+                        (match) => `<mark>${match}</mark>`
+                    ),
+                });
+            }
+        }
+        this.filteredCues = results;
+    }
+
+    seekTo(seconds: number) {
+        if (!this.videoOn) {
+            this.toggleVideo();
+            setTimeout(() => {
+                if (this.video) {
+                    this.video.nativeElement.currentTime = seconds;
+                }
+            }, 200);
+        } else if (this.video) {
+            this.video.nativeElement.currentTime = seconds;
+        }
     }
 
     getDefaultMarkup() {

--- a/timApp/modules/svn/js/vtt-parser.ts
+++ b/timApp/modules/svn/js/vtt-parser.ts
@@ -1,0 +1,73 @@
+export interface VttCue {
+    startTime: string;
+    endTime: string;
+    startSeconds: number;
+    endSeconds: number;
+    text: string;
+    highlightedText: string;
+}
+
+export function parseVttTimestamp(ts: string): number {
+    const parts = ts.trim().split(":");
+    if (parts.length === 3) {
+        return (
+            parseFloat(parts[0]) * 3600 +
+            parseFloat(parts[1]) * 60 +
+            parseFloat(parts[2])
+        );
+    } else if (parts.length === 2) {
+        return parseFloat(parts[0]) * 60 + parseFloat(parts[1]);
+    }
+    return 0;
+}
+
+export function formatVttTimestamp(ts: string): string {
+    const seconds = parseVttTimestamp(ts);
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+    if (h > 0) {
+        return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+    }
+    return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function parseVtt(content: string): VttCue[] {
+    const cues: VttCue[] = [];
+    const blocks = content.replace(/\r\n/g, "\n").split(/\n\n+/);
+    for (const block of blocks) {
+        const lines = block.trim().split("\n");
+        let tsLineIndex = -1;
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].includes("-->")) {
+                tsLineIndex = i;
+                break;
+            }
+        }
+        if (tsLineIndex < 0) {
+            continue;
+        }
+        const tsParts = lines[tsLineIndex].split("-->");
+        if (tsParts.length < 2) {
+            continue;
+        }
+        const startTime = tsParts[0].trim();
+        const endTime = tsParts[1].trim().split(/\s/)[0];
+        const text = lines
+            .slice(tsLineIndex + 1)
+            .join(" ")
+            .trim();
+        if (!text) {
+            continue;
+        }
+        cues.push({
+            startTime: formatVttTimestamp(startTime),
+            endTime: formatVttTimestamp(endTime),
+            startSeconds: parseVttTimestamp(startTime),
+            endSeconds: parseVttTimestamp(endTime),
+            text,
+            highlightedText: text,
+        });
+    }
+    return cues;
+}

--- a/timApp/modules/svn/js/vtt-parser.ts
+++ b/timApp/modules/svn/js/vtt-parser.ts
@@ -27,7 +27,9 @@ export function formatVttTimestamp(ts: string): string {
     const m = Math.floor((seconds % 3600) / 60);
     const s = Math.floor(seconds % 60);
     if (h > 0) {
-        return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+        return `${h}:${m.toString().padStart(2, "0")}:${s
+            .toString()
+            .padStart(2, "0")}`;
     }
     return `${m}:${s.toString().padStart(2, "0")}`;
 }


### PR DESCRIPTION
## Motivation

I think recordings are fantastic but it sucks to search them. You might remember that "Yeah, the lecture was talking about this and that when they mentioned their pet guinea pigs.", but then searching the video for the occurrence of this can be troublesome. I usually download transcripts (if available) and search them in a text editor, or similar, when I need to find a specific part of a recording. I thought it would be convenient to have this feature directly on TIM, and since we can jump to timestamps already, I thought the integration would be a good enhancement, making TIM even nicer for students. Also, since Moniviestin can readily generate transcripts for recordings, these are pretty much automatically available in most cases. There is a short video clip at the end of the summary demonstrating this feature in practice.

I hope others will find this feature useful as well.

## Summary

- Add transcript search to the showVideo plugin, reusing the existing `subtitles` markup as the data source.
- When subtitles are configured, a collapsible "Transcript Search" panel appears below the video.
- Typing keywords filters matching cues with highlighted matches; clicking a result seeks the video to that timestamp.
- When multiple subtitles are configured, a dropdown lets users pick which one to search.
- VTT parsing logic is extracted to a separate `vtt-parser.ts` module for reuse and testability.

See the following clip for a demonstration:

https://github.com/user-attachments/assets/5808bc14-d0fe-4a98-a115-aecf034dde56

## Usage example

```yaml
```{plugin="showVideo"}
file: "https://example.com/lecture.mp4"
subtitles:
  - name: "English"
    file: "/files/123/en.vtt"
  - name: "Finnish"
    file: "/files/456/fi.vtt"
defaultSubtitles: "English"
```

The above uses the existing `subtitles` and `defaultSubtitles` fields. The following new markup options are also available:

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `transcriptSearch` | `boolean` | `true` (enabled) | Set to `false` to disable transcript search UI |
| `transcriptPlaceholder` | `string` | `"Search transcript..."` | Custom placeholder for the search input |
| `transcriptMaxResults` | `number` | `50` | Max results shown |

## Limitations

- Seeking only works with native `<video>`/`<audio>` elements, not YouTube/iframe embeds. But the search feature still works and users can manually skip to the timestamp in case of, e.g., YouTube videos.
- Only the VTT file format for timestamped transcripts is supported (generated by, e.g., Moniviestin).
- No tests were implemented, I could not find any setup for testing code for the frontend in the project.
    - But works on my machine!™