### PR TITLE
New fixes and features to STACK questions

### DIFF
--- a/timApp/modules/cs/cs.py
+++ b/timApp/modules/cs/cs.py
@@ -2067,38 +2067,6 @@ class TIMServer(http.server.BaseHTTPRequestHandler):
 
         result["web"] = web
 
-        # For Stack type, remove contents of 'formatcorrectresponse' if
-        # - the score indicates an empty or incorrect answer
-        # - the user has exceeded the answerLimit to this task
-        # - the answer is not valid (usually when answer came outside of deadline)
-        #
-        # This is to prevent the correct answer from leaking prematurely via web -> stackResult.
-        if "stack" in ttype:
-            ucode = save.get("usercode", "")
-            if ucode:
-                # Stack tasks may have several answer fields, so we need to check each one
-                ucode = json.loads(ucode)
-                ucode = len("".join([str(v) for v in ucode.values()])) > 0
-            score = result["web"]["stackResult"].get("score", False)
-            valid = False
-            has_tries_left = False
-            queryinfo = query.query.get("info", None)
-            queryinfo = queryinfo[0] if queryinfo else None
-            if queryinfo:
-                valid = queryinfo.get("valid", False)
-                max_tries = queryinfo.get("max_answers", 1)
-                num_tries = queryinfo.get("earlier_answers", 0)
-                has_tries_left = max_tries is not None and num_tries <= max_tries
-
-            if (
-                (not has_tries_left)
-                or (not valid)
-                or (not ucode)
-                or (not score)
-                or (not has_tries_left and score <= 0)
-            ):
-                result["web"]["stackResult"]["formatcorrectresponse"] = ""
-
         # print(result)
 
         # Clean up

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -389,7 +389,7 @@ export class StackPluginComponent
             DOMPurify.sanitize(r.questiontext),
             "text/html"
         );
-        let el = doc.querySelector("div.stackinputfeedback");
+        const el = doc.querySelector("div.stackinputfeedback");
 
         if (!el) {
             return;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -18,6 +18,7 @@ import {PurifyModule} from "tim/util/purify.module";
 import {ScriptedInnerHTMLModule} from "tim/util/scripted-inner-html.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
+import DOMPurify from "dompurify";
 
 const STACK_VARIABLE_PREFIX = "stackapi_";
 
@@ -111,9 +112,6 @@ interface IStackData {
                         (click)="runPeek()">Peek
                 </button>
             </p>
-            <div *ngIf="stackPeek" class="peekdiv" id="peek" style="min-height: 10em;">
-                <div></div>
-            </div>
             <div *ngIf="stackInputFeedback" id="stackinputfeedback"
                  class="stackinputfeedback1"
                  [scriptedInnerHTML]="stackInputFeedback"></div>
@@ -319,9 +317,8 @@ export class StackPluginComponent
             this.error = r.message;
             return;
         }
-
         const qt = this.replace(r.questiontext);
-        const i = qt.indexOf('<div class="stackinputfeedback"');
+        const i = qt.indexOf('<div class="stackinputfeedback"'); // Mahdollinen bugi
         const helper = await import("../stack/ServerSyncValues");
         windowAsAny().ServerSyncValues = helper.ServerSyncValues;
         windowAsAny().findParentElementFromScript =
@@ -358,7 +355,7 @@ export class StackPluginComponent
         if (getTask) {
             // remove input validation texts
             const divinput = this.element.find(".stackinputfeedback");
-            divinput.remove();
+            divinput.addClass("hidden");
         }
     }
 
@@ -386,12 +383,31 @@ export class StackPluginComponent
             this.error = r.message;
             return;
         }
-        const peekDiv = this.element.find(".peekdiv");
-        const peekDivC = peekDiv.children();
-        // editorDiv.empty();
-        const pdiv = $(`<div><div class="math">${r.questiontext}</div></div>`);
-        await ParCompiler.processAllMath(pdiv);
-        peekDivC.replaceWith(pdiv); // TODO: still flashes
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(
+            DOMPurify.sanitize(r.questiontext),
+            "text/html"
+        );
+        let el = doc.querySelector("div.stackinputfeedback");
+
+        if (!el) {
+            return;
+        }
+
+        const curEl = this.element.get()[0];
+        const curMathEl = curEl.querySelector(
+            `div#${el.id}.stackinputfeedback`
+        );
+
+        if (!curMathEl) {
+            return;
+        }
+
+        curMathEl.replaceWith(el);
+
+        el.classList.add("math");
+        await ParCompiler.processAllMath(this.element);
     }
 
     autoPeekInput(id: string) {
@@ -438,7 +454,7 @@ export class StackPluginComponent
         if (!this.stackPeek) {
             // remove extra fields from screen
             let divinput = this.element.find(".stackinputfeedback");
-            divinput.remove();
+            divinput.addClass("hidden");
             divinput = this.element.find(".stackprtfeedback");
             divinput.remove();
             divinput = this.element.find(".stackpartmark");
@@ -455,7 +471,6 @@ export class StackPluginComponent
                 stackData: {...data},
             },
         });
-
         this.isRunning = false;
         if (!r.ok) {
             this.error = r.result.error.error;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -405,18 +405,7 @@ export class StackPluginComponent
         windowAsAny().findParentElementFromScript =
             helper.findParentElementFromScript;
         if (this.markup.buttonBottom || i < 0) {
-            if (this.markup.autosave) {
-                const doc = this.parseElements(qt);
-                doc.querySelectorAll("div.stackprtfeedback").forEach((el) =>
-                    el.remove()
-                );
-                doc.querySelectorAll("p.stackpartmark").forEach((el) =>
-                    el.remove()
-                );
-                this.stackOutput = doc.body.innerHTML;
-            } else {
-                this.stackOutput = qt;
-            }
+            this.stackOutput = qt;
             this.stackInputFeedback = "";
         } else {
             this.stackOutput = qt.substr(0, i) + "\n";

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -1,5 +1,5 @@
 ﻿import * as t from "io-ts";
-import type {ApplicationRef, DoBootstrap} from "@angular/core";
+import {ApplicationRef, DoBootstrap, HostListener} from "@angular/core";
 import {Component, NgModule} from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
 import {
@@ -24,6 +24,7 @@ const STACK_VARIABLE_PREFIX = "stackapi_";
 
 const StackMarkup = t.intersection([
     t.partial({
+        autosave: t.boolean,
         showAnswersOnLoad: t.boolean,
         beforeOpen: t.string,
         buttonBottom: t.boolean,
@@ -101,7 +102,7 @@ interface IStackData {
                         class="timButton btn-sm"
                         (click)="runGetTask()">Show task
                 </button>
-                <button *ngIf="isOpen"
+                <button *ngIf="isOpen && !markup.autosave"
                         [disabled]="isRunning"
                         title="(Ctrl-S)"
                         class="timButton btn-sm"
@@ -119,6 +120,8 @@ interface IStackData {
             <span class="csRunError"
                   *ngIf="error"
                   [innerHtml]="error | purify"></span>
+            &nbsp;&nbsp;
+            <span *ngIf="savedText" class="savedtext">{{savedText}}</span>
 
             <div *ngIf="stackFeedback">
                 <div *ngIf="markup.generalfeedback">
@@ -158,11 +161,14 @@ export class StackPluginComponent
 
     getContentArray?: () => string[] | undefined;
     isUnSaved(userChange?: boolean | undefined): boolean {
+        console.log(this.userCode);
+        console.log(this.originalUserCode);
         return this.userCode !== this.originalUserCode;
     }
 
     async save() {
         await this.runSave();
+        this.savedText = "Saved";
         return {saved: true, message: undefined};
     }
 
@@ -201,8 +207,11 @@ export class StackPluginComponent
     private lastInputFieldId: string = "";
     private lastInputFieldValue: string = "";
     private lastInputFieldElement?: HTMLInputElement;
+    private focusedInputId: string = "";
+    private focusedInputElement?: HTMLInputElement | null = null;
     button: string = "";
     inputplaceholder!: string;
+    savedText: string = "";
 
     private timer?: number;
 
@@ -211,7 +220,9 @@ export class StackPluginComponent
         this.button = this.buttonText();
         const aa = this.attrsall;
         this.userCode = aa.usercode ?? this.markup.by ?? "";
+        console.log(this.userCode);
         this.originalUserCode = this.userCode;
+        console.log(this.originalUserCode);
         this.timWay = aa.timWay ?? this.markup.timWay ?? false;
         this.inputrows = this.markup.inputrows;
         this.inputplaceholder = this.markup.inputplaceholder ?? "";
@@ -243,6 +254,25 @@ export class StackPluginComponent
     ngOnDestroy() {
         if (!this.attrsall.preview) {
             this.vctrl.removeTimComponent(this);
+        }
+    }
+
+    @HostListener("focusin", ["$event"])
+    onFocusIn(event: FocusEvent) {
+        const target = event.target as HTMLElement;
+
+        if (target instanceof HTMLInputElement) {
+            this.focusedInputId = target.id;
+        }
+    }
+
+    @HostListener("focusout")
+    onFocusOut() {
+        this.focusedInputElement = null;
+        this.focusedInputId = "";
+
+        if (this.markup.autosave && this.isUnSaved()) {
+            this.save();
         }
     }
 
@@ -350,6 +380,7 @@ export class StackPluginComponent
             this.stackOutput = qt.substr(0, i) + "\n";
             this.stackInputFeedback = qt.substr(i);
         }
+        // TODO: Tähän if.markup.autosave jne. Parsitaan qt dom ja poistetaan vastauspalautteet
 
         if (!getTask) {
             this.stackFeedback = this.replace(r.generalfeedback);
@@ -377,6 +408,19 @@ export class StackPluginComponent
             const divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
         }
+
+        if (this.markup.autosave && !getTask) {
+            html.find(".stackinputfeedback").addClass("hidden");
+            html.find(".stackprtfeedback").remove();
+            html.find(".stackpartmark").remove();
+        }
+    }
+
+    parseElementsFromSelection(qt: string, select: string) {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(DOMPurify.sanitize(qt), "text/html");
+
+        return doc.querySelector(select);
     }
 
     inputHandler(e: JQuery.TriggeredEvent) {
@@ -391,6 +435,7 @@ export class StackPluginComponent
         }
         this.lastInputFieldId = id;
         this.lastInputFieldValue = target.value;
+        this.savedText = "";
         this.autoPeekInput(id);
     }
 
@@ -404,12 +449,17 @@ export class StackPluginComponent
             return;
         }
 
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(
-            DOMPurify.sanitize(r.questiontext),
-            "text/html"
+        // const parser = new DOMParser();
+        // const doc = parser.parseFromString(
+        //     DOMPurify.sanitize(r.questiontext),
+        //     "text/html"
+        // );
+        // const el = doc.querySelector("div.stackinputfeedback");
+
+        const el = this.parseElementsFromSelection(
+            r.questiontext,
+            "div.stackinputfeedback"
         );
-        const el = doc.querySelector("div.stackinputfeedback");
 
         if (!el) {
             return;
@@ -546,7 +596,7 @@ export class StackPluginComponent
         const stackResult = r.result.web.stackResult;
         this.originalUserCode = this.userCode;
         await this.handleServerResult(stackResult, getTask);
-        if (this.lastInputFieldId) {
+        if (this.lastInputFieldId && !this.markup.autosave) {
             this.lastInputFieldElement = this.element.find(
                 `#${this.lastInputFieldId}`
             )[0] as HTMLInputElement;
@@ -554,6 +604,18 @@ export class StackPluginComponent
                 this.lastInputFieldElement.focus();
                 this.lastInputFieldElement.selectionStart = 0;
                 this.lastInputFieldElement.selectionEnd = 1000;
+            }
+        }
+        // Refocus to the selected input field after autosave
+        if (this.markup.autosave && this.focusedInputId) {
+            this.focusedInputElement = this.element.find(
+                `#${this.focusedInputId}`
+            )[0] as HTMLInputElement;
+            if (this.focusedInputElement) {
+                this.focusedInputElement.focus();
+                // Move the caret to the end of the input
+                const caretPos = this.focusedInputElement.value.length;
+                this.focusedInputElement.setSelectionRange(caretPos, caretPos);
             }
         }
     }

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -25,7 +25,6 @@ import {ScriptedInnerHTMLModule} from "tim/util/scripted-inner-html.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 import DOMPurify from "dompurify";
-import {event} from "jquery";
 
 const STACK_VARIABLE_PREFIX = "stackapi_";
 
@@ -269,6 +268,10 @@ export class StackPluginComponent
 
     @HostListener("focusin", ["$event"])
     onFocusIn(event: FocusEvent) {
+        if (!this.markup.autosave) {
+            return;
+        }
+
         const target = event.target as HTMLElement;
 
         if (target instanceof HTMLInputElement) {
@@ -278,19 +281,19 @@ export class StackPluginComponent
 
     @HostListener("focusout", ["$event"])
     onFocusOut(event: FocusEvent) {
+        if (!this.markup.autosave) {
+            return;
+        }
+
         this.focusedInputElement = null;
         this.focusedInputId = "";
 
         const target = event.target as HTMLElement;
-
-        if (
-            this.originalUserCode === "" &&
-            target instanceof HTMLInputElement
-        ) {
+        if (!this.originalUserCode && target instanceof HTMLInputElement) {
             this.userCode = target.value;
         }
 
-        if (this.markup.autosave && this.isUnSaved()) {
+        if (this.isUnSaved()) {
             this.save();
         }
     }
@@ -393,7 +396,18 @@ export class StackPluginComponent
         windowAsAny().findParentElementFromScript =
             helper.findParentElementFromScript;
         if (this.markup.buttonBottom || i < 0) {
-            this.stackOutput = qt;
+            if (this.markup.autosave) {
+                const doc = this.parseElements(qt);
+                doc.querySelectorAll("div.stackprtfeedback").forEach((el) =>
+                    el.remove()
+                );
+                doc.querySelectorAll("p.stackpartmark").forEach((el) =>
+                    el.remove()
+                );
+                this.stackOutput = doc.body.innerHTML;
+            } else {
+                this.stackOutput = qt;
+            }
             this.stackInputFeedback = "";
         } else {
             this.stackOutput = qt.substr(0, i) + "\n";
@@ -427,19 +441,11 @@ export class StackPluginComponent
             const divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
         }
-
-        if (this.markup.autosave && !getTask) {
-            html.find(".stackinputfeedback").addClass("hidden");
-            html.find(".stackprtfeedback").remove();
-            html.find(".stackpartmark").remove();
-        }
     }
 
-    parseElementsFromSelection(qt: string, select: string) {
+    parseElements(qt: string) {
         const parser = new DOMParser();
-        const doc = parser.parseFromString(DOMPurify.sanitize(qt), "text/html");
-
-        return doc.querySelector(select);
+        return parser.parseFromString(DOMPurify.sanitize(qt), "text/html");
     }
 
     inputHandler(e: JQuery.TriggeredEvent) {
@@ -468,8 +474,7 @@ export class StackPluginComponent
             return;
         }
 
-        const el = this.parseElementsFromSelection(
-            r.questiontext,
+        const el = this.parseElements(r.questiontext).querySelector(
             "div.stackinputfeedback"
         );
 

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -167,17 +167,10 @@ export class StackPluginComponent
 
     getContentArray?: () => string[] | undefined;
     isUnSaved(userChange?: boolean | undefined): boolean {
-        console.log("isUnsaved userCode: ", this.userCode);
-        console.log("isUnsaved originalUserCode: ", this.originalUserCode);
-        console.log(
-            "Ovatko eri, eli pitääkö tallentaa? ",
-            this.userCode !== this.originalUserCode
-        );
         return this.userCode !== this.originalUserCode;
     }
 
     async save() {
-        console.log("Tallentaminen tapahtui eli ajetaan runSend()");
         await this.runSave();
         return {saved: true, message: undefined};
     }
@@ -227,7 +220,6 @@ export class StackPluginComponent
     private timer?: number;
 
     ngOnInit() {
-        console.log("ngOnInit");
         super.ngOnInit();
         this.button = this.buttonText();
         const aa = this.attrsall;
@@ -249,12 +241,10 @@ export class StackPluginComponent
         });
 
         if (this.markup.open) {
-            console.log("Opening...");
             this.runGetTask();
         }
 
         if (this.markup.showAnswersOnLoad) {
-            console.log("showAnswersOnLoad");
             this.showResponseWithoutAnswering();
         }
 
@@ -313,7 +303,6 @@ export class StackPluginComponent
         }
         await ab.loader.abLoad.promise;
         if (ab.answers.length > 0) {
-            console.log("ShowResponseWithoutAnswering: ");
             this.runSend(false, true, true);
         }
     }
@@ -568,20 +557,11 @@ export class StackPluginComponent
     }
 
     async runGetTask() {
-        console.log("runGetTask");
         this.isOpen = true;
         await this.runSend(true);
     }
 
     async runSend(getTask = false, getPrevAnswer = false, nosave = false) {
-        console.log(
-            "runSend: getTask:  ",
-            getTask,
-            " getPrevAnswer",
-            getPrevAnswer,
-            " nosave: ",
-            nosave
-        );
         if (this.pluginMeta.isPreview()) {
             this.error = "Cannot run plugin while previewing.";
             return;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -24,6 +24,7 @@ const STACK_VARIABLE_PREFIX = "stackapi_";
 
 const StackMarkup = t.intersection([
     t.partial({
+        showAnswersOnLoad: t.boolean,
         beforeOpen: t.string,
         buttonBottom: t.boolean,
         by: t.string,
@@ -230,6 +231,10 @@ export class StackPluginComponent
             this.runGetTask();
         }
 
+        if (this.markup.showAnswersOnLoad) {
+            this.showResponseWithoutAnswering();
+        }
+
         if (!this.attrsall.preview) {
             this.vctrl.addTimComponent(this);
         }
@@ -238,6 +243,21 @@ export class StackPluginComponent
     ngOnDestroy() {
         if (!this.attrsall.preview) {
             this.vctrl.removeTimComponent(this);
+        }
+    }
+
+    async showResponseWithoutAnswering(): Promise<void> {
+        const taskId = this.getTaskId()?.docTask();
+        if (!taskId) {
+            return;
+        }
+        const ab = await this.vctrl.getAnswerBrowserAsync(taskId);
+        if (!ab) {
+            return;
+        }
+        await ab.loader.abLoad.promise;
+        if (ab.answers.length > 0) {
+            this.runSend(false);
         }
     }
 

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -1,5 +1,11 @@
 ﻿import * as t from "io-ts";
-import {ApplicationRef, DoBootstrap, HostListener} from "@angular/core";
+import {
+    ApplicationRef,
+    DoBootstrap,
+    ElementRef,
+    HostListener,
+    ViewChild,
+} from "@angular/core";
 import {Component, NgModule} from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
 import {
@@ -19,6 +25,7 @@ import {ScriptedInnerHTMLModule} from "tim/util/scripted-inner-html.module";
 import {registerPlugin} from "tim/plugin/pluginRegistry";
 import {CommonModule} from "@angular/common";
 import DOMPurify from "dompurify";
+import {event} from "jquery";
 
 const STACK_VARIABLE_PREFIX = "stackapi_";
 
@@ -161,8 +168,12 @@ export class StackPluginComponent
 
     getContentArray?: () => string[] | undefined;
     isUnSaved(userChange?: boolean | undefined): boolean {
-        console.log(this.userCode);
-        console.log(this.originalUserCode);
+        console.log("isUnsaved userCode: ", this.userCode);
+        console.log("isUnsaved originalUserCode: ", this.originalUserCode);
+        console.log(
+            "Ovatko eri, eli pitääkö tallentaa? ",
+            this.userCode !== this.originalUserCode
+        );
         return this.userCode !== this.originalUserCode;
     }
 
@@ -212,6 +223,7 @@ export class StackPluginComponent
     button: string = "";
     inputplaceholder!: string;
     savedText: string = "";
+    inputs?: HTMLInputElement[];
 
     private timer?: number;
 
@@ -220,9 +232,7 @@ export class StackPluginComponent
         this.button = this.buttonText();
         const aa = this.attrsall;
         this.userCode = aa.usercode ?? this.markup.by ?? "";
-        console.log(this.userCode);
         this.originalUserCode = this.userCode;
-        console.log(this.originalUserCode);
         this.timWay = aa.timWay ?? this.markup.timWay ?? false;
         this.inputrows = this.markup.inputrows;
         this.inputplaceholder = this.markup.inputplaceholder ?? "";
@@ -266,10 +276,19 @@ export class StackPluginComponent
         }
     }
 
-    @HostListener("focusout")
-    onFocusOut() {
+    @HostListener("focusout", ["$event"])
+    onFocusOut(event: FocusEvent) {
         this.focusedInputElement = null;
         this.focusedInputId = "";
+
+        const target = event.target as HTMLElement;
+
+        if (
+            this.originalUserCode === "" &&
+            target instanceof HTMLInputElement
+        ) {
+            this.userCode = target.value;
+        }
 
         if (this.markup.autosave && this.isUnSaved()) {
             this.save();
@@ -448,13 +467,6 @@ export class StackPluginComponent
             this.error = r.message;
             return;
         }
-
-        // const parser = new DOMParser();
-        // const doc = parser.parseFromString(
-        //     DOMPurify.sanitize(r.questiontext),
-        //     "text/html"
-        // );
-        // const el = doc.querySelector("div.stackinputfeedback");
 
         const el = this.parseElementsFromSelection(
             r.questiontext,

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -177,8 +177,8 @@ export class StackPluginComponent
     }
 
     async save() {
+        console.log("Tallentaminen tapahtui eli ajetaan runSend()");
         await this.runSave();
-        this.savedText = "Saved";
         return {saved: true, message: undefined};
     }
 
@@ -227,6 +227,7 @@ export class StackPluginComponent
     private timer?: number;
 
     ngOnInit() {
+        console.log("ngOnInit");
         super.ngOnInit();
         this.button = this.buttonText();
         const aa = this.attrsall;
@@ -248,10 +249,12 @@ export class StackPluginComponent
         });
 
         if (this.markup.open) {
+            console.log("Opening...");
             this.runGetTask();
         }
 
         if (this.markup.showAnswersOnLoad) {
+            console.log("showAnswersOnLoad");
             this.showResponseWithoutAnswering();
         }
 
@@ -287,6 +290,7 @@ export class StackPluginComponent
 
         this.focusedInputElement = null;
         this.focusedInputId = "";
+        this.savedText = "";
 
         const target = event.target as HTMLElement;
         if (!this.originalUserCode && target instanceof HTMLInputElement) {
@@ -309,7 +313,8 @@ export class StackPluginComponent
         }
         await ab.loader.abLoad.promise;
         if (ab.answers.length > 0) {
-            this.runSend(false);
+            console.log("ShowResponseWithoutAnswering: ");
+            this.runSend(false, true, true);
         }
     }
 
@@ -380,7 +385,11 @@ export class StackPluginComponent
         return s;
     }
 
-    async handleServerResult(r: StackResult, getTask: boolean) {
+    async handleServerResult(
+        r: StackResult,
+        getTask: boolean,
+        getPrevAnswer: boolean
+    ) {
         if (typeof r === "string") {
             this.error = r.toString();
             return;
@@ -413,9 +422,8 @@ export class StackPluginComponent
             this.stackOutput = qt.substr(0, i) + "\n";
             this.stackInputFeedback = qt.substr(i);
         }
-        // TODO: Tähän if.markup.autosave jne. Parsitaan qt dom ja poistetaan vastauspalautteet
 
-        if (!getTask) {
+        if (!getTask || getPrevAnswer) {
             this.stackFeedback = this.replace(r.generalfeedback);
             this.stackFormatCorrectResponse = this.replace(
                 r.formatcorrectresponse
@@ -436,7 +444,7 @@ export class StackPluginComponent
         const inputse = html.find("textarea");
         $(inputs).on("keyup", (e) => this.inputHandler(e));
         $(inputse).on("keyup", (e) => this.inputHandler(e));
-        if (getTask) {
+        if (getTask && !this.markup.autosave) {
             // remove input validation texts
             const divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
@@ -538,7 +546,7 @@ export class StackPluginComponent
             return;
         }
         this.isRunning = true;
-        if (!this.stackPeek) {
+        if (!this.stackPeek && !this.markup.autosave) {
             // remove extra fields from screen
             let divinput = this.element.find(".stackinputfeedback");
             divinput.addClass("hidden");
@@ -571,25 +579,36 @@ export class StackPluginComponent
     }
 
     async runGetTask() {
+        console.log("runGetTask");
         this.isOpen = true;
         await this.runSend(true);
     }
 
-    async runSend(getTask = false) {
+    async runSend(getTask = false, getPrevAnswer = false, nosave = false) {
+        console.log(
+            "runSend: getTask:  ",
+            getTask,
+            " getPrevAnswer",
+            getPrevAnswer,
+            " nosave: ",
+            nosave
+        );
         if (this.pluginMeta.isPreview()) {
             this.error = "Cannot run plugin while previewing.";
             return;
         }
         this.stackPeek = false;
         this.error = "";
+        this.savedText = "";
         this.isRunning = true;
         const stackData = this.collectData();
-
         const r = await this.postAnswer<{
             web: {stackResult: StackResult; error?: string};
         }>({
             input: {
                 getTask: getTask,
+                nosave: nosave,
+                prevAnswer: getPrevAnswer,
                 stackData: stackData,
                 type: "stack",
                 usercode: this.timWay
@@ -610,9 +629,12 @@ export class StackPluginComponent
             this.error = r.result.web.error;
             return;
         }
+        if (r.result.savedNew) {
+            this.savedText = "Saved";
+        }
         const stackResult = r.result.web.stackResult;
         this.originalUserCode = this.userCode;
-        await this.handleServerResult(stackResult, getTask);
+        await this.handleServerResult(stackResult, getTask, getPrevAnswer);
         if (this.lastInputFieldId && !this.markup.autosave) {
             this.lastInputFieldElement = this.element.find(
                 `#${this.lastInputFieldId}`

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -279,13 +279,18 @@ export class StackPluginComponent
         }
 
         this.focusedInputElement = null;
+
         this.focusedInputId = "";
         this.savedText = "";
-
         const target = event.target as HTMLElement;
+
         if (!this.originalUserCode && target instanceof HTMLInputElement) {
             this.userCode = target.value;
         }
+
+        // Flush the DOM to userCode
+        this.stopTimer();
+        this.collectAnswer("");
 
         if (this.isUnSaved()) {
             this.save();

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -416,7 +416,9 @@ export class StackPluginComponent
             );
             this.stackAnswerNotes = this.replace(JSON.stringify(r.answernotes));
         }
-        this.stackScore = r.score.toString();
+        if (r.score) {
+            this.stackScore = r.score.toString();
+        }
         this.stackTime = `Request Time: ${r.request_time.toFixed(
             2
         )} Api Time: ${r.api_time.toFixed(2)}`;

--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -1,11 +1,6 @@
 ﻿import * as t from "io-ts";
-import {
-    ApplicationRef,
-    DoBootstrap,
-    ElementRef,
-    HostListener,
-    ViewChild,
-} from "@angular/core";
+import type {ApplicationRef, DoBootstrap} from "@angular/core";
+import {HostListener} from "@angular/core";
 import {Component, NgModule} from "@angular/core";
 import {ParCompiler} from "tim/editor/parCompiler";
 import {

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -114,6 +114,33 @@ class Stack(Language):
         except json.JSONDecodeError:
             return 1, "", str(r.content.decode()), ""
 
+        # Remove contents of 'formatcorrectresponse' if
+        # - the score indicates an empty or incorrect answer
+        # - the user has exceeded the answerLimit to this task
+        # - the answer is not valid (usually when answer was sent outside the deadline)
+        #
+        # This is to prevent the correct answer from leaking prematurely via web -> stackResult.
+        ucode = input.get("usercode", "")
+        if ucode:
+            # Stack tasks may have several answer fields, so we need to check each one
+            ucode = json.loads(ucode)
+            ucode = len("".join([str(v) for v in ucode.values()])) > 0
+        score = r["score"]
+        valid = info.get("valid", False)
+        max_tries = info.get("max_answers", 1)
+        num_tries = info.get("earlier_answers", 0)
+        # If max_tries is None the task does not have an answer limit
+        has_tries_left = True if max_tries is None else num_tries <= max_tries
+
+        if (
+            (not has_tries_left)
+            or (not valid)
+            or (not ucode)
+            or (not score)
+            or (not has_tries_left and score <= 0)
+        ):
+            r["formatcorrectresponse"] = ""
+
         if "score" in r:
             out = "Score: %s" % r.get("score", 0)
             del r["score"]  # Don't leak the score in the response

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -86,8 +86,11 @@ class Stack(Language):
         )
         stack_data["question"] = q_data
 
-        if not prev_answer and nosave or get_task or hide_results:
+        if not prev_answer and nosave or get_task:
             stack_data["score"] = False
+            stack_data["feedback"] = False
+        if hide_results:
+            stack_data["score"] = True
             stack_data["feedback"] = False
         stack_data["answer"] = data.get("answer")
         stack_data["prefix"] = data.get("prefix")
@@ -108,7 +111,11 @@ class Stack(Language):
             r = r.json()
         except json.JSONDecodeError:
             return 1, "", str(r.content.decode()), ""
-        out = "Score: %s" % r.get("score", 0)
+
+        if "score" in r:
+            out = "Score: %s" % r.get("score", 0)
+            del r["score"]  # Don't leak the score in the response
+
         # r['questiontext'] = tim_sanitize(r['questiontext'])
 
         if nosave:

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -77,13 +77,16 @@ class Stack(Language):
         nosave = input.get("nosave", False)
         stack_data["seed"] = userseed
 
+        prev_answer = input.get("prevAnswer", False)
+        hide_results = markup.get("hideResults", False)
+
         q = stack_data.get("question", "")
         q_data = self.parse_stack_question(
             q, not self.query.jso.get("markup").get("stackjsx")
         )
         stack_data["question"] = q_data
 
-        if nosave or get_task:
+        if not prev_answer and nosave or get_task or hide_results:
             stack_data["score"] = False
             stack_data["feedback"] = False
         stack_data["answer"] = data.get("answer")

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 
 import requests
 import yaml
+from bs4 import BeautifulSoup
 
 from languages import Language
 from tim_common.cs_sanitizer import tim_sanitize
@@ -92,6 +93,7 @@ class Stack(Language):
         if hide_results:
             stack_data["score"] = True
             stack_data["feedback"] = False
+
         stack_data["answer"] = data.get("answer")
         stack_data["prefix"] = data.get("prefix")
         stack_data["verifyvar"] = data.get("verifyvar", "")
@@ -117,6 +119,15 @@ class Stack(Language):
             del r["score"]  # Don't leak the score in the response
 
         # r['questiontext'] = tim_sanitize(r['questiontext'])
+
+        if hide_results:
+            # The information about points needs to be removed from the questiontext HTML
+            question_text = r.get("questiontext", "")
+            soup = BeautifulSoup(question_text, "html.parser")
+            for element in soup.select(".stackpartmark"):
+                element.decompose()
+
+            r["questiontext"] = str(soup)
 
         if nosave:
             out = ""


### PR DESCRIPTION
This pull request introduces possibility to use autosave in stack questions, and  to display the input feedback and stack results in the position set in the stack question HTML. Also, now it is possible to have the question load previous answers on document load. 

New option is added for exams to hide results. This also hides points, but ensures that the points are saved for the answerBrowser.

The functionality of timWay option is no longer guaranteed.

### Usages

**Loading previous answers** - New option `showAnswersOnLoad: true/false`.
Use the following settings to have stack load previous answers when the document loads:

Example:
```
showAnswersOnLoad: true
eagerlyLoadState: true
open: true
```

**Hiding results** - New option `hideResults: true/false`
The score information and the feedback are removed from the HTML that is retrieved from the stack server. This does not affect the score that is recorded in the answer route. The removal of feedback is done by parsing the question text and removing them from parsed HTML. Note that the score should be set to true, otherwise the points won't be saved to the answer.

Example: 
```
...
-pointsRule: {}
hideResults: true
-stackData:
    ...
    score: true
    feedback: true
    ...
```

**Autosave** - New option `autosave: true/false`
This option removes the send button and saving is done when the input fields lose focus. Introduces "Saved" text in the bottom of the component.

Example:
```
autosave: true
```