### PR TITLE
Allow editing upload filenames

### DIFF
--- a/timApp/static/scripts/tim/editor/pareditor.ts
+++ b/timApp/static/scripts/tim/editor/pareditor.ts
@@ -253,6 +253,8 @@ export class PareditorController extends DialogController<
         acebehaviours: TimStorage<boolean>;
         acewrap: TimStorage<boolean>;
         autocomplete: TimStorage<boolean>;
+        askFilename: TimStorage<boolean>;
+        useDocumentName: TimStorage<boolean>;
         proeditor: TimStorage<boolean>;
         spellcheck: TimStorage<boolean>;
         editortab: TimStorage<string>;
@@ -263,10 +265,14 @@ export class PareditorController extends DialogController<
     };
     private touchDevice: boolean;
     private autocomplete!: boolean; // $onInit
+    private askFilename!: boolean;
+    private useDocumentName!: boolean;
     private citeText!: string; // $onInit
     private docSettings?: IDocSettings;
     private memoMinutesSettings?: IMeetingMemoSettings;
     private uploadedFile?: string;
+    private fileURL?: string;
+    private fileURLLatest?: string;
     private activeTab?: string;
     private lastTab?: string;
     private tabs: IEditorTab[];
@@ -1208,6 +1214,11 @@ ${backTicks}
             acebehaviours: new TimStorage("acebehaviours" + saveTag, t.boolean),
             acewrap: new TimStorage("acewrap" + saveTag, t.boolean),
             autocomplete: new TimStorage("autocomplete" + saveTag, t.boolean),
+            askFilename: new TimStorage("askFilename" + saveTag, t.boolean),
+            useDocumentName: new TimStorage(
+                "useDocumentName" + saveTag,
+                t.boolean
+            ),
             editortab: new TimStorage("editortab" + saveTag, t.string),
             noteAccess: new TimStorage("noteAccess", t.string), // No saveTag here.
             oldMode: new TimStorage("oldMode" + saveTag, t.string),
@@ -1231,6 +1242,8 @@ ${backTicks}
 
         this.spellcheck = this.storage.spellcheck.get() ?? false;
         this.autocomplete = this.storage.autocomplete.get() ?? false;
+        this.askFilename = this.storage.askFilename.get() ?? false;
+        this.useDocumentName = this.storage.useDocumentName.get() ?? false;
         this.proeditor =
             this.storage.proeditor.get() ??
             (saveTag === "par" || saveTag === TIM_TABLE_CELL);
@@ -1742,7 +1755,7 @@ ${backTicks}
     }
 
     /**
-     * Checks whether or not the document is the original document.
+     * Checks whether the document is the original document.
      */
     isOriginalDocument() {
         const tags = this.getExtraData().tags;
@@ -1900,7 +1913,7 @@ ${backTicks}
                 return;
             }
             const cancelSuccess = await this.handleFormulaCancel();
-            // editing wasn't cancelled so do nothing
+            // editing wasn't canceled so do nothing
             if (!cancelSuccess) {
                 return;
             }
@@ -2057,8 +2070,8 @@ ${backTicks}
                         return;
                     }
                 }
-                // If Save and exit was chosen, falls through to normal saving process.
-                // Dismiss (pressing x to close) is considered the same as Save and exit.
+                // If "Save and exit" was chosen, falls through to normal saving process.
+                // Dismiss (pressing x to close) is considered the same as "Save and exit".
             }
         }
         const text = this.editor!.getEditorText();
@@ -2090,14 +2103,33 @@ ${backTicks}
             return;
         }
         const items = clipboardData.items;
-        // find pasted image among pasted items
         let blobs = 0;
+        let htmlImageName: string | null = null;
+
+        // First pass: extract HTML image name and find image blobs
         for (const i of items) {
-            // TODO: one could inspect if some item contains image name and then use that to name the image
+            if (i.type === "text/html") {
+                const html = clipboardData.getData("text/html");
+                const match = html.match(/src="([^"]+)"/);
+                if (match) {
+                    htmlImageName = match[1].split("/").pop() ?? null;
+                }
+            }
+        }
+
+        // Second pass: handle image blobs
+        for (const i of items) {
             if (i.type.startsWith("image")) {
                 const blob = i.getAsFile();
                 if (blob !== null) {
-                    this.onFileSelect(blob);
+                    // Use extracted HTML name if blob doesn't have one
+                    if (htmlImageName) {
+                        Object.defineProperty(blob, "name", {
+                            value: htmlImageName,
+                            writable: false,
+                        });
+                    }
+                    void this.onFileSelect(blob);
                     blobs++;
                 }
             }
@@ -2115,7 +2147,7 @@ ${backTicks}
         }
         const files = de.dataTransfer.files;
         for (const f of files) {
-            this.onFileSelect(f);
+            void this.onFileSelect(f);
         }
     }
 
@@ -2177,7 +2209,6 @@ ${backTicks}
     async onFileSelect(file: File) {
         const editor = this.editor!;
         await this.focusEditor();
-        this.file = file;
         const editorText = editor.getEditorText();
         let autostamp = false;
         let attachmentParams;
@@ -2193,6 +2224,22 @@ ${backTicks}
             this.liiteMacroStringEnd,
             selectionRange
         );
+
+        const suggestedName = (file.name?.trim() ?? "image.png")
+            .replace(/\?.*$/, "")
+            .trim();
+
+        let chosenName: string | null = suggestedName;
+        if (this.askFilename) {
+            chosenName = window.prompt("Give filename", suggestedName);
+        }
+        if (chosenName === null) {
+            // User canceled
+            return;
+        }
+        const trimmedName = chosenName.trim();
+        file = new File([file], trimmedName, {type: file.type});
+        this.file = file;
 
         // If there's an attachment macro in the editor (i.e. macroRange is defined), assume need to stamp.
         // Also requires data from preamble to work correctly (dates and knro).
@@ -2264,6 +2311,7 @@ ${backTicks}
                     let start = "[File](";
                     let end = ")";
                     let savedir = "/files/";
+                    let savename = "";
                     if (
                         response.data.image ||
                         response.data.file.toString().includes(".svg")
@@ -2272,10 +2320,11 @@ ${backTicks}
                     }
                     if (response.data.image) {
                         savedir = "/images/";
-                        this.uploadedFile = savedir + response.data.image;
+                        savename = response.data.image;
                     } else {
-                        this.uploadedFile = savedir + response.data.file;
+                        savename = response.data.file;
                     }
+                    this.uploadedFile = savedir + savename;
                     // For attachments without stamps (only look for this if stamped version wasn't found):
                     let macroRange2;
                     if (!macroRange) {
@@ -2303,7 +2352,34 @@ ${backTicks}
                             }
                         }
                     }
-                    ed.insertTemplate(`${start}${this.uploadedFile}${end}`);
+                    this.fileURL = this.uploadedFile;
+                    const doc = $(document)[0];
+                    if (doc) {
+                        const parsed = new URL(doc.URL);
+                        let cleanPath = parsed.pathname.replace(
+                            /^\/view\//,
+                            ""
+                        );
+                        if (cleanPath === "") {
+                            cleanPath = "/";
+                        }
+                        this.fileURL =
+                            savedir +
+                            cleanPath +
+                            "/" +
+                            // savename.split("/").pop();
+                            savename;
+                        this.fileURLLatest =
+                            savedir +
+                            cleanPath +
+                            "/" +
+                            savename.split("/").pop();
+                    }
+                    let mdUrl = this.uploadedFile;
+                    if (this.useDocumentName) {
+                        mdUrl = this.fileURL;
+                    }
+                    ed.insertTemplate(`${start}${mdUrl}${end}`);
                     // Separate from isPlugin so this is run only when there are attachments with stamps.
                     if (macroRange && kokousDate) {
                         stamped.uploadUrl = this.uploadedFile;
@@ -2647,6 +2723,8 @@ ${backTicks}
         this.storage.spellcheck.set(this.spellcheck);
         this.storage.editortab.set(this.activeTab ?? "navigation");
         this.storage.autocomplete.set(this.autocomplete);
+        this.storage.askFilename.set(this.askFilename);
+        this.storage.useDocumentName.set(this.useDocumentName);
         const ace = this.isAce();
         this.storage.oldMode.set(ace ? "ace" : "text");
         this.storage.wrap.set("" + this.wrapValue());

--- a/timApp/static/stylesheets/stylesheet.scss
+++ b/timApp/static/stylesheets/stylesheet.scss
@@ -948,6 +948,14 @@ pareditor {
     .formula-editor-tab {
         width: 100%;
     }
+
+    .upload-options {
+        flex-basis: 100%;
+    }
+
+    .select-file {
+
+    }
 }
 
 .editButtonArea {

--- a/timApp/static/templates/parEditor.html
+++ b/timApp/static/templates/parEditor.html
@@ -20,15 +20,29 @@
     </uib-tab>
 
 
-    <uib-tab heading="Upload" index="'upload_main_tab'" ng-show="$ctrl.getOptions().showUpload">
+    <uib-tab class="editor-upload" heading="Upload" index="'upload_main_tab'" ng-show="$ctrl.getOptions().showUpload">
         <uib-tabset>
             <uib-tab heading="File or Image" index="'upload'" ng-show="$ctrl.getOptions().showImageUpload">
-                <span>
+                <div class="upload-options">
+                    <label class="font-weight-normal margin-5-right"
+                    title="Show filename input before save">
+                        <input type="checkbox" ng-model="$ctrl.askFilename"/>
+                        Ask filename</label>
+                    <label class="font-weight-normal margin-5-right"
+                    title="Use folder/document in URL; keep resource ID for this version, or remove it when sharing to link to latest version.">
+                        <input type="checkbox" ng-model="$ctrl.useDocumentName"/>
+                        Use document name</label>
+                </div>
+                <div class="select-file">
                     <input type="file" ngf-select="$ctrl.onFilesSelect($files, $invalidFiles)" ngf-multiple="true">
                     <span ng-show="$ctrl.file.progress >= 0 && !$ctrl.file.error"
                           ng-bind="$ctrl.file.progress < 100 ? 'Uploading... ' + $ctrl.file.progress + '%' : 'Done!'"></span>
-                    <a ng-href="{{$ctrl.uploadedFile}}">{{$ctrl.uploadedFile}}</a>
-                </span>
+                    <a ng-href="{{$ctrl.uploadedFile}}" target="_blank">{{$ctrl.uploadedFile}}</a>
+                    <span ng-show="$ctrl.fileURL" > -
+                    <a ng-href="{{$ctrl.fileURL}}" target="_blank" title="URL using the document name">URL via document</a> -
+                    <a ng-href="{{$ctrl.fileURLLatest}}" target="_blank" title="URL for the latest upload of this name.">Latest</a>
+                    </span>
+                </div>
                 <div class="error" ng-show="$ctrl.file.error" ng-bind="$ctrl.file.error"></div>
                 <span>
                 </span>

--- a/timApp/upload/upload.py
+++ b/timApp/upload/upload.py
@@ -596,7 +596,7 @@ def upload_and_stamp_attachment(
     :param stamp_data: Stamp data object (attachment and list ids) without the path.
     :param stampformat: Formatting of stamp text.
     :param custom_stamp_model_content: LaTeX-string for a custom stamp.
-    :return: Json response containing the stamped file path.
+    :return: JSON response containing the stamped file path.
     """
 
     attachment_folder = default_attachment_folder
@@ -650,12 +650,9 @@ def save_file_and_grant_access(
 @upload.get("/files/<path:file_id>/<file_filename>")
 @require_oauth(Scope.user_tasks.value, optional=True)
 def get_file(file_id: str, file_filename: str) -> Response:
-    if file_id.isdigit():
-        f = UploadedFile.get_by_id_and_filename(int(file_id), file_filename)
-    else:
-        f = UploadedFile.get_by_doc_and_filename(file_id, file_filename)
-    if not f:
-        raise NotExist("File not found")
+    f = get_resource_file(
+        file_id, file_filename, "File not found"
+    )  # Just to check existence and access
 
     user = current_token.user if current_token else None
 
@@ -724,16 +721,47 @@ def get_reviewcanvas_pdf(user_name: str, doc_id: int, task_id: str, answer_id: i
     )
 
 
+def get_resource_file(res_id: str, filename: str, error_text: str) -> UploadedFile:
+    """
+    Get the file resource for the given id and filename.
+    The id can be either the resource id or the document id with resource id
+    or full filepath with or without resource id.
+    If resource id is missing, latest file associated to
+
+      - 1549 = 1549 may be resource id or document id.
+        Try first with resource id, then document id
+      - 1549/1591 = 1549 is sure document id and 1591 is resource id
+        It could also be path 1549 and docname 1591,
+        but since docname is more likely to be non-numeric, we try resource id first
+      - users/vesal/koe/upload/pasteimage/1591 = 1591 may be resource id or
+        docname.  Try first with resource id, then with path
+      - users/vesal/koe/upload/pasteimage
+
+
+    :param res_id: resource id or document name or document id
+    :param filename: filename of resource
+    :return: UploadedFile object
+    """
+    f = None
+    if res_id.isdigit():
+        f = UploadedFile.get_by_id_and_filename(int(res_id), filename)
+        if not f:  # not res_id, maybe docid
+            f = UploadedFile.get_by_doc_and_filename(res_id, filename)
+    else:
+        last = res_id.rsplit("/", 1)[-1]
+        if last.isdigit():  # last may be res_id, try that
+            f = UploadedFile.get_by_id_and_filename(int(last), filename)
+        if not f:  # last was not res_id, try full path
+            f = UploadedFile.get_by_doc_and_filename(res_id, filename)
+    if not f:
+        raise NotExist(error_text)
+    return f
+
+
 @upload.get("/images/<path:image_id>/<image_filename>")
 @require_oauth(Scope.user_tasks.value, optional=True)
 def get_image(image_id: str, image_filename: str) -> Response:
-    if image_id.isdigit():
-        f = UploadedFile.get_by_id_and_filename(int(image_id), image_filename)
-    else:
-        f = UploadedFile.get_by_doc_and_filename(image_id, image_filename)
-    if not f:
-        raise NotExist("Image not found")
-
+    f = get_resource_file(image_id, image_filename, "Image not found")
     user = current_token.user if current_token else None
 
     verify_view_access(f, check_parents=True, user=user)

--- a/timApp/upload/uploadedfile.py
+++ b/timApp/upload/uploadedfile.py
@@ -152,7 +152,7 @@ class UploadedFile(ItemBase):
         :param filename: File name, which may contain "_stamped".
         :return: UploadedFile, StampedPDF, or None, if neither was found.
         """
-        d = DocEntry.find_by_path(doc_path)
+        d = DocEntry.find_by_path(doc_path, fallback_to_id=True)
         if not d:
             return None
         f = UploadedFile.find_first_child(d.block, filename)


### PR DESCRIPTION
Lisää seuraavat ominaisuudet kuvan tai muun tiedoston uploadiin tai copy/pasteen:

- jos copy/pastetaan kuva esim nettisivulta, niin saa saman nimen (ellei nimeä löydy, image.png)
- valita että kysytäänkö tiedoston nimi ennen uploadia
- valinta (upload välilehdellä), että sijoitetaanko editoriin tiedoston nimellä oleva linkki pelkän resid sijaan.  Editoriin
   tulee tällöin linkki muodossa docpath/resid/kuvanimi ja siitä voi itse pyyhkiä tuo resid pois jos haluaa
   viitata aina viimeiseen
- upload sivulle tulee kolme erilaista linkkivaihtoehtoa jotka voi kopioida itselleen
- reittit GET /images ja GET /filenames ymmärtävät muodot
    - resid/resname  (vanha)
    - docid/resname  (uusi, linkki viimeiseen)
    - docid/resid/resname (uusi)
    - docpath/resid/resname (uusi, lähinnä ideana että näkee helpommin mihin dokuun liittyy) 
    - docpath/resname (vanha)

Yhdistetty haaraan log-docparagraph ja kokeiltavissa tim02 (eli tätä ei ole pakko mergetä enää masteriin jos
tuon log-haaran ottaa käyttöön).