### PR TITLE
Fix test post program fields

### DIFF
--- a/timApp/tests/browser/test_postprogram_fields.py
+++ b/timApp/tests/browser/test_postprogram_fields.py
@@ -33,7 +33,8 @@ class PostProgramFieldsTest(BrowserTest):
     def test_postprogram_fields(self):
         self.login_test1()
 
-        d = self.create_doc(initial_par="""
+        d = self.create_doc(
+            initial_par="""
 ``` {#qst1 question="false" plugin="qst"}
 answerFieldType: radio
 expl: {}
@@ -75,7 +76,8 @@ postprogram: |!!
   return data;
 !!
 ```
-""")
+"""
+        )
 
         self.login_browser_quick_test1()
         self.goto_document(d)


### PR DESCRIPTION
Koska tuossa täydellä vauhdilla ajettaessa qst1 tallennus oli vieläkesken kun jo qst2:ssa
haettiin sen tulosta, niin joskus saattoi tulos olla oikein ja joskus vielä tallentumatta.

Lisätty koodiin odotus että Saved tulee qst1:een ja vasti sitten käsitellään qst2:sta.

Tuosta voi ottaa mallia moneen muuhunkin Selenium testiin ja ehkä käyttää hyväkseen ja tehdä
lisää noita yleiskäyttöisiä funktioita jolloin itse testikoodin saisi lyhyemmäksi.