### PR TITLE
Qst save c

### DIFF
--- a/timApp/modules/cs/cs.py
+++ b/timApp/modules/cs/cs.py
@@ -2067,7 +2067,9 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
 
         result["web"] = web
 
-        # For Stack type, remove contents of 'formatcorrectresponse' if
+        # TODO: The correct way to do this is to put the code in the run() method of stack.py.
+        # TODO: If it needs to be done here specifically, add a method such as "postprocess"
+        # TODO: to the language base class and implement it for the stack type.        # For Stack type, remove contents of 'formatcorrectresponse' if
         # - the score indicates an empty or incorrect answer
         # - the user has exceeded the answerLimit to this task
         # - the answer is not valid (usually when answer came outside of deadline)

--- a/timApp/modules/cs/cs.py
+++ b/timApp/modules/cs/cs.py
@@ -2067,38 +2067,6 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
 
         result["web"] = web
 
-        # For Stack type, remove contents of 'formatcorrectresponse' if
-        # - the score indicates an empty or incorrect answer
-        # - the user has exceeded the answerLimit to this task
-        # - the answer is not valid (usually when answer came outside of deadline)
-        #
-        # This is to prevent the correct answer from leaking prematurely via web -> stackResult.
-        if "stack" in ttype:
-            ucode = save.get("usercode", "")
-            if ucode:
-                # Stack tasks may have several answer fields, so we need to check each one
-                ucode = json.loads(ucode)
-                ucode = len("".join([str(v) for v in ucode.values()])) > 0
-            score = result["web"]["stackResult"].get("score", False)
-            valid = False
-            has_tries_left = False
-            queryinfo = query.query.get("info", None)
-            queryinfo = queryinfo[0] if queryinfo else None
-            if queryinfo:
-                valid = queryinfo.get("valid", False)
-                max_tries = queryinfo.get("max_answers", 1)
-                num_tries = queryinfo.get("earlier_answers", 0)
-                has_tries_left = max_tries is not None and num_tries <= max_tries
-
-            if (
-                (not has_tries_left)
-                or (not valid)
-                or (not ucode)
-                or (not score)
-                or (not has_tries_left and score <= 0)
-            ):
-                result["web"]["stackResult"]["formatcorrectresponse"] = ""
-
         # print(result)
 
         # Clean up

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -389,7 +389,7 @@ export class StackPluginComponent
             DOMPurify.sanitize(r.questiontext),
             "text/html"
         );
-        let el = doc.querySelector("div.stackinputfeedback");
+        const el = doc.querySelector("div.stackinputfeedback");
 
         if (!el) {
             return;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -18,6 +18,7 @@ import {PurifyModule} from "tim/util/purify.module";
 import {ScriptedInnerHTMLModule} from "tim/util/scripted-inner-html.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
+import DOMPurify from "dompurify";
 
 const STACK_VARIABLE_PREFIX = "stackapi_";
 
@@ -111,9 +112,6 @@ interface IStackData {
                         (click)="runPeek()">Peek
                 </button>
             </p>
-            <div *ngIf="stackPeek" class="peekdiv" id="peek" style="min-height: 10em;">
-                <div></div>
-            </div>
             <div *ngIf="stackInputFeedback" id="stackinputfeedback"
                  class="stackinputfeedback1"
                  [scriptedInnerHTML]="stackInputFeedback"></div>
@@ -319,9 +317,8 @@ export class StackPluginComponent
             this.error = r.message;
             return;
         }
-
         const qt = this.replace(r.questiontext);
-        const i = qt.indexOf('<div class="stackinputfeedback"');
+        const i = qt.indexOf('<div class="stackinputfeedback"'); // Mahdollinen bugi
         const helper = await import("../stack/ServerSyncValues");
         windowAsAny().ServerSyncValues = helper.ServerSyncValues;
         windowAsAny().findParentElementFromScript =
@@ -358,7 +355,7 @@ export class StackPluginComponent
         if (getTask) {
             // remove input validation texts
             const divinput = this.element.find(".stackinputfeedback");
-            divinput.remove();
+            divinput.addClass("hidden");
         }
     }
 
@@ -386,12 +383,31 @@ export class StackPluginComponent
             this.error = r.message;
             return;
         }
-        const peekDiv = this.element.find(".peekdiv");
-        const peekDivC = peekDiv.children();
-        // editorDiv.empty();
-        const pdiv = $(`<div><div class="math">${r.questiontext}</div></div>`);
-        await ParCompiler.processAllMath(pdiv);
-        peekDivC.replaceWith(pdiv); // TODO: still flashes
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(
+            DOMPurify.sanitize(r.questiontext),
+            "text/html"
+        );
+        let el = doc.querySelector("div.stackinputfeedback");
+
+        if (!el) {
+            return;
+        }
+
+        const curEl = this.element.get()[0];
+        const curMathEl = curEl.querySelector(
+            `div#${el.id}.stackinputfeedback`
+        );
+
+        if (!curMathEl) {
+            return;
+        }
+
+        curMathEl.replaceWith(el);
+
+        el.classList.add("math");
+        await ParCompiler.processAllMath(this.element);
     }
 
     autoPeekInput(id: string) {
@@ -438,7 +454,7 @@ export class StackPluginComponent
         if (!this.stackPeek) {
             // remove extra fields from screen
             let divinput = this.element.find(".stackinputfeedback");
-            divinput.remove();
+            divinput.addClass("hidden");
             divinput = this.element.find(".stackprtfeedback");
             divinput.remove();
             divinput = this.element.find(".stackpartmark");
@@ -455,7 +471,6 @@ export class StackPluginComponent
                 stackData: {...data},
             },
         });
-
         this.isRunning = false;
         if (!r.ok) {
             this.error = r.result.error.error;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -405,18 +405,7 @@ export class StackPluginComponent
         windowAsAny().findParentElementFromScript =
             helper.findParentElementFromScript;
         if (this.markup.buttonBottom || i < 0) {
-            if (this.markup.autosave) {
-                const doc = this.parseElements(qt);
-                doc.querySelectorAll("div.stackprtfeedback").forEach((el) =>
-                    el.remove()
-                );
-                doc.querySelectorAll("p.stackpartmark").forEach((el) =>
-                    el.remove()
-                );
-                this.stackOutput = doc.body.innerHTML;
-            } else {
-                this.stackOutput = qt;
-            }
+            this.stackOutput = qt;
             this.stackInputFeedback = "";
         } else {
             this.stackOutput = qt.substr(0, i) + "\n";

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -1,5 +1,5 @@
 ﻿import * as t from "io-ts";
-import type {ApplicationRef, DoBootstrap} from "@angular/core";
+import {ApplicationRef, DoBootstrap, HostListener} from "@angular/core";
 import {Component, NgModule} from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
 import {
@@ -24,6 +24,7 @@ const STACK_VARIABLE_PREFIX = "stackapi_";
 
 const StackMarkup = t.intersection([
     t.partial({
+        autosave: t.boolean,
         showAnswersOnLoad: t.boolean,
         beforeOpen: t.string,
         buttonBottom: t.boolean,
@@ -101,7 +102,7 @@ interface IStackData {
                         class="timButton btn-sm"
                         (click)="runGetTask()">Show task
                 </button>
-                <button *ngIf="isOpen"
+                <button *ngIf="isOpen && !markup.autosave"
                         [disabled]="isRunning"
                         title="(Ctrl-S)"
                         class="timButton btn-sm"
@@ -119,6 +120,8 @@ interface IStackData {
             <span class="csRunError"
                   *ngIf="error"
                   [innerHtml]="error | purify"></span>
+            &nbsp;&nbsp;
+            <span *ngIf="savedText" class="savedtext">{{savedText}}</span>
 
             <div *ngIf="stackFeedback">
                 <div *ngIf="markup.generalfeedback">
@@ -158,11 +161,14 @@ export class StackPluginComponent
 
     getContentArray?: () => string[] | undefined;
     isUnSaved(userChange?: boolean | undefined): boolean {
+        console.log(this.userCode);
+        console.log(this.originalUserCode);
         return this.userCode !== this.originalUserCode;
     }
 
     async save() {
         await this.runSave();
+        this.savedText = "Saved";
         return {saved: true, message: undefined};
     }
 
@@ -201,8 +207,11 @@ export class StackPluginComponent
     private lastInputFieldId: string = "";
     private lastInputFieldValue: string = "";
     private lastInputFieldElement?: HTMLInputElement;
+    private focusedInputId: string = "";
+    private focusedInputElement?: HTMLInputElement | null = null;
     button: string = "";
     inputplaceholder!: string;
+    savedText: string = "";
 
     private timer?: number;
 
@@ -211,7 +220,9 @@ export class StackPluginComponent
         this.button = this.buttonText();
         const aa = this.attrsall;
         this.userCode = aa.usercode ?? this.markup.by ?? "";
+        console.log(this.userCode);
         this.originalUserCode = this.userCode;
+        console.log(this.originalUserCode);
         this.timWay = aa.timWay ?? this.markup.timWay ?? false;
         this.inputrows = this.markup.inputrows;
         this.inputplaceholder = this.markup.inputplaceholder ?? "";
@@ -243,6 +254,25 @@ export class StackPluginComponent
     ngOnDestroy() {
         if (!this.attrsall.preview) {
             this.vctrl.removeTimComponent(this);
+        }
+    }
+
+    @HostListener("focusin", ["$event"])
+    onFocusIn(event: FocusEvent) {
+        const target = event.target as HTMLElement;
+
+        if (target instanceof HTMLInputElement) {
+            this.focusedInputId = target.id;
+        }
+    }
+
+    @HostListener("focusout")
+    onFocusOut() {
+        this.focusedInputElement = null;
+        this.focusedInputId = "";
+
+        if (this.markup.autosave && this.isUnSaved()) {
+            this.save();
         }
     }
 
@@ -350,6 +380,7 @@ export class StackPluginComponent
             this.stackOutput = qt.substr(0, i) + "\n";
             this.stackInputFeedback = qt.substr(i);
         }
+        // TODO: Tähän if.markup.autosave jne. Parsitaan qt dom ja poistetaan vastauspalautteet
 
         if (!getTask) {
             this.stackFeedback = this.replace(r.generalfeedback);
@@ -377,6 +408,19 @@ export class StackPluginComponent
             const divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
         }
+
+        if (this.markup.autosave && !getTask) {
+            html.find(".stackinputfeedback").addClass("hidden");
+            html.find(".stackprtfeedback").remove();
+            html.find(".stackpartmark").remove();
+        }
+    }
+
+    parseElementsFromSelection(qt: string, select: string) {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(DOMPurify.sanitize(qt), "text/html");
+
+        return doc.querySelector(select);
     }
 
     inputHandler(e: JQuery.TriggeredEvent) {
@@ -391,6 +435,7 @@ export class StackPluginComponent
         }
         this.lastInputFieldId = id;
         this.lastInputFieldValue = target.value;
+        this.savedText = "";
         this.autoPeekInput(id);
     }
 
@@ -404,12 +449,17 @@ export class StackPluginComponent
             return;
         }
 
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(
-            DOMPurify.sanitize(r.questiontext),
-            "text/html"
+        // const parser = new DOMParser();
+        // const doc = parser.parseFromString(
+        //     DOMPurify.sanitize(r.questiontext),
+        //     "text/html"
+        // );
+        // const el = doc.querySelector("div.stackinputfeedback");
+
+        const el = this.parseElementsFromSelection(
+            r.questiontext,
+            "div.stackinputfeedback"
         );
-        const el = doc.querySelector("div.stackinputfeedback");
 
         if (!el) {
             return;
@@ -546,7 +596,7 @@ export class StackPluginComponent
         const stackResult = r.result.web.stackResult;
         this.originalUserCode = this.userCode;
         await this.handleServerResult(stackResult, getTask);
-        if (this.lastInputFieldId) {
+        if (this.lastInputFieldId && !this.markup.autosave) {
             this.lastInputFieldElement = this.element.find(
                 `#${this.lastInputFieldId}`
             )[0] as HTMLInputElement;
@@ -554,6 +604,18 @@ export class StackPluginComponent
                 this.lastInputFieldElement.focus();
                 this.lastInputFieldElement.selectionStart = 0;
                 this.lastInputFieldElement.selectionEnd = 1000;
+            }
+        }
+        // Refocus to the selected input field after autosave
+        if (this.markup.autosave && this.focusedInputId) {
+            this.focusedInputElement = this.element.find(
+                `#${this.focusedInputId}`
+            )[0] as HTMLInputElement;
+            if (this.focusedInputElement) {
+                this.focusedInputElement.focus();
+                // Move the caret to the end of the input
+                const caretPos = this.focusedInputElement.value.length;
+                this.focusedInputElement.setSelectionRange(caretPos, caretPos);
             }
         }
     }

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -25,7 +25,6 @@ import {ScriptedInnerHTMLModule} from "tim/util/scripted-inner-html.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 import DOMPurify from "dompurify";
-import {event} from "jquery";
 
 const STACK_VARIABLE_PREFIX = "stackapi_";
 
@@ -269,6 +268,10 @@ export class StackPluginComponent
 
     @HostListener("focusin", ["$event"])
     onFocusIn(event: FocusEvent) {
+        if (!this.markup.autosave) {
+            return;
+        }
+
         const target = event.target as HTMLElement;
 
         if (target instanceof HTMLInputElement) {
@@ -278,19 +281,19 @@ export class StackPluginComponent
 
     @HostListener("focusout", ["$event"])
     onFocusOut(event: FocusEvent) {
+        if (!this.markup.autosave) {
+            return;
+        }
+
         this.focusedInputElement = null;
         this.focusedInputId = "";
 
         const target = event.target as HTMLElement;
-
-        if (
-            this.originalUserCode === "" &&
-            target instanceof HTMLInputElement
-        ) {
+        if (!this.originalUserCode && target instanceof HTMLInputElement) {
             this.userCode = target.value;
         }
 
-        if (this.markup.autosave && this.isUnSaved()) {
+        if (this.isUnSaved()) {
             this.save();
         }
     }
@@ -393,7 +396,18 @@ export class StackPluginComponent
         windowAsAny().findParentElementFromScript =
             helper.findParentElementFromScript;
         if (this.markup.buttonBottom || i < 0) {
-            this.stackOutput = qt;
+            if (this.markup.autosave) {
+                const doc = this.parseElements(qt);
+                doc.querySelectorAll("div.stackprtfeedback").forEach((el) =>
+                    el.remove()
+                );
+                doc.querySelectorAll("p.stackpartmark").forEach((el) =>
+                    el.remove()
+                );
+                this.stackOutput = doc.body.innerHTML;
+            } else {
+                this.stackOutput = qt;
+            }
             this.stackInputFeedback = "";
         } else {
             this.stackOutput = qt.substr(0, i) + "\n";
@@ -427,19 +441,11 @@ export class StackPluginComponent
             const divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
         }
-
-        if (this.markup.autosave && !getTask) {
-            html.find(".stackinputfeedback").addClass("hidden");
-            html.find(".stackprtfeedback").remove();
-            html.find(".stackpartmark").remove();
-        }
     }
 
-    parseElementsFromSelection(qt: string, select: string) {
+    parseElements(qt: string) {
         const parser = new DOMParser();
-        const doc = parser.parseFromString(DOMPurify.sanitize(qt), "text/html");
-
-        return doc.querySelector(select);
+        return parser.parseFromString(DOMPurify.sanitize(qt), "text/html");
     }
 
     inputHandler(e: JQuery.TriggeredEvent) {
@@ -468,8 +474,7 @@ export class StackPluginComponent
             return;
         }
 
-        const el = this.parseElementsFromSelection(
-            r.questiontext,
+        const el = this.parseElements(r.questiontext).querySelector(
             "div.stackinputfeedback"
         );
 

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -167,17 +167,10 @@ export class StackPluginComponent
 
     getContentArray?: () => string[] | undefined;
     isUnSaved(userChange?: boolean | undefined): boolean {
-        console.log("isUnsaved userCode: ", this.userCode);
-        console.log("isUnsaved originalUserCode: ", this.originalUserCode);
-        console.log(
-            "Ovatko eri, eli pitääkö tallentaa? ",
-            this.userCode !== this.originalUserCode
-        );
         return this.userCode !== this.originalUserCode;
     }
 
     async save() {
-        console.log("Tallentaminen tapahtui eli ajetaan runSend()");
         await this.runSave();
         return {saved: true, message: undefined};
     }
@@ -227,7 +220,6 @@ export class StackPluginComponent
     private timer?: number;
 
     ngOnInit() {
-        console.log("ngOnInit");
         super.ngOnInit();
         this.button = this.buttonText();
         const aa = this.attrsall;
@@ -249,12 +241,10 @@ export class StackPluginComponent
         });
 
         if (this.markup.open) {
-            console.log("Opening...");
             this.runGetTask();
         }
 
         if (this.markup.showAnswersOnLoad) {
-            console.log("showAnswersOnLoad");
             this.showResponseWithoutAnswering();
         }
 
@@ -313,7 +303,6 @@ export class StackPluginComponent
         }
         await ab.loader.abLoad.promise;
         if (ab.answers.length > 0) {
-            console.log("ShowResponseWithoutAnswering: ");
             this.runSend(false, true, true);
         }
     }
@@ -568,20 +557,11 @@ export class StackPluginComponent
     }
 
     async runGetTask() {
-        console.log("runGetTask");
         this.isOpen = true;
         await this.runSend(true);
     }
 
     async runSend(getTask = false, getPrevAnswer = false, nosave = false) {
-        console.log(
-            "runSend: getTask:  ",
-            getTask,
-            " getPrevAnswer",
-            getPrevAnswer,
-            " nosave: ",
-            nosave
-        );
         if (this.pluginMeta.isPreview()) {
             this.error = "Cannot run plugin while previewing.";
             return;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -24,6 +24,7 @@ const STACK_VARIABLE_PREFIX = "stackapi_";
 
 const StackMarkup = t.intersection([
     t.partial({
+        showAnswersOnLoad: t.boolean,
         beforeOpen: t.string,
         buttonBottom: t.boolean,
         by: t.string,
@@ -230,6 +231,10 @@ export class StackPluginComponent
             this.runGetTask();
         }
 
+        if (this.markup.showAnswersOnLoad) {
+            this.showResponseWithoutAnswering();
+        }
+
         if (!this.attrsall.preview) {
             this.vctrl.addTimComponent(this);
         }
@@ -238,6 +243,21 @@ export class StackPluginComponent
     ngOnDestroy() {
         if (!this.attrsall.preview) {
             this.vctrl.removeTimComponent(this);
+        }
+    }
+
+    async showResponseWithoutAnswering(): Promise<void> {
+        const taskId = this.getTaskId()?.docTask();
+        if (!taskId) {
+            return;
+        }
+        const ab = await this.vctrl.getAnswerBrowserAsync(taskId);
+        if (!ab) {
+            return;
+        }
+        await ab.loader.abLoad.promise;
+        if (ab.answers.length > 0) {
+            this.runSend(false);
         }
     }
 

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -1,5 +1,11 @@
 ﻿import * as t from "io-ts";
-import {ApplicationRef, DoBootstrap, HostListener} from "@angular/core";
+import {
+    ApplicationRef,
+    DoBootstrap,
+    ElementRef,
+    HostListener,
+    ViewChild,
+} from "@angular/core";
 import {Component, NgModule} from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
 import {
@@ -19,6 +25,7 @@ import {ScriptedInnerHTMLModule} from "tim/util/scripted-inner-html.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 import DOMPurify from "dompurify";
+import {event} from "jquery";
 
 const STACK_VARIABLE_PREFIX = "stackapi_";
 
@@ -161,8 +168,12 @@ export class StackPluginComponent
 
     getContentArray?: () => string[] | undefined;
     isUnSaved(userChange?: boolean | undefined): boolean {
-        console.log(this.userCode);
-        console.log(this.originalUserCode);
+        console.log("isUnsaved userCode: ", this.userCode);
+        console.log("isUnsaved originalUserCode: ", this.originalUserCode);
+        console.log(
+            "Ovatko eri, eli pitääkö tallentaa? ",
+            this.userCode !== this.originalUserCode
+        );
         return this.userCode !== this.originalUserCode;
     }
 
@@ -212,6 +223,7 @@ export class StackPluginComponent
     button: string = "";
     inputplaceholder!: string;
     savedText: string = "";
+    inputs?: HTMLInputElement[];
 
     private timer?: number;
 
@@ -220,9 +232,7 @@ export class StackPluginComponent
         this.button = this.buttonText();
         const aa = this.attrsall;
         this.userCode = aa.usercode ?? this.markup.by ?? "";
-        console.log(this.userCode);
         this.originalUserCode = this.userCode;
-        console.log(this.originalUserCode);
         this.timWay = aa.timWay ?? this.markup.timWay ?? false;
         this.inputrows = this.markup.inputrows;
         this.inputplaceholder = this.markup.inputplaceholder ?? "";
@@ -266,10 +276,19 @@ export class StackPluginComponent
         }
     }
 
-    @HostListener("focusout")
-    onFocusOut() {
+    @HostListener("focusout", ["$event"])
+    onFocusOut(event: FocusEvent) {
         this.focusedInputElement = null;
         this.focusedInputId = "";
+
+        const target = event.target as HTMLElement;
+
+        if (
+            this.originalUserCode === "" &&
+            target instanceof HTMLInputElement
+        ) {
+            this.userCode = target.value;
+        }
 
         if (this.markup.autosave && this.isUnSaved()) {
             this.save();
@@ -448,13 +467,6 @@ export class StackPluginComponent
             this.error = r.message;
             return;
         }
-
-        // const parser = new DOMParser();
-        // const doc = parser.parseFromString(
-        //     DOMPurify.sanitize(r.questiontext),
-        //     "text/html"
-        // );
-        // const el = doc.querySelector("div.stackinputfeedback");
 
         const el = this.parseElementsFromSelection(
             r.questiontext,

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -177,8 +177,8 @@ export class StackPluginComponent
     }
 
     async save() {
+        console.log("Tallentaminen tapahtui eli ajetaan runSend()");
         await this.runSave();
-        this.savedText = "Saved";
         return {saved: true, message: undefined};
     }
 
@@ -227,6 +227,7 @@ export class StackPluginComponent
     private timer?: number;
 
     ngOnInit() {
+        console.log("ngOnInit");
         super.ngOnInit();
         this.button = this.buttonText();
         const aa = this.attrsall;
@@ -248,10 +249,12 @@ export class StackPluginComponent
         });
 
         if (this.markup.open) {
+            console.log("Opening...");
             this.runGetTask();
         }
 
         if (this.markup.showAnswersOnLoad) {
+            console.log("showAnswersOnLoad");
             this.showResponseWithoutAnswering();
         }
 
@@ -287,6 +290,7 @@ export class StackPluginComponent
 
         this.focusedInputElement = null;
         this.focusedInputId = "";
+        this.savedText = "";
 
         const target = event.target as HTMLElement;
         if (!this.originalUserCode && target instanceof HTMLInputElement) {
@@ -309,7 +313,8 @@ export class StackPluginComponent
         }
         await ab.loader.abLoad.promise;
         if (ab.answers.length > 0) {
-            this.runSend(false);
+            console.log("ShowResponseWithoutAnswering: ");
+            this.runSend(false, true, true);
         }
     }
 
@@ -380,7 +385,11 @@ export class StackPluginComponent
         return s;
     }
 
-    async handleServerResult(r: StackResult, getTask: boolean) {
+    async handleServerResult(
+        r: StackResult,
+        getTask: boolean,
+        getPrevAnswer: boolean
+    ) {
         if (typeof r === "string") {
             this.error = r.toString();
             return;
@@ -413,9 +422,8 @@ export class StackPluginComponent
             this.stackOutput = qt.substr(0, i) + "\n";
             this.stackInputFeedback = qt.substr(i);
         }
-        // TODO: Tähän if.markup.autosave jne. Parsitaan qt dom ja poistetaan vastauspalautteet
 
-        if (!getTask) {
+        if (!getTask || getPrevAnswer) {
             this.stackFeedback = this.replace(r.generalfeedback);
             this.stackFormatCorrectResponse = this.replace(
                 r.formatcorrectresponse
@@ -436,7 +444,7 @@ export class StackPluginComponent
         const inputse = html.find("textarea");
         $(inputs).on("keyup", (e) => this.inputHandler(e));
         $(inputse).on("keyup", (e) => this.inputHandler(e));
-        if (getTask) {
+        if (getTask && !this.markup.autosave) {
             // remove input validation texts
             const divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
@@ -538,7 +546,7 @@ export class StackPluginComponent
             return;
         }
         this.isRunning = true;
-        if (!this.stackPeek) {
+        if (!this.stackPeek && !this.markup.autosave) {
             // remove extra fields from screen
             let divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
@@ -571,25 +579,36 @@ export class StackPluginComponent
     }
 
     async runGetTask() {
+        console.log("runGetTask");
         this.isOpen = true;
         await this.runSend(true);
     }
 
-    async runSend(getTask = false) {
+    async runSend(getTask = false, getPrevAnswer = false, nosave = false) {
+        console.log(
+            "runSend: getTask:  ",
+            getTask,
+            " getPrevAnswer",
+            getPrevAnswer,
+            " nosave: ",
+            nosave
+        );
         if (this.pluginMeta.isPreview()) {
             this.error = "Cannot run plugin while previewing.";
             return;
         }
         this.stackPeek = false;
         this.error = "";
+        this.savedText = "";
         this.isRunning = true;
         const stackData = this.collectData();
-
         const r = await this.postAnswer<{
             web: {stackResult: StackResult; error?: string};
         }>({
             input: {
                 getTask: getTask,
+                nosave: nosave,
+                prevAnswer: getPrevAnswer,
                 stackData: stackData,
                 type: "stack",
                 usercode: this.timWay
@@ -610,9 +629,12 @@ export class StackPluginComponent
             this.error = r.result.web.error;
             return;
         }
+        if (r.result.savedNew) {
+            this.savedText = "Saved";
+        }
         const stackResult = r.result.web.stackResult;
         this.originalUserCode = this.userCode;
-        await this.handleServerResult(stackResult, getTask);
+        await this.handleServerResult(stackResult, getTask, getPrevAnswer);
         if (this.lastInputFieldId && !this.markup.autosave) {
             this.lastInputFieldElement = this.element.find(
                 `#${this.lastInputFieldId}`

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -279,13 +279,18 @@ export class StackPluginComponent
         }
 
         this.focusedInputElement = null;
+
         this.focusedInputId = "";
         this.savedText = "";
-
         const target = event.target as HTMLElement;
+
         if (!this.originalUserCode && target instanceof HTMLInputElement) {
             this.userCode = target.value;
         }
+
+        // Flush the DOM to userCode
+        this.stopTimer();
+        this.collectAnswer("");
 
         if (this.isUnSaved()) {
             this.save();

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -416,7 +416,9 @@ export class StackPluginComponent
             );
             this.stackAnswerNotes = this.replace(JSON.stringify(r.answernotes));
         }
-        this.stackScore = r.score.toString();
+        if (r.score) {
+            this.stackScore = r.score.toString();
+        }
         this.stackTime = `Request Time: ${r.request_time.toFixed(
             2
         )} Api Time: ${r.api_time.toFixed(2)}`;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -1,11 +1,6 @@
 ﻿import * as t from "io-ts";
-import {
-    ApplicationRef,
-    DoBootstrap,
-    ElementRef,
-    HostListener,
-    ViewChild,
-} from "@angular/core";
+import type {ApplicationRef, DoBootstrap} from "@angular/core";
+import {HostListener} from "@angular/core";
 import {Component, NgModule} from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
 import {

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -114,6 +114,33 @@ class Stack(Language):
         except json.JSONDecodeError:
             return 1, "", str(r.content.decode()), ""
 
+        # Remove contents of 'formatcorrectresponse' if
+        # - the score indicates an empty or incorrect answer
+        # - the user has exceeded the answerLimit to this task
+        # - the answer is not valid (usually when answer was sent outside the deadline)
+        #
+        # This is to prevent the correct answer from leaking prematurely via web -> stackResult.
+        ucode = input.get("usercode", "")
+        if ucode:
+            # Stack tasks may have several answer fields, so we need to check each one
+            ucode = json.loads(ucode)
+            ucode = len("".join([str(v) for v in ucode.values()])) > 0
+        score = r["score"]
+        valid = info.get("valid", False)
+        max_tries = info.get("max_answers", 1)
+        num_tries = info.get("earlier_answers", 0)
+        # If max_tries is None the task does not have an answer limit
+        has_tries_left = True if max_tries is None else num_tries <= max_tries
+
+        if (
+            (not has_tries_left)
+            or (not valid)
+            or (not ucode)
+            or (not score)
+            or (not has_tries_left and score <= 0)
+        ):
+            r["formatcorrectresponse"] = ""
+
         if "score" in r:
             out = "Score: %s" % r.get("score", 0)
             del r["score"]  # Don't leak the score in the response

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -86,8 +86,11 @@ class Stack(Language):
         )
         stack_data["question"] = q_data
 
-        if not prev_answer and nosave or get_task or hide_results:
+        if not prev_answer and nosave or get_task:
             stack_data["score"] = False
+            stack_data["feedback"] = False
+        if hide_results:
+            stack_data["score"] = True
             stack_data["feedback"] = False
         stack_data["answer"] = data.get("answer")
         stack_data["prefix"] = data.get("prefix")
@@ -108,7 +111,11 @@ class Stack(Language):
             r = r.json()
         except json.JSONDecodeError:
             return 1, "", str(r.content.decode()), ""
-        out = "Score: %s" % r.get("score", 0)
+
+        if "score" in r:
+            out = "Score: %s" % r.get("score", 0)
+            del r["score"]  # Don't leak the score in the response
+
         # r['questiontext'] = tim_sanitize(r['questiontext'])
 
         if nosave:

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -77,13 +77,16 @@ class Stack(Language):
         nosave = input.get("nosave", False)
         stack_data["seed"] = userseed
 
+        prev_answer = input.get("prevAnswer", False)
+        hide_results = markup.get("hideResults", False)
+
         q = stack_data.get("question", "")
         q_data = self.parse_stack_question(
             q, not self.query.jso.get("markup").get("stackjsx")
         )
         stack_data["question"] = q_data
 
-        if nosave or get_task:
+        if not prev_answer and nosave or get_task or hide_results:
             stack_data["score"] = False
             stack_data["feedback"] = False
         stack_data["answer"] = data.get("answer")

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 
 import requests
 import yaml
+from bs4 import BeautifulSoup
 
 from languages import Language
 from tim_common.cs_sanitizer import tim_sanitize
@@ -92,6 +93,7 @@ class Stack(Language):
         if hide_results:
             stack_data["score"] = True
             stack_data["feedback"] = False
+
         stack_data["answer"] = data.get("answer")
         stack_data["prefix"] = data.get("prefix")
         stack_data["verifyvar"] = data.get("verifyvar", "")
@@ -117,6 +119,15 @@ class Stack(Language):
             del r["score"]  # Don't leak the score in the response
 
         # r['questiontext'] = tim_sanitize(r['questiontext'])
+
+        if hide_results:
+            # The information about points needs to be removed from the questiontext HTML
+            question_text = r.get("questiontext", "")
+            soup = BeautifulSoup(question_text, "html.parser")
+            for element in soup.select(".stackpartmark"):
+                element.decompose()
+
+            r["questiontext"] = str(soup)
 
         if nosave:
             out = ""

--- a/timApp/package-lock.json
+++ b/timApp/package-lock.json
@@ -515,9 +515,9 @@
       }
     },
     "@angular/language-service": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.3.0.tgz",
-      "integrity": "sha512-Sij3OQzj1UGs1O8H9PxVAY/o27+oqZwQRnib66rsWvtbIBTjHp4FV3dTs5iVcr62GGv4V4Mff/2I82NP10GPQg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.2.3.tgz",
+      "integrity": "sha512-11rp2DumlZFO5+/N38RW6lXzicD/6LlqeVoS4qf8sIMGJ4bzeyOrG0T/PAG2iEA7hay1jPH51t0G529xaSw0tQ==",
       "dev": true
     },
     "@angular/localize": {
@@ -2714,7 +2714,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
     "@types/katex": {
@@ -3786,7 +3786,7 @@
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "dev": true
     },
     "big.js": {
@@ -3870,7 +3870,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
     "bootstrap": {
@@ -3942,7 +3942,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
       "dev": true
     },
     "cacache": {
@@ -4140,7 +4140,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true
     },
     "clone-deep": {
@@ -4188,7 +4188,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "complex.js": {
@@ -4232,7 +4232,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -4252,7 +4252,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "dev": true
     },
     "content-disposition": {
@@ -4295,7 +4295,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
     "copy-anything": {
@@ -4717,7 +4717,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -4740,7 +4740,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
       "dev": true
     },
     "depd": {
@@ -4784,7 +4784,7 @@
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
       "dev": true
     },
     "dns-packet": {
@@ -4866,7 +4866,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
     "electron-to-chromium": {
@@ -4889,7 +4889,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
     "encoding": {
@@ -5384,7 +5384,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
     "escape-latex": {
@@ -5956,7 +5956,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
     "eventemitter-asyncresource": {
@@ -6101,7 +6101,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastq": {
@@ -6323,7 +6323,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
     "fs-extra": {
@@ -6629,7 +6629,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
     },
     "hdr-histogram-js": {
@@ -6669,7 +6669,7 @@
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -6739,7 +6739,7 @@
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
       "dev": true
     },
     "http-errors": {
@@ -6820,7 +6820,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
@@ -6890,7 +6890,7 @@
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
       "dev": true,
       "optional": true
     },
@@ -7091,7 +7091,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-bigint": {
@@ -7183,7 +7183,7 @@
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
       "dev": true
     },
     "is-map": {
@@ -7400,7 +7400,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
     },
     "isexe": {
@@ -7411,7 +7411,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -7444,7 +7444,7 @@
     "javascript-natural-sort": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -7520,7 +7520,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
@@ -7550,7 +7550,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "dev": true
     },
     "karma-source-map-support": {
@@ -7712,7 +7712,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
     "lodash.merge": {
@@ -7889,7 +7889,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
     "memfs": {
@@ -7904,7 +7904,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "merge-stream": {
@@ -7922,7 +7922,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
     "mhchemparser": {
@@ -8186,7 +8186,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "needle": {
@@ -8388,7 +8388,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
       "dev": true
     },
     "npm-bundled": {
@@ -8844,7 +8844,7 @@
     "parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "parse5": {
       "version": "6.0.1",
@@ -9009,7 +9009,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
     "path-type": {
@@ -9484,7 +9484,7 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
       "dev": true
     },
     "promise-retry": {
@@ -9500,7 +9500,7 @@
         "retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
           "dev": true
         }
       }
@@ -9526,7 +9526,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
       "optional": true
     },
@@ -9588,7 +9588,7 @@
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
@@ -9597,7 +9597,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
       }
@@ -9951,7 +9951,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve": {
@@ -10192,7 +10192,7 @@
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "dev": true
     },
     "selfsigned": {
@@ -10271,7 +10271,7 @@
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -10301,7 +10301,7 @@
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
           "dev": true,
           "requires": {
             "depd": "~1.1.2",
@@ -10313,13 +10313,13 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         },
         "setprototypeof": {
@@ -10351,7 +10351,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "setprototypeof": {
@@ -10603,7 +10603,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "ssri": {
@@ -10677,7 +10677,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true
     },
     "strip-final-newline": {
@@ -10871,7 +10871,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "thunky": {
@@ -10897,7 +10897,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -11099,7 +11099,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
     },
     "update-browserslist-db": {
@@ -11123,13 +11123,13 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "utrie": {
@@ -11168,7 +11168,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
     "viz.js": {
@@ -11198,7 +11198,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
@@ -11577,7 +11577,7 @@
     "wicked-good-xpath": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
     },
     "wide-align": {
       "version": "1.1.5",

--- a/timApp/package-lock.json
+++ b/timApp/package-lock.json
@@ -515,9 +515,9 @@
       }
     },
     "@angular/language-service": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.3.0.tgz",
-      "integrity": "sha512-Sij3OQzj1UGs1O8H9PxVAY/o27+oqZwQRnib66rsWvtbIBTjHp4FV3dTs5iVcr62GGv4V4Mff/2I82NP10GPQg==",
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.2.3.tgz",
+      "integrity": "sha512-11rp2DumlZFO5+/N38RW6lXzicD/6LlqeVoS4qf8sIMGJ4bzeyOrG0T/PAG2iEA7hay1jPH51t0G529xaSw0tQ==",
       "dev": true
     },
     "@angular/localize": {

--- a/timApp/package-lock.json
+++ b/timApp/package-lock.json
@@ -515,9 +515,9 @@
       }
     },
     "@angular/language-service": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.2.3.tgz",
-      "integrity": "sha512-11rp2DumlZFO5+/N38RW6lXzicD/6LlqeVoS4qf8sIMGJ4bzeyOrG0T/PAG2iEA7hay1jPH51t0G529xaSw0tQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.3.0.tgz",
+      "integrity": "sha512-Sij3OQzj1UGs1O8H9PxVAY/o27+oqZwQRnib66rsWvtbIBTjHp4FV3dTs5iVcr62GGv4V4Mff/2I82NP10GPQg==",
       "dev": true
     },
     "@angular/localize": {
@@ -2714,7 +2714,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@types/katex": {
@@ -3786,7 +3786,7 @@
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "big.js": {
@@ -3870,7 +3870,7 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
     "bootstrap": {
@@ -3942,7 +3942,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
     "cacache": {
@@ -4140,7 +4140,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "clone-deep": {
@@ -4188,7 +4188,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "complex.js": {
@@ -4232,7 +4232,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -4252,7 +4252,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "content-disposition": {
@@ -4295,7 +4295,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "copy-anything": {
@@ -4717,7 +4717,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -4740,7 +4740,7 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
@@ -4784,7 +4784,7 @@
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-      "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
     "dns-packet": {
@@ -4866,7 +4866,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "electron-to-chromium": {
@@ -4889,7 +4889,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "encoding": {
@@ -5384,7 +5384,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-latex": {
@@ -5956,7 +5956,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "eventemitter-asyncresource": {
@@ -6101,7 +6101,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fastq": {
@@ -6323,7 +6323,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-extra": {
@@ -6629,7 +6629,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "hdr-histogram-js": {
@@ -6669,7 +6669,7 @@
     "hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -6739,7 +6739,7 @@
     "http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
@@ -6820,7 +6820,7 @@
     "humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
         "ms": "^2.0.0"
@@ -6890,7 +6890,7 @@
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
     },
@@ -7091,7 +7091,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-bigint": {
@@ -7183,7 +7183,7 @@
     "is-lambda": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
     },
     "is-map": {
@@ -7400,7 +7400,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "isexe": {
@@ -7411,7 +7411,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -7444,7 +7444,7 @@
     "javascript-natural-sort": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -7520,7 +7520,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json5": {
@@ -7550,7 +7550,7 @@
     "jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
     "karma-source-map-support": {
@@ -7712,7 +7712,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
     "lodash.merge": {
@@ -7889,7 +7889,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "memfs": {
@@ -7904,7 +7904,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "merge-stream": {
@@ -7922,7 +7922,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "mhchemparser": {
@@ -8186,7 +8186,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "needle": {
@@ -8388,7 +8388,7 @@
     "normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
     "npm-bundled": {
@@ -8844,7 +8844,7 @@
     "parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse5": {
       "version": "6.0.1",
@@ -9009,7 +9009,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "path-type": {
@@ -9484,7 +9484,7 @@
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "promise-retry": {
@@ -9500,7 +9500,7 @@
         "retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "dev": true
         }
       }
@@ -9526,7 +9526,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true,
       "optional": true
     },
@@ -9588,7 +9588,7 @@
     "read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "dev": true,
       "requires": {
         "pify": "^2.3.0"
@@ -9597,7 +9597,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
       }
@@ -9951,7 +9951,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
@@ -10192,7 +10192,7 @@
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
     "selfsigned": {
@@ -10271,7 +10271,7 @@
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -10301,7 +10301,7 @@
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
             "depd": "~1.1.2",
@@ -10313,13 +10313,13 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "setprototypeof": {
@@ -10351,7 +10351,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "setprototypeof": {
@@ -10603,7 +10603,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "ssri": {
@@ -10677,7 +10677,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-final-newline": {
@@ -10871,7 +10871,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "thunky": {
@@ -10897,7 +10897,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -11099,7 +11099,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "update-browserslist-db": {
@@ -11123,13 +11123,13 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "utrie": {
@@ -11168,7 +11168,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "viz.js": {
@@ -11198,7 +11198,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
@@ -11577,7 +11577,7 @@
     "wicked-good-xpath": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
-      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
+      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
     },
     "wide-align": {
       "version": "1.1.5",

--- a/timApp/package-lock.json
+++ b/timApp/package-lock.json
@@ -515,9 +515,9 @@
       }
     },
     "@angular/language-service": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.2.3.tgz",
-      "integrity": "sha512-11rp2DumlZFO5+/N38RW6lXzicD/6LlqeVoS4qf8sIMGJ4bzeyOrG0T/PAG2iEA7hay1jPH51t0G529xaSw0tQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-14.3.0.tgz",
+      "integrity": "sha512-Sij3OQzj1UGs1O8H9PxVAY/o27+oqZwQRnib66rsWvtbIBTjHp4FV3dTs5iVcr62GGv4V4Mff/2I82NP10GPQg==",
       "dev": true
     },
     "@angular/localize": {

--- a/timApp/package.json
+++ b/timApp/package.json
@@ -96,7 +96,7 @@
     "@angular-devkit/build-angular": "^14.2.3",
     "@angular/cli": "^14.2.3",
     "@angular/compiler-cli": "^14.2.3",
-    "@angular/language-service": "^14.2.3",
+    "@angular/language-service": "^14.3.0",
     "@limegrass/eslint-plugin-import-alias": "^1.0.6",
     "@prettier/plugin-xml": "^2.2.0",
     "@types/angular": "1.8.4",

--- a/timApp/package.json
+++ b/timApp/package.json
@@ -96,7 +96,7 @@
     "@angular-devkit/build-angular": "^14.2.3",
     "@angular/cli": "^14.2.3",
     "@angular/compiler-cli": "^14.2.3",
-    "@angular/language-service": "^14.3.0",
+    "@angular/language-service": "^14.2.3",
     "@limegrass/eslint-plugin-import-alias": "^1.0.6",
     "@prettier/plugin-xml": "^2.2.0",
     "@types/angular": "1.8.4",

--- a/timApp/plugin/jsrunner/util.py
+++ b/timApp/plugin/jsrunner/util.py
@@ -226,36 +226,11 @@ class AllowedOverwriteOptions:
         )
 
 
-def get_qst_index(qfield: str, qmax: int) -> int:
-    """
-    Given a qfield and a value, return the index of the qfield in the list
-    If just qst[ return 0
-    :param qfield: string like qst[2] => 1
-    :param qmax: max len for answer
-    :return: index after [
-    """
-    m: Match[str] | None | Match[bytes] = re.fullmatch(r"qst\[(\d+)]?", qfield)
-    if m:
-        index = int(m.group(1)) - 1
-        if index < 0:
-            return 0
-        if index >= qmax:
-            return qmax - 1
-        return index
-    return 0
-
-
-def list_to_string(lst):
-    sio = StringIO()
-    csv.writer(sio).writerow(lst)
-    return sio.getvalue().rstrip("\r\n")
-
-
-def parse_list(s):
+def parse_list(s: Any) -> list[int | str]:
     if not isinstance(s, str):
         s = str(s)
     row = next(csv.reader(StringIO(s), skipinitialspace=True))
-    result = []
+    result: list[int | str] = []
     for item in row:
         item = item.strip()
         try:

--- a/timApp/plugin/jsrunner/util.py
+++ b/timApp/plugin/jsrunner/util.py
@@ -1,8 +1,12 @@
 import copy
+import re
+import csv
+from io import StringIO
 import json
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
+from re import Match
 from typing import TypedDict, Any, DefaultDict, Literal, Sequence
 
 from sqlalchemy import func, select, Row
@@ -220,6 +224,45 @@ class AllowedOverwriteOptions:
             points=parse_bool(markup.get("canOverwritePoints", False)),
             validity=parse_bool(markup.get("canOverwriteValidity", False)),
         )
+
+
+def get_qst_index(qfield: str, qmax: int) -> int:
+    """
+    Given a qfield and a value, return the index of the qfield in the list
+    If just qst[ return 0
+    :param qfield: string like qst[2] => 1
+    :param qmax: max len for answer
+    :return: index after [
+    """
+    m: Match[str] | None | Match[bytes] = re.fullmatch(r"qst\[(\d+)]?", qfield)
+    if m:
+        index = int(m.group(1)) - 1
+        if index < 0:
+            return 0
+        if index >= qmax:
+            return qmax - 1
+        return index
+    return 0
+
+
+def list_to_string(lst):
+    sio = StringIO()
+    csv.writer(sio).writerow(lst)
+    return sio.getvalue().rstrip("\r\n")
+
+
+def parse_list(s):
+    if not isinstance(s, str):
+        s = str(s)
+    row = next(csv.reader(StringIO(s), skipinitialspace=True))
+    result = []
+    for item in row:
+        item = item.strip()
+        try:
+            result.append(int(item))
+        except ValueError:
+            result.append(item)
+    return result
 
 
 def save_fields(
@@ -479,6 +522,33 @@ def save_fields(
             lastfield = "c"
             for c_field, c_value in contents.items():  # type: str, Any
                 lastfield = c_field
+                if c_field.startswith("qst["):
+                    # used for qst-type rows from TableForm like 1,2,4 to replace
+                    # row in qst answer
+                    qstvalue: list = []
+                    qmax = 20
+                    if an:
+                        if isinstance(content, list):
+                            qstvalue = content.copy()
+                        if isinstance(content, dict):
+                            qstvalue = content["c"].copy()
+                        qmax = len(qstvalue)
+                    index = get_qst_index(c_field, qmax)
+                    if len(qstvalue) <= index:
+                        qstvalue.extend([[] for _ in range(index + 1 - len(qstvalue))])
+                    """
+                    try:
+                        qstvalue[index] = json.loads(f"[{c_value}]")
+                    except json.JSONDecodeError:
+                        raise RouteException(
+                            f"Expected a comma-separated list of integers: {c_value}"
+                        )
+                    """
+                    qstvalue[index] = parse_list(c_value)
+
+                    c_field = "c"
+                    c_value = qstvalue
+
                 match c_field:
                     case "points":
                         if c_value == "":
@@ -497,6 +567,10 @@ def save_fields(
                         if not an or json.dumps(content) != c_value:
                             new_answer = True
                         content = json.loads(c_value)  # TODO: should this be inside if
+                    case "ALL":
+                        if not an or json.dumps(content) != c_value:
+                            new_answer = True
+                            content = json.loads(c_value)
                     case "valid":
                         c_b_value = parse_bool(c_value)
                         validity_changed = True
@@ -527,9 +601,25 @@ def save_fields(
                             if c_field not in content:
                                 content[c_field] = None
                     case _:
-                        if not an or content.get(c_field, "") != c_value:
+                        old_value = None
+                        if an:
+                            if type(content) is dict:
+                                old_value = content[c_field]
+                                if type(old_value) is dict and type(c_value) is str:
+                                    c_value = json.loads(c_value)
+                                if type(old_value) is list and type(c_value) is str:
+                                    c_value = json.loads(c_value)  # mostly qst
+                                content[c_field] = c_value
+                            if type(content) is list:
+                                old_value = content
+                                if type(c_value) is str:
+                                    c_value = json.loads(c_value)
+                                content = c_value
+                            if old_value != c_value:
+                                new_answer = True
+                        else:
+                            content[c_field] = c_value
                             new_answer = True
-                        content[c_field] = c_value
 
             if points_changed:
                 if an and not new_answer and overwrite_opts.points:

--- a/timApp/plugin/jsrunner/util.py
+++ b/timApp/plugin/jsrunner/util.py
@@ -1,12 +1,10 @@
 import copy
-import re
 import csv
 from io import StringIO
 import json
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from re import Match
 from typing import TypedDict, Any, DefaultDict, Literal, Sequence
 
 from sqlalchemy import func, select, Row
@@ -52,7 +50,6 @@ from timApp.user.user import (
     User,
     UserInfo,
     UserOrigin,
-    teacher_access_set,
     view_access_set,
 )
 from timApp.user.usergroup import UserGroup
@@ -63,7 +60,12 @@ from timApp.util.get_fields import (
     ALL_ANSWERED_WILDCARD,
     MembershipFilter,
 )
-from timApp.util.utils import is_valid_email, approximate_real_name
+from timApp.util.utils import (
+    is_valid_email,
+    approximate_real_name,
+    get_qst_index,
+    parse_list,
+)
 from tim_common.marshmallow_dataclass import class_schema
 from tim_common.utils import parse_bool
 
@@ -224,20 +226,6 @@ class AllowedOverwriteOptions:
             points=parse_bool(markup.get("canOverwritePoints", False)),
             validity=parse_bool(markup.get("canOverwriteValidity", False)),
         )
-
-
-def parse_list(s: Any) -> list[int | str]:
-    if not isinstance(s, str):
-        s = str(s)
-    row = next(csv.reader(StringIO(s), skipinitialspace=True))
-    result: list[int | str] = []
-    for item in row:
-        item = item.strip()
-        try:
-            result.append(int(item))
-        except ValueError:
-            result.append(item)
-    return result
 
 
 def save_fields(

--- a/timApp/plugin/plugin.py
+++ b/timApp/plugin/plugin.py
@@ -97,7 +97,7 @@ PLUGIN_MAX_POINTS_COUNTER: dict[str, Callable[[dict, bool], str | None]] = {
     "graphviz": count_max_points,
 }
 
-ALLOW_STYLES_PLUGINS = {"textfield", "numericfield", "drag", "dropdown"}
+ALLOW_STYLES_PLUGINS = {"textfield", "numericfield", "drag", "dropdown", "qst"}
 
 WANT_FIELDS = {"csPlugin"}
 

--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -107,7 +107,7 @@ def qst_mmcq_answer():
 
 @dataclass
 class QstInputModel:
-    answers: list[list[str]]
+    answers: list[list[str]] | dict[str, Any]
     nosave: bool | Missing = missing
 
 
@@ -152,11 +152,20 @@ class QstRandomState:
     order: list[int]
 
 
+@dataclass
+class QstCState:
+    class Meta:
+        unknown = EXCLUDE
+
+    c: QstBasicState
+    order: list[int] | None = None
+
+
 # Store answer in original row order if no randomizedRows specified in markup:
 # [["1"], [], ["1"], ["2"]]
 # Otherwise specify order in which rows were presented
 # {"c": [["1"], ["2"], ["3"], []], "order": [3, 7, 4, 5]}
-QstStateModel = Union[QstBasicState, QstRandomState]
+QstStateModel = Union[QstBasicState, QstRandomState, QstCState]
 
 
 @dataclass
@@ -184,8 +193,9 @@ def qst_answer_jso(m: QstAnswerModel):
     rand_arr = None
     prev_state = m.state
     # if prev state exists, try to get order from there
-    if isinstance(prev_state, QstRandomState):
-        rand_arr = prev_state.order
+    # if isinstance(prev_state, QstRandomState):
+    #    rand_arr = prev_state.order
+    rand_arr = getattr(prev_state, "order", None)
     # if prev state is none, check if markup wants random order
     if (
         prev_state is None

--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -141,6 +141,7 @@ class QstMarkupModel(GenericMarkupModel):
     json: dict[Any, Any] | None | Missing = missing
     title: str | None | Missing = missing
     showResult: bool | None | Missing = missing
+    keys: list[list[str]] | Missing = missing
 
 
 QstBasicState = list[list[int | str]]
@@ -255,16 +256,22 @@ def qst_answer_jso(m: QstAnswerModel):
         tim_info["points"] = points
 
     webstate = answers
-    if markup.saveKey:
+    if markup.saveKey or markup.keys:
+        if not markup.saveKey:
+            markup.saveKey = "c"
         answers = {markup.saveKey: answers}
     if rand_arr is not None:
         # TODO: Schema?
-        answers = {"c": answers, "order": rand_arr}
+        answers = {"c": webstate, "order": rand_arr}
         m.markup.rows = qst_set_array_order(m.markup.rows, rand_arr)
         if m.markup.expl is not missing:
             m.markup.expl = qst_pick_expls(m.markup.expl, rand_arr)
     if isinstance(extra, dict) and extra and isinstance(answers, dict):
         answers = {**answers, **extra}
+    if markup.keys:
+        answers["k"] = ",".join(
+            markup.keys[i][int(a) - 1] for i, ans in enumerate(webstate) for a in ans
+        )
 
     result = False
     if (

--- a/timApp/plugin/qst/qst.py
+++ b/timApp/plugin/qst/qst.py
@@ -1,14 +1,14 @@
 """Routes for qst (question) plugin."""
 import json
 import re
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import Union, Any
 
 import yaml
 from flask import Blueprint, render_template_string
 from flask import Response
 from flask import request
-from marshmallow import missing, EXCLUDE, ValidationError
+from marshmallow import missing, EXCLUDE, INCLUDE, ValidationError, pre_load
 
 from timApp.auth.sessioninfo import get_current_user_object
 from timApp.document.docinfo import DocInfo
@@ -143,7 +143,7 @@ class QstMarkupModel(GenericMarkupModel):
     showResult: bool | None | Missing = missing
 
 
-QstBasicState = list[list[str]]
+QstBasicState = list[list[int | str]]
 
 
 @dataclass
@@ -153,12 +153,29 @@ class QstRandomState:
 
 
 @dataclass
-class QstCState:
+class XQstCState:
     class Meta:
-        unknown = EXCLUDE
+        unknown = INCLUDE
 
     c: QstBasicState
     order: list[int] | None = None
+
+
+class QstCState:
+    class Meta:
+        unknown = EXCLUDE  # älä pudota tuntemattomia
+
+    c: QstBasicState
+    order: list[int] | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @pre_load
+    def collect_unknown(self, data, **kwargs):
+        known = {"c", "order", "extra"}
+        extra = {k: v for k, v in data.items() if k not in known}
+        data = dict(data)
+        data["extra"] = {**data.get("extra", {}), **extra}
+        return data
 
 
 # Store answer in original row order if no randomizedRows specified in markup:
@@ -196,6 +213,7 @@ def qst_answer_jso(m: QstAnswerModel):
     # if isinstance(prev_state, QstRandomState):
     #    rand_arr = prev_state.order
     rand_arr = getattr(prev_state, "order", None)
+    extra = getattr(prev_state, "extra", None)
     # if prev state is none, check if markup wants random order
     if (
         prev_state is None
@@ -237,12 +255,16 @@ def qst_answer_jso(m: QstAnswerModel):
         tim_info["points"] = points
 
     webstate = answers
+    if markup.saveKey:
+        answers = {markup.saveKey: answers}
     if rand_arr is not None:
         # TODO: Schema?
         answers = {"c": answers, "order": rand_arr}
         m.markup.rows = qst_set_array_order(m.markup.rows, rand_arr)
         if m.markup.expl is not missing:
             m.markup.expl = qst_pick_expls(m.markup.expl, rand_arr)
+    if isinstance(extra, dict) and extra and isinstance(answers, dict):
+        answers = {**answers, **extra}
 
     result = False
     if (

--- a/timApp/plugin/tableform/tableForm.py
+++ b/timApp/plugin/tableform/tableForm.py
@@ -947,7 +947,7 @@ def tableform_get_fields(
         email = user_info["email"]
         rows[username] = dict(f["fields"])
         for key, content in rows[username].items():
-            if type(content) is dict:
+            if type(content) is dict or type(content) is list:
                 rows[username][key] = json.dumps(content)
         users[username] = TableFormUserInfo(
             id=u.id,

--- a/timApp/plugin/taskid.py
+++ b/timApp/plugin/taskid.py
@@ -7,7 +7,7 @@ from timApp.document.docparagraph import DocParagraph
 from timApp.document.randutils import is_valid_id
 from timApp.plugin.pluginexception import PluginException
 
-KNOWN_FIELD_NAMES = {"points", "datetime", "ALL"}
+KNOWN_FIELD_NAMES = {"points", "datetime", "ALL", "qstn"}
 
 
 @dataclass
@@ -49,7 +49,7 @@ class TaskId:
         allow_type=True,
     ) -> "TaskId":
         m = re.fullmatch(
-            r"((?P<docid>\d+)\.)?(?P<name>[a-zåäöA-ZÅÄÖ0-9_-]+)(\.(?P<field>[a-zA-Z0-9_-]+))?(:(?P<type>[a-zA-Z]*)(:(?P<rw>readonly|readwrite))?)?",
+            r"((?P<docid>\d+)\.)?(?P<name>[a-zåäöA-ZÅÄÖ0-9_-]+)(\.(?P<field>[\[\]a-zA-Z0-9_-]+))?(:(?P<type>[a-zA-Z]*)(:(?P<rw>readonly|readwrite))?)?",
             s,
         )
         if not m:

--- a/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
+++ b/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
@@ -5,7 +5,6 @@ import {
     EventEmitter,
     Input,
     NgModule,
-    NgZone,
     Output,
 } from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
@@ -303,9 +302,10 @@ export class AnswerSheetComponent implements OnChanges {
     userpoints?: number;
     disabled = false;
     @Output() onAnswerChange: EventEmitter<AnswerTable> = new EventEmitter();
-    private customDomUpdateInProgress = false;
+    // private customDomUpdateInProgress = false;
 
-    constructor(element: ElementRef, private zone: NgZone) {
+    // constructor(element: ElementRef, private zone: NgZone) {
+    constructor(element: ElementRef) {
         this.element = $(element.nativeElement);
     }
 

--- a/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
+++ b/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
@@ -529,7 +529,8 @@ export class AnswerSheetComponent implements OnChanges {
                         if (!val) {
                             continue;
                         }
-                        const value = parseInt(val, 10);
+                        const value =
+                            typeof val === "number" ? val : parseInt(val, 10);
                         if (this.isCheckbox()) {
                             arr[i][value - 1] = 1;
                         } else {
@@ -552,7 +553,7 @@ export class AnswerSheetComponent implements OnChanges {
                 if (!val) {
                     continue;
                 }
-                const value = parseInt(val, 10);
+                const value = typeof val === "number" ? val : parseInt(val, 10);
                 if (this.isCheckbox()) {
                     arr[value - 1][0] = 1;
                 } else if (this.isRadio()) {

--- a/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
+++ b/timApp/static/scripts/tim/document/question/answer-sheet.component.ts
@@ -5,7 +5,6 @@ import {
     EventEmitter,
     Input,
     NgModule,
-    NgZone,
     Output,
 } from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
@@ -230,7 +229,7 @@ type MatrixElement = string | number;
                 </tr>
                 <tr *ngFor="let row of processed.rows; let rowi = index" [ngClass]="getTableRowClass()">
                     <td *ngIf="isMatrix()" [innerHtml]="fixText(row.text) | purify" class="qst-row_text"></td>
-                    <td *ngFor="let col of row.columns; let coli = index;" class="qst-td">
+                    <td *ngFor="let _col of row.columns; let coli = index;" class="qst-td">
                         <ng-template #points>
                             &ngsp;<span [innerHtml]="getLabelText(row) | purify"></span>
                             <p *ngIf="getPoints(rowi, coli) as p" class="qst-points" [innerText]="p"></p>
@@ -303,9 +302,10 @@ export class AnswerSheetComponent implements OnChanges {
     userpoints?: number;
     disabled = false;
     @Output() onAnswerChange: EventEmitter<AnswerTable> = new EventEmitter();
-    private customDomUpdateInProgress = false;
+    // private customDomUpdateInProgress = false;
 
-    constructor(element: ElementRef, private zone: NgZone) {
+    // constructor(element: ElementRef, private zone: NgZone) {
+    constructor(element: ElementRef) {
         this.element = $(element.nativeElement);
     }
 

--- a/timApp/static/scripts/tim/lecture/answer-chart.component.ts
+++ b/timApp/static/scripts/tim/lecture/answer-chart.component.ts
@@ -1,5 +1,5 @@
 import type {OnChanges} from "@angular/core";
-import {ChangeDetectorRef, Component, Input, NgModule} from "@angular/core";
+import {Component, Input, NgModule} from "@angular/core";
 import type {ChartData, ChartDataset, ChartOptions, ChartType} from "chart.js";
 import {fixQuestionJson} from "tim/document/question/answer-sheet.component";
 import type {Overwrite} from "type-zoo";
@@ -37,7 +37,8 @@ function timStripHtml(s: string) {
 }
 
 function timFillArray<T>(len: number, value: T) {
-    return Array.apply(null, new Array(len)).map(() => value);
+    // return Array.apply(null, new Array(len)).map(() => value);
+    return new Array<T>(len).fill(value);
 }
 
 function qstCleanHtml(s: string) {
@@ -159,19 +160,19 @@ interface ChartConfig {
 @Component({
     selector: "tim-answer-chart",
     template: `
-        <div *ngIf="!isText && chartData" style="flex: 1; min-height: 0">
+        <div *ngIf="!isText && chartData as cd" style="flex: 1; min-height: 0">
             <canvas baseChart
-                    [datasets]="chartData?.datasets"
-                    [labels]="chartData?.config?.data?.labels"
+                    [datasets]="cd.datasets"
+                    [labels]="cd.config.data.labels"
                     [options]="chartOptions"
-                    [legend]="chartData?.config?.options?.plugins?.legend?.display ?? false"
+                    [legend]="cd.config.options.plugins?.legend?.display ?? false"
                     [type]="'bar'">
             </canvas>
         </div>
         <div *ngIf="isText">
             <p *ngFor="let t of textAnswers" [innerText]="t"></p>
         </div>
-        <p *ngIf="answers">Total answers: {{ answers?.length }}</p>
+        <p *ngIf="answers as a">Total answers: {{ a.length }}</p>
         <p *ngIf="answers">Total points: {{ getTotalPoints() }}</p>
         <div *ngIf="!isText">
             <button class="timButton btn-xs" (click)="toggleAxis()">Change chart orientation</button>
@@ -316,7 +317,7 @@ export class AnswerChartComponent implements OnChanges {
     ];
     textAnswers: string[] = [];
 
-    constructor(private cdr: ChangeDetectorRef) {}
+    // constructor(private cdr: ChangeDetectorRef) {}
 
     get chartOptions(): ChartOptions<"bar"> {
         return {

--- a/timApp/static/scripts/tim/lecture/answer-chart.component.ts
+++ b/timApp/static/scripts/tim/lecture/answer-chart.component.ts
@@ -125,7 +125,9 @@ function qstShortText(s: string): string {
 
 type AnswerList = (IQuestionAnswer | IQuestionAnswerPlain)[];
 
-function* enumAnswers(answers: AnswerList): Iterable<[number, string[]]> {
+function* enumAnswers(
+    answers: AnswerList
+): Iterable<[number, (number | string)[]]> {
     for (const answ of answers) {
         const onePersonAnswers = answ.answer;
         for (let a = 0; a < onePersonAnswers.length; a++) {
@@ -159,17 +161,17 @@ interface ChartConfig {
     template: `
         <div *ngIf="!isText && chartData" style="flex: 1; min-height: 0">
             <canvas baseChart
-                    [datasets]="chartData.datasets"
-                    [labels]="chartData.config.data.labels"
+                    [datasets]="chartData?.datasets"
+                    [labels]="chartData?.config?.data?.labels"
                     [options]="chartOptions"
-                    [legend]="chartData.config.options.plugins?.legend?.display || false"
+                    [legend]="chartData?.config?.options?.plugins?.legend?.display ?? false"
                     [type]="'bar'">
             </canvas>
         </div>
         <div *ngIf="isText">
             <p *ngFor="let t of textAnswers" [innerText]="t"></p>
         </div>
-        <p *ngIf="answers">Total answers: {{ answers.length }}</p>
+        <p *ngIf="answers">Total answers: {{ answers?.length }}</p>
         <p *ngIf="answers">Total points: {{ getTotalPoints() }}</p>
         <div *ngIf="!isText">
             <button class="timButton btn-xs" (click)="toggleAxis()">Change chart orientation</button>
@@ -472,7 +474,7 @@ export class AnswerChartComponent implements OnChanges {
             this.textAnswers = [];
             for (const [_, singleAnswers] of enumAnswers(answers)) {
                 for (const singleAnswer of singleAnswers) {
-                    this.textAnswers.push(singleAnswer);
+                    this.textAnswers.push(String(singleAnswer));
                 }
             }
         } else {
@@ -494,7 +496,10 @@ export class AnswerChartComponent implements OnChanges {
                     }
                 }
                 for (const singleAnswer of singleAnswers) {
-                    const index = parseInt(singleAnswer, 10) - 1;
+                    const index =
+                        (typeof singleAnswer === "number"
+                            ? singleAnswer
+                            : parseInt(singleAnswer, 10)) - 1;
                     if (datasets.length === 1) {
                         if (index >= 0 && index < firstSet.length) {
                             firstSet[index]++;

--- a/timApp/static/scripts/tim/lecture/answer-chart.component.ts
+++ b/timApp/static/scripts/tim/lecture/answer-chart.component.ts
@@ -1,5 +1,5 @@
 import type {OnChanges} from "@angular/core";
-import {ChangeDetectorRef, Component, Input, NgModule} from "@angular/core";
+import {Component, Input, NgModule} from "@angular/core";
 import type {ChartData, ChartDataset, ChartOptions, ChartType} from "chart.js";
 import {fixQuestionJson} from "tim/document/question/answer-sheet.component";
 import type {Overwrite} from "type-zoo";
@@ -37,7 +37,8 @@ function timStripHtml(s: string) {
 }
 
 function timFillArray<T>(len: number, value: T) {
-    return Array.apply(null, new Array(len)).map(() => value);
+    // return Array.apply(null, new Array(len)).map(() => value);
+    return new Array<T>(len).fill(value);
 }
 
 function qstCleanHtml(s: string) {
@@ -159,19 +160,19 @@ interface ChartConfig {
 @Component({
     selector: "tim-answer-chart",
     template: `
-        <div *ngIf="!isText && chartData" style="flex: 1; min-height: 0">
+        <div *ngIf="!isText && chartData as cd" style="flex: 1; min-height: 0">
             <canvas baseChart
-                    [datasets]="chartData?.datasets"
-                    [labels]="chartData?.config?.data?.labels"
+                    [datasets]="cd.datasets"
+                    [labels]="cd.config.data.labels"
                     [options]="chartOptions"
-                    [legend]="chartData?.config?.options?.plugins?.legend?.display ?? false"
+                    [legend]="cd.config.options.plugins?.legend?.display ?? false"
                     [type]="'bar'">
             </canvas>
         </div>
         <div *ngIf="isText">
             <p *ngFor="let t of textAnswers" [innerText]="t"></p>
         </div>
-        <p *ngIf="answers">Total answers: {{ answers?.length }}</p>
+        <p *ngIf="answers as ans">Total answers: {{ ans.length }}</p>
         <p *ngIf="answers">Total points: {{ getTotalPoints() }}</p>
         <div *ngIf="!isText">
             <button class="timButton btn-xs" (click)="toggleAxis()">Change chart orientation</button>
@@ -316,7 +317,7 @@ export class AnswerChartComponent implements OnChanges {
     ];
     textAnswers: string[] = [];
 
-    constructor(private cdr: ChangeDetectorRef) {}
+    // constructor(private cdr: ChangeDetectorRef) {}
 
     get chartOptions(): ChartOptions<"bar"> {
         return {

--- a/timApp/static/scripts/tim/lecture/lecturetypes.ts
+++ b/timApp/static/scripts/tim/lecture/lecturetypes.ts
@@ -358,4 +358,4 @@ export function isAskedQuestion(qa: QuestionOrAnswer): qa is IAskedQuestion {
     return (qa as IAskedQuestion).asked_id != null;
 }
 
-export type AnswerTable = string[][];
+export type AnswerTable = (string | number)[][];

--- a/timApp/static/scripts/tim/plugin/qst/qst.component.ts
+++ b/timApp/static/scripts/tim/plugin/qst/qst.component.ts
@@ -49,7 +49,7 @@ const PluginMarkupFields = t.intersection([
 const PluginFields = t.intersection([
     getTopLevelFields(PluginMarkupFields),
     t.type({
-        state: nullable(t.array(t.array(t.string))),
+        state: nullable(t.array(t.array(t.union([t.string, t.number])))),
     }),
     t.partial({
         show_result: t.boolean,
@@ -59,7 +59,7 @@ const PluginFields = t.intersection([
 @Component({
     selector: "tim-qst",
     template: `
-        <tim-markup-error *ngIf="markupError" [data]="markupError"></tim-markup-error>
+        <tim-markup-error *ngIf="markupError" [data]="markupError!"></tim-markup-error>
         <div class="csRunDiv qst no-popup-menu" [class.cs-has-header]="getHeader()" *ngIf="isTask()">
             <h4 *ngIf="getHeader()" [innerHtml]="getHeader() | purify"></h4>
             <p *ngIf="stem" class="stem" [innerHtml]="stem | purify"></p>

--- a/timApp/static/scripts/tim/plugin/taskid.ts
+++ b/timApp/static/scripts/tim/plugin/taskid.ts
@@ -30,7 +30,7 @@ export enum TaskIdAccess {
     ReadWrite,
 }
 
-const KNOWN_FIELD_NAMES = new Set(["points", "datetime", "ALL"]);
+const KNOWN_FIELD_NAMES = new Set(["points", "datetime", "ALL", "qstn"]);
 
 function isValidId(blockHint: string) {
     return blockHint.length === 12; // TODO more accurate check

--- a/timApp/tests/browser/test_csplugin.py
+++ b/timApp/tests/browser/test_csplugin.py
@@ -12,7 +12,7 @@ class CsPluginTest(BrowserTest):
     def test_csplugin_translation(self):
         self.login_browser_quick_test1()
         self.login_test1()
-        d = self.create_doc(
+        d = self.try_create_doc(
             initial_par="""
 #- {plugin=csPlugin #py}
 type: python
@@ -22,7 +22,7 @@ pointsRule:
   expectCode: .*Hei maailma.*
         """
         )
-        dt = self.create_translation(d)
+        dt = self.try_create_translation(d)
         dt.document.set_settings(
             {
                 "global_plugin_attrs": {"all": {"lang": "en"}},
@@ -93,7 +93,8 @@ pointsRule:
         par = self.find_element("#py > tim-plugin-loader > div")
 
         # Wait until the height workaround completes (see answer-browser.component.ts)
-        # self.wait.until(expected_conditions.presence_of_element_located((By.XPATH, "//*[@id='py'][@style='opacity: 1;']")))
+        # self.wait.until(expected_conditions.presence_of_element_located(
+        #   (By.XPATH, "//*[@id='py'][@style='opacity: 1;']")))
 
         # TODO: Why is this slightly different from python_before_answer ?
         self.assert_same_screenshot(
@@ -174,7 +175,7 @@ disableUnchanged: true
 
     def test_csplugin_require_type(self):
         self.login_test1()
-        d = self.create_doc(
+        d = self.try_create_doc(
             initial_par="""
 #- {plugin=csPlugin}
 stem: ""
@@ -186,9 +187,9 @@ stem: ""
 
     def test_csplugin_answernr1(self):
         def input_and_send(s):
-            input = self.find_element(".csEditArea")
-            input.clear()
-            input.send_keys(s)
+            a_input = self.find_element(".csEditArea")
+            a_input.clear()
+            a_input.send_keys(s)
             button = self.find_element(".csRunDiv .timButton")
             button.click()
             self.wait_until_hidden("tim-loading")
@@ -200,7 +201,7 @@ stem: ""
         # 1: 1 + -5
         # 2: -2 + -1
         # 3: 10 + -3
-        d = self.create_doc(
+        d = self.try_create_doc(
             initial_par="""
 ``` {id="suSn2NPH8MC3" #summa2 plugin="csPlugin" rnd="[[-10,10],[-10,-1]]" seed="answernr"}
 type: text
@@ -265,8 +266,8 @@ postprogram: |!!
         # got to task 1/2 there should be the first correct answer -9
         self.find_element(".nextAnswer").click()
         sleep(0.3)
-        input = self.find_element(".csEditArea")
-        self.assertEqual("-9", input.get_attribute("value"))
+        cs_input = self.find_element(".csEditArea")
+        self.assertEqual("-9", cs_input.get_attribute("value"))
 
         # answer again to task 1/2
         self.assertEqual("1/2", count.text)
@@ -297,8 +298,8 @@ postprogram: |!!
         self.goto_document(d)
         time.sleep(0.5)
         self.wait_until_present(".csEditArea")
-        input = self.find_element(".csEditArea")
-        input.click()
+        cs_input = self.find_element(".csEditArea")
+        cs_input.click()
         self.wait_until_present_and_vis(".answer-index-count")
         # self.assertEqual("Uusi", button_new.text) # how to test that there is no new button
         self.assertEqual("Laske: 10 + -3", self.find_element(".stem").text)
@@ -307,7 +308,7 @@ postprogram: |!!
     def test_missing_taskid_warning(self):
         self.login_browser_quick_test1()
         self.login_test1()
-        d = self.create_doc(
+        d = self.try_create_doc(
             initial_par="""
 #- {plugin=csPlugin}
 type: text
@@ -349,10 +350,11 @@ class StackRandomTest(BrowserTest):
         # 1: 11370:1+5
         # 2:
         # 3:
-        d = self.create_doc(
+        d = self.try_create_doc(
             initial_par="""
 ``` {id="suSn2NPH8MC3" #summa3 plugin="csPlugin" rnd="1,20000" seed="answernr"}
 type: stack
+autopeek: false
 copyConsoleLink: ""
 buttonNewTask: Uusi
 undo:
@@ -416,13 +418,42 @@ stackversion: 0
         def stem_text():
             return removeTex(self.find_element(".stackOutput p").text)
 
-        def feedback_text():
-            return self.find_element(".stackprtfeedback-ans1").text
+        def feedback_text(expected: str | None = None):
+            # Markup differs between STACK/TIM versions. Poll known containers
+            # and require expected text so test can't pass accidentally.
+            plugin_selector = ".csRunDiv"
+            plugin = self.find_element(plugin_selector)
+            feedback_selectors = [
+                ".stackprtfeedback-ans1",
+                ".stackprtfeedback",
+                ".stackOutput",
+                "#stackinputfeedback",
+                ".stackinputfeedback1",
+            ]
+            last_texts: list[str] = []
+            timeout = time.time() + 10
+            while time.time() < timeout:
+                found_any = False
+                last_texts = []
+                for selector in feedback_selectors:
+                    for e in plugin.find_elements(By.CSS_SELECTOR, selector):
+                        found_any = True
+                        txt = e.text.strip()
+                        if txt:
+                            last_texts.append(f"{selector}: {txt}")
+                        if txt and (expected is None or expected in txt):
+                            return txt
+                if expected is None and found_any:
+                    break
+                sleep(0.1)
+            if expected is not None:
+                self.fail(f"Feedback text '{expected}' not found. Seen: {last_texts}")
+            self.fail("Feedback element not found in known feedback containers.")
 
         def input_and_send(s):
-            input = self.find_element("#stackapi_ans1")
-            input.clear()
-            input.send_keys(s)
+            s_input = self.find_element("#stackapi_ans1")
+            s_input.clear()
+            s_input.send_keys(s)
             button = self.find_element(".csRunDiv .timButton")
             button.click()
             sleep(0.8)
@@ -438,13 +469,13 @@ stackversion: 0
         button_new = self.find_element_by_text("Uusi")
         count = self.find_element(".answer-index-count")
         self.assertEqual("1/1", count.text)
-        self.assertEqual("OK!", feedback_text())
+        self.assertEqual("OK!", feedback_text("OK!"))
 
         # make a new answer, that is not saved (see later)
         input_and_send("16")
         self.assertEqual("1/1", count.text)
         self.assertEqual("4553:15+2", stem_text())
-        self.assertEqual("Wrong! 4553", feedback_text())
+        self.assertEqual("Wrong! 4553", feedback_text("Wrong! 4553"))
 
         # Answer to new task 2
         button_new.click()
@@ -454,10 +485,10 @@ stackversion: 0
         input_and_send("6")
         self.assertEqual("2/2", count.text)
         self.assertEqual("11370:1+5", stem_text())
-        self.assertEqual("OK!", feedback_text())
+        self.assertEqual("OK!", feedback_text("OK!"))
 
         # Make new answer to same task => no changes
         input_and_send("5")
         self.assertEqual("2/2", count.text)
         self.assertEqual("11370:1+5", stem_text())
-        self.assertEqual("Wrong! 11370", feedback_text())
+        self.assertEqual("Wrong! 11370", feedback_text("Wrong! 11370"))

--- a/timApp/tests/server/timroutetest.py
+++ b/timApp/tests/server/timroutetest.py
@@ -1130,6 +1130,30 @@ class TimRouteTestBase(TimDbTest):
             else None
         )
 
+    def try_create_translation(
+        self,
+        doc: DocEntry,
+        doc_title: str = "title",
+        lang: str = "en",
+        expect_contains=None,
+        expect_content=None,
+        expect_status=200,
+        **kwargs,
+    ) -> Translation:
+        dt = self.create_translation(
+            doc,
+            doc_title,
+            lang,
+            expect_contains,
+            expect_content,
+            expect_status,
+            **kwargs,
+        )
+        assert (
+            dt is not None
+        ), f"Translation creation failed with status {expect_status}"
+        return dt
+
     def assert_content(self, element: HtmlElement, expected: list[str]):
         pars = get_content(element)
         self.assertEqual(expected, pars)

--- a/timApp/util/get_fields.py
+++ b/timApp/util/get_fields.py
@@ -538,6 +538,17 @@ def get_fields_and_users(
                     value = datetime_isoformat(a.answered_on)
                 elif task.field == "ALL":
                     value = p
+                elif task.field and task.field.startswith("qst["):
+                    if type(p) is dict:
+                        p = p.get("c")
+                    if type(p) is list:
+                        from plugin.jsrunner.util import get_qst_index
+
+                        index = get_qst_index(task.field, len(p))
+                        # value = ", ".join(map(str, p[index])) if len(p) > 0 else None
+                        from plugin.jsrunner.util import list_to_string
+
+                        value = list_to_string(p[index]) if len(p) > 0 else None
                 elif task.field == "count":
                     continue
                 else:

--- a/timApp/util/get_fields.py
+++ b/timApp/util/get_fields.py
@@ -43,6 +43,8 @@ from timApp.util.utils import (
     fin_timezone,
     get_current_time,
     partition,
+    get_qst_index,
+    list_to_string,
 )
 
 ALL_ANSWERED_WILDCARD = "*"
@@ -54,7 +56,7 @@ def chunks(l: list, n: int):
 
 
 tallyfield_re = re.compile(
-    r"tally:(?:(?P<validity>count_only_valid|count_all):)?((?P<doc>\d+)\.)?(?P<field>[a-zA-Z0-9öäåÖÄÅ_-]+)(?:.(?P<subfield>[a-zA-Z0-9öäåÖÄÅ_-]+))?(\[ *(?P<ds>[^\[\],]*) *, *(?P<de>[^\[\],]*) *\])?"
+    r"tally:(?:(?P<validity>count_only_valid|count_all):)?((?P<doc>\d+)\.)?(?P<field>[a-zA-Z0-9öäåÖÄÅ_-]+)(?:.(?P<subfield>[a-zA-Z0-9öäåÖÄÅ_-]+))?(\[ *(?P<ds>[^\[\],]*) *, *(?P<de>[^\[\],]*) *])?"
 )
 
 
@@ -542,12 +544,8 @@ def get_fields_and_users(
                     if type(p) is dict:
                         p = p.get("c")
                     if type(p) is list:
-                        from plugin.jsrunner.util import get_qst_index
-
                         index = get_qst_index(task.field, len(p))
                         # value = ", ".join(map(str, p[index])) if len(p) > 0 else None
-                        from plugin.jsrunner.util import list_to_string
-
                         value = list_to_string(p[index]) if len(p) > 0 else None
                 elif task.field == "count":
                     continue

--- a/timApp/util/utils.py
+++ b/timApp/util/utils.py
@@ -367,7 +367,7 @@ def get_error_message(e: Exception) -> str:
 Range = tuple[int, int]
 
 TASK_PROG = re.compile(
-    r"([\w.]*)(:\w*)?\( *(\d*) *, *(\d*) *\)(.*)"
+    r"([\w.\[]*)(:\w*)?\( *(\d*) *, *(\d*) *\)(.*)"
 )  # see https://regex101.com/r/ZZuizF/4
 TASK_NAME_PROG = re.compile(
     r"(\d+\.)?(\w+)[.\[]?.*"

--- a/timApp/util/utils.py
+++ b/timApp/util/utils.py
@@ -1,6 +1,7 @@
 """Utility functions."""
 
 import base64
+import csv
 import hashlib
 import json
 import os
@@ -12,6 +13,7 @@ from concurrent.futures import Future
 from dataclasses import fields, asdict
 from datetime import datetime, timezone
 from enum import Enum
+from io import StringIO
 from itertools import tee
 from pathlib import Path, PurePosixPath
 from types import TracebackType, FrameType
@@ -21,7 +23,7 @@ import dateutil.parser
 import pytz
 import requests
 from flask import g
-from lxml.html import HtmlElement
+from lxml import html
 
 from tim_common.html_sanitize import sanitize_html
 
@@ -56,9 +58,10 @@ def is_int(s: str) -> bool:
 
 
 def datestr_to_relative(d: str | datetime) -> str:
-    if isinstance(d, str):
-        d = datetime.strptime(d, "%Y-%m-%d %H:%M:%S")
-    return date_to_relative(d) if d else ""
+    dt: datetime = (
+        datetime.strptime(d, "%Y-%m-%d %H:%M:%S") if isinstance(d, str) else d
+    )
+    return date_to_relative(dt)
 
 
 def date_to_relative(d: datetime) -> str:
@@ -334,7 +337,7 @@ def static_tim_doc(path: str) -> str:
     return f"static/tim_docs/{path}"
 
 
-def decode_csplugin(text: HtmlElement) -> dict[str, Any]:
+def decode_csplugin(text: html.HtmlElement) -> dict[str, Any]:
     return json.loads(base64.b64decode(text.get("json")))["markup"]
 
 
@@ -396,7 +399,7 @@ def widen_fields(flds: list[str] | str) -> list[str]:
             continue
         parts = field.split("=")
         t = parts[0].strip()
-        a = None
+        a: str | None = None
         if len(parts) > 1:
             a = parts[1].strip()
         match = re.search(TASK_PROG, t)
@@ -415,7 +418,7 @@ def widen_fields(flds: list[str] | str) -> list[str]:
             if not tb:
                 tn = ""
             tn += ft
-            if a is not None:  # a is allowed to be empty
+            if a is not None:  # 'a' variable is allowed to be empty
                 tn += "=" + a + str(i)
             rfields.append(tn)
 
@@ -648,3 +651,39 @@ def short_repr(value: object, n: int = 40) -> str:
         return "{" + items + "}"
 
     return repr(shorten_str(repr(value)))
+
+
+def list_to_string(lst: list[Any]) -> str:
+    sio = StringIO()
+    csv.writer(sio).writerow(lst)
+    return sio.getvalue().rstrip("\r\n")
+
+
+def get_qst_index(qfield: str, qmax: int) -> int:
+    """
+    Given a qfield and a value, return the index of the qfield in the list.
+    If just 'qst[' return 0.
+    """
+    m: re.Match[str] | None | re.Match[bytes] = re.fullmatch(r"qst\[(\d+)]?", qfield)
+    if m:
+        index = int(m.group(1)) - 1
+        if index < 0:
+            return 0
+        if index >= qmax:
+            return qmax - 1
+        return index
+    return 0
+
+
+def parse_list(s: Any) -> list[int | str]:
+    if not isinstance(s, str):
+        s = str(s)
+    row = next(csv.reader(StringIO(s), skipinitialspace=True))
+    result: list[int | str] = []
+    for item in row:
+        item = item.strip()
+        try:
+            result.append(int(item))
+        except ValueError:
+            result.append(item)
+    return result

--- a/timApp/velp/velps.py
+++ b/timApp/velp/velps.py
@@ -238,7 +238,8 @@ def get_velp_content_for_document(
         .join(VelpContent, sq.c.ver == VelpContent.version_id)
         .filter(VelpContent.language_id == language_id)
         .filter(
-            (Velp.valid_until is None) | (Velp.valid_until >= func.current_timestamp())
+            (Velp.valid_until.is_(None))
+            | (Velp.valid_until >= func.current_timestamp())
         )
         .join(VelpInGroup)
         .join(
@@ -279,7 +280,7 @@ def get_velp_label_content_for_document(
             .join(Velp)
             .filter(
                 (Velp.valid_until >= func.current_timestamp())
-                | (Velp.valid_until is None)
+                | (Velp.valid_until.is_(None))
             )
             .join(VelpInGroup)
             .join(

--- a/timApp/velp/velps.py
+++ b/timApp/velp/velps.py
@@ -43,14 +43,13 @@ def _create_velp(
     :return: ID of velp that was just created.
 
     """
-    if not visible_to:
-        visible_to = 4
+    velp_visible_to = 4 if visible_to is None else visible_to
     v = Velp(
         creator_id=creator_id,
         default_points=default_points,
         color=color,
         valid_until=valid_until,
-        visible_to=visible_to,
+        visible_to=velp_visible_to,
         style=style,
     )
     db.session.add(v)
@@ -126,6 +125,7 @@ def create_new_velp(
     :param language_id: Language ID of velp.
     :param visible_to: Default visibility to annotation.
     :param color: Velp color
+    :param style: Velp style
     :return: A tuple of (velp id, velp version id).
 
     """
@@ -152,7 +152,7 @@ def update_velp(
     """
     if not visible_to:
         visible_to = 4
-    v: Velp = db.session.get(Velp, velp_id)
+    v: Velp | None = db.session.get(Velp, velp_id)
     if v:
         v.default_points = default_points
         v.color = color
@@ -238,7 +238,7 @@ def get_velp_content_for_document(
         .join(VelpContent, sq.c.ver == VelpContent.version_id)
         .filter(VelpContent.language_id == language_id)
         .filter(
-            (Velp.valid_until == None) | (Velp.valid_until >= func.current_timestamp())
+            (Velp.valid_until is None) | (Velp.valid_until >= func.current_timestamp())
         )
         .join(VelpInGroup)
         .join(
@@ -279,7 +279,7 @@ def get_velp_label_content_for_document(
             .join(Velp)
             .filter(
                 (Velp.valid_until >= func.current_timestamp())
-                | (Velp.valid_until == None)
+                | (Velp.valid_until is None)
             )
             .join(VelpInGroup)
             .join(

--- a/tim_common/markupmodels.py
+++ b/tim_common/markupmodels.py
@@ -317,6 +317,7 @@ class GenericMarkupModel(KnownMarkupFields):
     spellcheck: bool | None | Missing = missing
     warningFilter: str | Missing | None = missing
     invalidMarker: InvalidMarkerSettings | Missing | None = missing
+    saveKey: str | Missing | None = missing
 
     def get_visible_data(self) -> dict:
         assert isinstance(self.hidden_keys, list)


### PR DESCRIPTION
- lisää qst:hen mahdollisuuden pakottaa tallennus normaalissa muodissa c-attribuuttiin
- keys-attribuutti jolloin tulos on valitu  avaimen arvo k-attribuutissa (tällöin aina c-tallennus)
- mahdollisuus ottaa tableFormiin ja jsrunneriin vain
   valittu arvo ja muuttaa sitä
- mahdollisuus lisätä omia attribuutteja

ks: https://tim.jyu.fi/view/tim/ohjeita/qst#savekey

Tämän hetken käyttötapaus on ISEAI-kursseilla ryhmien arvosanojen antaminen missä kullakin vastaajalla
on eri valinnat (omat ryhmäläiset) ja sitten JSRunnerilla voidaan 'k'-attribuutista lukea annetut arvosanat.

Pohja jolla voi kokeilla:

- https://tim.jyu.fi/teacher/users/vesal/koe/qst/savename2