### PR TITLE
Rnd: i-list

### DIFF
--- a/timApp/tests/server/test_random.py
+++ b/timApp/tests/server/test_random.py
@@ -2,7 +2,7 @@
 import ast
 
 from timApp.tests.server.timroutetest import TimRouteTest, get_content
-from timApp.util.rndutils import SeedClass, get_rnds
+from timApp.util.rndutils import SeedClass, get_rands_as_dict, get_rnds
 
 
 class RandomTest(TimRouteTest):
@@ -47,7 +47,7 @@ class RandomTest(TimRouteTest):
 """
         )
         nums = self.get_number_list(d)
-        # A plain paragraph has no attempt counter, so an m-list stays on the
+        # A plain paragraph has no attempt counter, so an i-list stays on the
         # first value of the first cycle.
         self.assertEqual(1, len(nums))
         self.assertIn(nums[0], range(1, 8))
@@ -126,6 +126,34 @@ class RandomTest(TimRouteTest):
         for spec in ["i", "i[1,7,0]", "i[1,900]"]:
             with self.assertRaises(ValueError, msg=spec):
                 get_rnds({"rnd": spec}, "rnd", SeedClass(1, 0))
+
+    @staticmethod
+    def walk_names(specs, attempts, seed=12345):
+        """Values each named i-list gives on successive attempts.
+
+        Same as walk(), but through get_rands_as_dict, which is the way a block
+        with several rndnames is served.
+        """
+        attrs = {"rndnames": ",".join(specs), "seed": "answernr", **specs}
+        out: dict = {name: [] for name in specs}
+        for i in range(attempts):
+            rnds, _, _ = get_rands_as_dict(attrs, SeedClass(seed, i))
+            for name in specs:
+                out[name].append(rnds[name][0])
+        return out
+
+    def test_distinct_with_several_rndnames(self):
+        # Every named i-list gets the attempt counter, not only the first one.
+        walks = self.walk_names({"a": "i[1,5]", "b": "i[1,5]", "c": "i[1,5]"}, 10)
+        for name, nums in walks.items():
+            self.assertEqual([1, 2, 3, 4, 5], sorted(nums[:5]), msg=name)
+            self.assertEqual([1, 2, 3, 4, 5], sorted(nums[5:]), msg=name)
+            for i in range(1, len(nums)):
+                self.assertNotEqual(nums[i - 1], nums[i], msg=f"{name} {i=}")
+        # And lists over the same range walk it in their own order.
+        self.assertNotEqual(walks["a"], walks["b"])
+        self.assertNotEqual(walks["b"], walks["c"])
+        self.assertNotEqual(walks["a"], walks["c"])
 
     def test_distinct_with_new_task_seed(self):
         # A paragraph is only a new task, and so only gets its attempts

--- a/timApp/tests/server/test_random.py
+++ b/timApp/tests/server/test_random.py
@@ -104,11 +104,14 @@ class RandomTest(TimRouteTest):
 
     def test_distinct_step_and_bare_forms(self):
         self.assertEqual([1, 3, 5, 7], sorted(v[0] for v in self.walk("i[1,7,2]", 4)))
-        # Both ends of the range belong to it, as with s.
-        bare = [v[0] for v in self.walk("i10", 11)]
-        self.assertEqual(list(range(0, 11)), sorted(bare))
-        self.assertEqual(bare, [v[0] for v in self.walk("i1:10", 11)])
-        self.assertEqual(bare, [v[0] for v in self.walk("i[10]", 11)])
+        # A bare number is the size of the range, as with s: i10 walks 0-9.
+        bare = [v[0] for v in self.walk("i10", 10)]
+        self.assertEqual(list(range(0, 10)), sorted(bare))
+        self.assertEqual(bare, [v[0] for v in self.walk("i[0,9]", 10)])
+        # Written out, both ends of the range belong to it, again as with s.
+        for spec in ["i1:10", "i[10]", "i[0,10]"]:
+            nums = [v[0] for v in self.walk(spec, 11)]
+            self.assertEqual(list(range(0, 11)), sorted(nums), msg=spec)
 
     def test_distinct_without_attempt_counter(self):
         # A seed that is not a SeedClass carries no counter, so the walk stays

--- a/timApp/tests/server/test_random.py
+++ b/timApp/tests/server/test_random.py
@@ -38,11 +38,11 @@ class RandomTest(TimRouteTest):
         self.assertTrue(all(1 <= x <= 8 for x in nums))
         self.assertEqual(nums, self.get_number_list(d, 1))
 
-    def test_rnd_m(self):
+    def test_rnd_i(self):
         self.login_test1()
         d = self.create_doc(
             initial_par="""
-#- {rnd="m[1,7]"}
+#- {rnd="i[1,7]"}
 %%rnd%%
 """
         )
@@ -55,7 +55,7 @@ class RandomTest(TimRouteTest):
 
     @staticmethod
     def walk(spec, attempts, seed=12345, attrs=None):
-        """Values an m-list gives on successive attempts.
+        """Values an i-list gives on successive attempts.
 
         SeedClass.extraseed is what askNew increases by one for every new
         version of a task, so counting it up here stands for pressing askNew.
@@ -65,23 +65,23 @@ class RandomTest(TimRouteTest):
             for i in range(attempts)
         ]
 
-    def test_m_cycle_uses_every_value_once(self):
-        nums = [v[0] for v in self.walk("m[1,7]", 7)]
+    def test_distinct_cycle_uses_every_value_once(self):
+        nums = [v[0] for v in self.walk("i[1,7]", 7)]
         self.assertEqual([1, 2, 3, 4, 5, 6, 7], sorted(nums))
         self.assertNotEqual([1, 2, 3, 4, 5, 6, 7], nums)  # and in a shuffled order
 
-    def test_m_reshuffles_on_every_cycle(self):
-        nums = [v[0] for v in self.walk("m[1,7]", 14)]
+    def test_distinct_reshuffles_on_every_cycle(self):
+        nums = [v[0] for v in self.walk("i[1,7]", 14)]
         first, second = nums[:7], nums[7:]
         self.assertEqual(sorted(first), sorted(second))
         self.assertNotEqual(first, second)
 
-    def test_m_no_repeat_until_pool_is_used_up(self):
+    def test_distinct_no_repeat_until_pool_is_used_up(self):
         # Includes the wrap: a cycle never starts with the value the cycle
         # before it ended with.
         for size in range(2, 10):
             for seed in range(20):
-                nums = [v[0] for v in self.walk(f"m[1,{size}]", size * 4, seed)]
+                nums = [v[0] for v in self.walk(f"i[1,{size}]", size * 4, seed)]
                 for start in range(0, len(nums), size):
                     cycle = nums[start : start + size]
                     self.assertEqual(size, len(set(cycle)), msg=f"{size=} {seed=}")
@@ -90,49 +90,49 @@ class RandomTest(TimRouteTest):
                         nums[i - 1], nums[i], msg=f"{size=} {seed=} {i=}"
                     )
 
-    def test_m_short_pools(self):
+    def test_distinct_short_pools(self):
         # One value cannot avoid repeating; two have no order left to choose.
-        self.assertEqual([[5]] * 4, self.walk("m[5,5]", 4))
-        nums = [v[0] for v in self.walk("m[1,2]", 6)]
+        self.assertEqual([[5]] * 4, self.walk("i[5,5]", 4))
+        nums = [v[0] for v in self.walk("i[1,2]", 6)]
         self.assertTrue(all(a != b for a, b in zip(nums, nums[1:])))
 
-    def test_m_many_values_per_attempt(self):
-        attempts = self.walk("m3:[1,9]", 3)
+    def test_distinct_many_values_per_attempt(self):
+        attempts = self.walk("i3:[1,9]", 3)
         self.assertTrue(all(len(a) == 3 for a in attempts))
         # Three attempts of three values use up the pool of nine exactly once.
         self.assertEqual(list(range(1, 10)), sorted(v for a in attempts for v in a))
 
-    def test_m_step_and_bare_forms(self):
-        self.assertEqual([1, 3, 5, 7], sorted(v[0] for v in self.walk("m[1,7,2]", 4)))
+    def test_distinct_step_and_bare_forms(self):
+        self.assertEqual([1, 3, 5, 7], sorted(v[0] for v in self.walk("i[1,7,2]", 4)))
         # Both ends of the range belong to it, as with s.
-        bare = [v[0] for v in self.walk("m10", 11)]
+        bare = [v[0] for v in self.walk("i10", 11)]
         self.assertEqual(list(range(0, 11)), sorted(bare))
-        self.assertEqual(bare, [v[0] for v in self.walk("m1:10", 11)])
-        self.assertEqual(bare, [v[0] for v in self.walk("m[10]", 11)])
+        self.assertEqual(bare, [v[0] for v in self.walk("i1:10", 11)])
+        self.assertEqual(bare, [v[0] for v in self.walk("i[10]", 11)])
 
-    def test_m_without_attempt_counter(self):
+    def test_distinct_without_attempt_counter(self):
         # A seed that is not a SeedClass carries no counter, so the walk stays
         # on the first value, and stays there for good.
-        nums, _, _ = get_rnds({"rnd": "m[1,7]"}, "rnd", 12345)
-        self.assertEqual(self.walk("m[1,7]", 1)[0], nums)
-        self.assertEqual(nums, get_rnds({"rnd": "m[1,7]"}, "rnd", 12345)[0])
+        nums, _, _ = get_rnds({"rnd": "i[1,7]"}, "rnd", 12345)
+        self.assertEqual(self.walk("i[1,7]", 1)[0], nums)
+        self.assertEqual(nums, get_rnds({"rnd": "i[1,7]"}, "rnd", 12345)[0])
 
-    def test_m_same_attempt_gives_same_value(self):
-        self.assertEqual(self.walk("m[1,7]", 20), self.walk("m[1,7]", 20))
-        self.assertNotEqual(self.walk("m[1,7]", 20), self.walk("m[1,7]", 20, 999))
+    def test_distinct_same_attempt_gives_same_value(self):
+        self.assertEqual(self.walk("i[1,7]", 20), self.walk("i[1,7]", 20))
+        self.assertNotEqual(self.walk("i[1,7]", 20), self.walk("i[1,7]", 20, 999))
 
-    def test_m_bad_range(self):
+    def test_distinct_bad_range(self):
         # ValueError is what insert_rnds turns into a message in the document.
-        for spec in ["m", "m[1,7,0]", "m[1,900]"]:
+        for spec in ["i", "i[1,7,0]", "i[1,900]"]:
             with self.assertRaises(ValueError, msg=spec):
                 get_rnds({"rnd": spec}, "rnd", SeedClass(1, 0))
 
-    def test_m_with_new_task_seed(self):
+    def test_distinct_with_new_task_seed(self):
         # A paragraph is only a new task, and so only gets its attempts
         # counted, when it has seed="answernr". That is therefore the seed an
-        # m-list is used with, and it must not put the pool in a new order on
+        # i-list is used with, and it must not put the pool in a new order on
         # every attempt.
-        nums = [v[0] for v in self.walk("m[1,7]", 14, attrs={"seed": "answernr"})]
+        nums = [v[0] for v in self.walk("i[1,7]", 14, attrs={"seed": "answernr"})]
         self.assertEqual([1, 2, 3, 4, 5, 6, 7], sorted(nums[:7]))
         self.assertEqual([1, 2, 3, 4, 5, 6, 7], sorted(nums[7:]))
         for i in range(1, len(nums)):

--- a/timApp/tests/server/test_random.py
+++ b/timApp/tests/server/test_random.py
@@ -2,6 +2,7 @@
 import ast
 
 from timApp.tests.server.timroutetest import TimRouteTest, get_content
+from timApp.util.rndutils import SeedClass, get_rnds
 
 
 class RandomTest(TimRouteTest):
@@ -36,3 +37,103 @@ class RandomTest(TimRouteTest):
         self.assertEqual(3, len(set(nums)))
         self.assertTrue(all(1 <= x <= 8 for x in nums))
         self.assertEqual(nums, self.get_number_list(d, 1))
+
+    def test_rnd_m(self):
+        self.login_test1()
+        d = self.create_doc(
+            initial_par="""
+#- {rnd="m[1,7]"}
+%%rnd%%
+"""
+        )
+        nums = self.get_number_list(d)
+        # A plain paragraph has no attempt counter, so an m-list stays on the
+        # first value of the first cycle.
+        self.assertEqual(1, len(nums))
+        self.assertIn(nums[0], range(1, 8))
+        self.assertEqual(nums, self.get_number_list(d))  # should be cached
+
+    @staticmethod
+    def walk(spec, attempts, seed=12345, attrs=None):
+        """Values an m-list gives on successive attempts.
+
+        SeedClass.extraseed is what askNew increases by one for every new
+        version of a task, so counting it up here stands for pressing askNew.
+        """
+        return [
+            get_rnds({"rnd": spec, **(attrs or {})}, "rnd", SeedClass(seed, i))[0]
+            for i in range(attempts)
+        ]
+
+    def test_m_cycle_uses_every_value_once(self):
+        nums = [v[0] for v in self.walk("m[1,7]", 7)]
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7], sorted(nums))
+        self.assertNotEqual([1, 2, 3, 4, 5, 6, 7], nums)  # and in a shuffled order
+
+    def test_m_reshuffles_on_every_cycle(self):
+        nums = [v[0] for v in self.walk("m[1,7]", 14)]
+        first, second = nums[:7], nums[7:]
+        self.assertEqual(sorted(first), sorted(second))
+        self.assertNotEqual(first, second)
+
+    def test_m_no_repeat_until_pool_is_used_up(self):
+        # Includes the wrap: a cycle never starts with the value the cycle
+        # before it ended with.
+        for size in range(2, 10):
+            for seed in range(20):
+                nums = [v[0] for v in self.walk(f"m[1,{size}]", size * 4, seed)]
+                for start in range(0, len(nums), size):
+                    cycle = nums[start : start + size]
+                    self.assertEqual(size, len(set(cycle)), msg=f"{size=} {seed=}")
+                for i in range(1, len(nums)):
+                    self.assertNotEqual(
+                        nums[i - 1], nums[i], msg=f"{size=} {seed=} {i=}"
+                    )
+
+    def test_m_short_pools(self):
+        # One value cannot avoid repeating; two have no order left to choose.
+        self.assertEqual([[5]] * 4, self.walk("m[5,5]", 4))
+        nums = [v[0] for v in self.walk("m[1,2]", 6)]
+        self.assertTrue(all(a != b for a, b in zip(nums, nums[1:])))
+
+    def test_m_many_values_per_attempt(self):
+        attempts = self.walk("m3:[1,9]", 3)
+        self.assertTrue(all(len(a) == 3 for a in attempts))
+        # Three attempts of three values use up the pool of nine exactly once.
+        self.assertEqual(list(range(1, 10)), sorted(v for a in attempts for v in a))
+
+    def test_m_step_and_bare_forms(self):
+        self.assertEqual([1, 3, 5, 7], sorted(v[0] for v in self.walk("m[1,7,2]", 4)))
+        # Both ends of the range belong to it, as with s.
+        bare = [v[0] for v in self.walk("m10", 11)]
+        self.assertEqual(list(range(0, 11)), sorted(bare))
+        self.assertEqual(bare, [v[0] for v in self.walk("m1:10", 11)])
+        self.assertEqual(bare, [v[0] for v in self.walk("m[10]", 11)])
+
+    def test_m_without_attempt_counter(self):
+        # A seed that is not a SeedClass carries no counter, so the walk stays
+        # on the first value, and stays there for good.
+        nums, _, _ = get_rnds({"rnd": "m[1,7]"}, "rnd", 12345)
+        self.assertEqual(self.walk("m[1,7]", 1)[0], nums)
+        self.assertEqual(nums, get_rnds({"rnd": "m[1,7]"}, "rnd", 12345)[0])
+
+    def test_m_same_attempt_gives_same_value(self):
+        self.assertEqual(self.walk("m[1,7]", 20), self.walk("m[1,7]", 20))
+        self.assertNotEqual(self.walk("m[1,7]", 20), self.walk("m[1,7]", 20, 999))
+
+    def test_m_bad_range(self):
+        # ValueError is what insert_rnds turns into a message in the document.
+        for spec in ["m", "m[1,7,0]", "m[1,900]"]:
+            with self.assertRaises(ValueError, msg=spec):
+                get_rnds({"rnd": spec}, "rnd", SeedClass(1, 0))
+
+    def test_m_with_new_task_seed(self):
+        # A paragraph is only a new task, and so only gets its attempts
+        # counted, when it has seed="answernr". That is therefore the seed an
+        # m-list is used with, and it must not put the pool in a new order on
+        # every attempt.
+        nums = [v[0] for v in self.walk("m[1,7]", 14, attrs={"seed": "answernr"})]
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7], sorted(nums[:7]))
+        self.assertEqual([1, 2, 3, 4, 5, 6, 7], sorted(nums[7:]))
+        for i in range(1, len(nums)):
+            self.assertNotEqual(nums[i - 1], nums[i], msg=f"{i=}")

--- a/timApp/util/rndutils.py
+++ b/timApp/util/rndutils.py
@@ -351,7 +351,7 @@ def get_rnds(
         return None, rnd_seed, state
 
     # How many attempts came before this one.
-    # Only m-lists use it; without it they stay on the first value.
+    # Only i-lists use it; without it they stay on the first value.
     index = rnd_seed.extraseed if isinstance(rnd_seed, SeedClass) else 0
 
     seed_to_use = rnd_seed
@@ -380,9 +380,13 @@ def get_rnds(
     # An i-list has to see the same pool on every attempt. seed="answernr" mixes
     # the attempt number into seed_to_use, which would put the pool in a new order
     # every time and undo the point of walking it.
-    distinct_list_seed = seed_to_use
+    stable_seed = seed_to_use
     if attrs_seed == "answernr" and isinstance(rnd_seed, SeedClass):
-        distinct_list_seed = rnd_seed.seed
+        stable_seed = rnd_seed.seed
+    # The name is mixed in so that two i-lists in the same block walk different
+    # orders. s and u are kept apart by the shared generator state instead, which
+    # an i-list does not use.
+    distinct_list_seed = f"{stable_seed}:{name}"
 
     myrandom = Random()
     myrandom.seed(a=seed_to_use)
@@ -425,8 +429,12 @@ def get_rands_as_dict(
         return None, rnd_seed, state
     names = attrs.get("rndnames", "rnd").split(",")
     ret: dict = {}
+    # get_rnds gives back a plain seed number, so passing that on would leave every
+    # name but the first without the attempt counter, and their i-lists would sit on
+    # the first value. Give each name the same SeedClass instead.
+    counter_seed = rnd_seed if isinstance(rnd_seed, SeedClass) else None
     for name in names:
-        rnds, rnd_seed, state = get_rnds(attrs, name, rnd_seed, state)
+        rnds, rnd_seed, state = get_rnds(attrs, name, counter_seed or rnd_seed, state)
         if rnds is None:
             continue
         ret[name] = rnds

--- a/timApp/util/rndutils.py
+++ b/timApp/util/rndutils.py
@@ -172,10 +172,11 @@ def sep_n_and_range(jso: str) -> tuple[int, str]:
 
     Unlike sep_n_and_jso, a value without a separator is the range and the count
     defaults to one, because an i-list gives one value per attempt by default.
+    A bare number is then the size of that range, as in s: i10 walks 0-9.
     For example:
         "3:[1,20]" -> 3, "[1,20]"
         "[1,7]"    -> 1, "[1,7]"
-        "10"       -> 1, "10"
+        "10"       -> 1, "[0,9]"
 
     :param jso: string to check
     :return: count of values per attempt and the string that stands for a range
@@ -184,7 +185,10 @@ def sep_n_and_range(jso: str) -> tuple[int, str]:
     if idx < 0:
         idx = jso.find("*")
     if idx < 0:
-        return 1, jso
+        try:
+            return 1, f"[0,{int(jso) - 1}]"
+        except ValueError:
+            return 1, jso
     n_str = jso[:idx]
     try:
         n = int(n_str)

--- a/timApp/util/rndutils.py
+++ b/timApp/util/rndutils.py
@@ -168,7 +168,7 @@ def get_uniform_list(myrandom: Random, jso: str) -> list[float]:
 
 def sep_n_and_range(jso: str) -> tuple[int, str]:
     """
-    Separates the count and the range part of a modulo (m) instruction.
+    Separates the count and the range part of an (m) instruction.
 
     Unlike sep_n_and_jso, a value without a separator is the range and the count
     defaults to one, because an m-list gives one value per attempt by default.
@@ -194,7 +194,7 @@ def sep_n_and_range(jso: str) -> tuple[int, str]:
     return min(n, MAX_RND_LIST_LEN), jso[idx + 1 :]
 
 
-def get_modulo_pool(jso: str) -> list[int]:
+def get_m_pool(jso: str) -> list[int]:
     """
     Returns the pool of unique values that an m-list cycles through.
 
@@ -238,16 +238,13 @@ def shuffle_pool(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
     return ints
 
 
-def get_modulo_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
+def get_m_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
     """
     Returns the order in which one cycle uses the values of the pool.
 
     Each cycle is shuffled anew, but a cycle never starts with the value the
     cycle before it ended with, so no value is given twice in a row over the
-    wrap. The fix moves the first value only, and never into the last slot, so
-    the last value of a cycle is always its plain shuffle. That is what lets the
-    cycle before this one be checked without working through every cycle since
-    the first one.
+    wrap.
 
     :param base_seed: seed that stays the same from one attempt to the next
     :param cycle: how many full rounds of the pool were used before this one
@@ -257,10 +254,7 @@ def get_modulo_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[i
     size = len(pool)
     if cycle <= 0 or size < 2:
         return shuffle_pool(base_seed, cycle, pool)
-    if size == 2:
-        # Two values leave no room to choose: the cycle has to start with the
-        # one the cycle before it did not end with, which is the first cycle
-        # over again.
+    if size == 2:  # Two values leave no room to choose
         return shuffle_pool(base_seed, 0, pool)
     ints = shuffle_pool(base_seed, cycle, pool)
     if ints[0] == shuffle_pool(base_seed, cycle - 1, pool)[-1]:
@@ -269,7 +263,7 @@ def get_modulo_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[i
     return ints
 
 
-def get_modulo_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
+def get_m_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
     """
     Returns one attempt's worth of values from a shuffled pool.
 
@@ -283,7 +277,7 @@ def get_modulo_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
     :return: list of values for this attempt
     """
     n, jso = sep_n_and_range(jso)
-    pool = get_modulo_pool(jso)
+    pool = get_m_pool(jso)
     size = len(pool)
     cycles: dict[int, list[int]] = {}
     ret = []
@@ -291,7 +285,7 @@ def get_modulo_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
         cycle, slot = divmod(pos, size)
         order = cycles.get(cycle)
         if order is None:
-            order = get_modulo_cycle(base_seed, cycle, pool)
+            order = get_m_cycle(base_seed, cycle, pool)
             cycles[cycle] = order
         ret.append(order[slot])
     return ret
@@ -356,9 +350,7 @@ def get_rnds(
     if not jso:
         return None, rnd_seed, state
 
-    # How many attempts came before this one. A paragraph is a new task when it
-    # has seed="answernr", and only then does pluginControl put the answer
-    # number in extraseed, growing by one for every version askNew hands out.
+    # How many attempts came before this one.
     # Only m-lists use it; without it they stay on the first value.
     index = rnd_seed.extraseed if isinstance(rnd_seed, SeedClass) else 0
 
@@ -390,9 +382,9 @@ def get_rnds(
     # seed_to_use, which would put the pool in a new order every time and undo
     # the point of walking it; for an m-list the attempt number is what picks
     # the value out of the pool instead.
-    modulo_seed = seed_to_use
+    mlist_seed = seed_to_use
     if attrs_seed == "answernr" and isinstance(rnd_seed, SeedClass):
-        modulo_seed = rnd_seed.seed
+        mlist_seed = rnd_seed.seed
 
     myrandom = Random()
     myrandom.seed(a=seed_to_use)
@@ -410,7 +402,7 @@ def get_rnds(
 
     if jso.startswith("m"):  # m[1,7], m[1,7,2], m3:[1,20], m10
         return (
-            get_modulo_list(modulo_seed, index, jso[1:]),
+            get_m_list(mlist_seed, index, jso[1:]),
             seed_to_use,
             myrandom.getstate(),
         )

--- a/timApp/util/rndutils.py
+++ b/timApp/util/rndutils.py
@@ -166,6 +166,137 @@ def get_uniform_list(myrandom: Random, jso: str) -> list[float]:
     return ret
 
 
+def sep_n_and_range(jso: str) -> tuple[int, str]:
+    """
+    Separates the count and the range part of a modulo (m) instruction.
+
+    Unlike sep_n_and_jso, a value without a separator is the range and the count
+    defaults to one, because an m-list gives one value per attempt by default.
+    For example:
+        "3:[1,20]" -> 3, "[1,20]"
+        "[1,7]"    -> 1, "[1,7]"
+        "10"       -> 1, "10"
+
+    :param jso: string to check
+    :return: count of values per attempt and the string that stands for a range
+    """
+    idx = jso.find(":")
+    if idx < 0:
+        idx = jso.find("*")
+    if idx < 0:
+        return 1, jso
+    n_str = jso[:idx]
+    try:
+        n = int(n_str)
+    except ValueError:
+        n = 1
+    n = max(n, 1)
+    return min(n, MAX_RND_LIST_LEN), jso[idx + 1 :]
+
+
+def get_modulo_pool(jso: str) -> list[int]:
+    """
+    Returns the pool of unique values that an m-list cycles through.
+
+    :param jso: string to find the values, for example "[1,7]", "[1,7,2]" or "10"
+    :return: list of unique ints
+    """
+    if not jso:
+        raise ValueError("No range for m")
+    if not jso.startswith("["):  # m10
+        jso = "[" + jso + "]"
+    r = json.loads(jso)
+    if len(r) < 2:  # m[50]
+        r.insert(0, 0)
+    step = 1
+    if len(r) > 2:  # m[1,7,2]
+        step = r[2]
+    if step == 0:
+        raise ValueError("Zero step for m")
+    if abs(r[1] - r[0]) > 500:
+        raise ValueError(f"Too big range for m: {r[0]}-{r[1]}")
+    # Like s, both ends of the range belong to it.
+    pool = list(range(r[0], r[1] + (1 if step > 0 else -1), step))
+    if not pool:
+        raise ValueError(f"Empty range for m: {r[0]}-{r[1]}")
+    return pool
+
+
+def shuffle_pool(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
+    """
+    Returns the pool shuffled for one cycle, not looking at any other cycle.
+
+    :param base_seed: seed that stays the same from one attempt to the next
+    :param cycle: how many full rounds of the pool were used before this one
+    :param pool: values to shuffle
+    :return: shuffled copy of pool
+    """
+    ints = list(pool)
+    myrandom = Random()
+    myrandom.seed(a=f"{base_seed}:{cycle}")
+    myrandom.shuffle(ints)
+    return ints
+
+
+def get_modulo_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
+    """
+    Returns the order in which one cycle uses the values of the pool.
+
+    Each cycle is shuffled anew, but a cycle never starts with the value the
+    cycle before it ended with, so no value is given twice in a row over the
+    wrap. The fix moves the first value only, and never into the last slot, so
+    the last value of a cycle is always its plain shuffle. That is what lets the
+    cycle before this one be checked without working through every cycle since
+    the first one.
+
+    :param base_seed: seed that stays the same from one attempt to the next
+    :param cycle: how many full rounds of the pool were used before this one
+    :param pool: values to put in order
+    :return: values of pool in the order this cycle uses them
+    """
+    size = len(pool)
+    if cycle <= 0 or size < 2:
+        return shuffle_pool(base_seed, cycle, pool)
+    if size == 2:
+        # Two values leave no room to choose: the cycle has to start with the
+        # one the cycle before it did not end with, which is the first cycle
+        # over again.
+        return shuffle_pool(base_seed, 0, pool)
+    ints = shuffle_pool(base_seed, cycle, pool)
+    if ints[0] == shuffle_pool(base_seed, cycle - 1, pool)[-1]:
+        i = 1 + cycle % (size - 2)  # neither the first nor the last slot
+        ints[0], ints[i] = ints[i], ints[0]
+    return ints
+
+
+def get_modulo_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
+    """
+    Returns one attempt's worth of values from a shuffled pool.
+
+    The pool is walked in order, so a value comes up again only after every
+    other value has been used. When the pool runs out, the walk wraps around to
+    a new shuffle of the same values.
+
+    :param base_seed: seed that stays the same from one attempt to the next
+    :param index: number of attempts before this one, from SeedClass.extraseed
+    :param jso: string to find the values
+    :return: list of values for this attempt
+    """
+    n, jso = sep_n_and_range(jso)
+    pool = get_modulo_pool(jso)
+    size = len(pool)
+    cycles: dict[int, list[int]] = {}
+    ret = []
+    for pos in range(index * n, index * n + n):
+        cycle, slot = divmod(pos, size)
+        order = cycles.get(cycle)
+        if order is None:
+            order = get_modulo_cycle(base_seed, cycle, pool)
+            cycles[cycle] = order
+        ret.append(order[slot])
+    return ret
+
+
 T = TypeVar("T")
 
 
@@ -225,6 +356,12 @@ def get_rnds(
     if not jso:
         return None, rnd_seed, state
 
+    # How many attempts came before this one. A paragraph is a new task when it
+    # has seed="answernr", and only then does pluginControl put the answer
+    # number in extraseed, growing by one for every version askNew hands out.
+    # Only m-lists use it; without it they stay on the first value.
+    index = rnd_seed.extraseed if isinstance(rnd_seed, SeedClass) else 0
+
     seed_to_use = rnd_seed
     attrs_seed = attrs.get("seed", None)
     if attrs_seed is not None:
@@ -248,6 +385,15 @@ def get_rnds(
         # seed_to_use = int(time.perf_counter() * 1000)
         seed_to_use = secrets.randbits(64)
 
+    # An m-list has to see the same pool on every attempt, so it seeds from the
+    # part that does not change. seed="answernr" mixes the attempt number into
+    # seed_to_use, which would put the pool in a new order every time and undo
+    # the point of walking it; for an m-list the attempt number is what picks
+    # the value out of the pool instead.
+    modulo_seed = seed_to_use
+    if attrs_seed == "answernr" and isinstance(rnd_seed, SeedClass):
+        modulo_seed = rnd_seed.seed
+
     myrandom = Random()
     myrandom.seed(a=seed_to_use)
     if state:
@@ -258,6 +404,13 @@ def get_rnds(
     if jso.startswith("u"):  # u[[0,1],[100,110],[-30,-20],[0.001,0.002]], u6
         return (
             repeat_rnd(get_uniform_list, myrandom, jso[1:]),
+            seed_to_use,
+            myrandom.getstate(),
+        )
+
+    if jso.startswith("m"):  # m[1,7], m[1,7,2], m3:[1,20], m10
+        return (
+            get_modulo_list(modulo_seed, index, jso[1:]),
             seed_to_use,
             myrandom.getstate(),
         )

--- a/timApp/util/rndutils.py
+++ b/timApp/util/rndutils.py
@@ -168,10 +168,10 @@ def get_uniform_list(myrandom: Random, jso: str) -> list[float]:
 
 def sep_n_and_range(jso: str) -> tuple[int, str]:
     """
-    Separates the count and the range part of an (m) instruction.
+    Separates the count and the range part of an (i) instruction.
 
     Unlike sep_n_and_jso, a value without a separator is the range and the count
-    defaults to one, because an m-list gives one value per attempt by default.
+    defaults to one, because an i-list gives one value per attempt by default.
     For example:
         "3:[1,20]" -> 3, "[1,20]"
         "[1,7]"    -> 1, "[1,7]"
@@ -194,31 +194,31 @@ def sep_n_and_range(jso: str) -> tuple[int, str]:
     return min(n, MAX_RND_LIST_LEN), jso[idx + 1 :]
 
 
-def get_m_pool(jso: str) -> list[int]:
+def get_distinct_pool(jso: str) -> list[int]:
     """
-    Returns the pool of unique values that an m-list cycles through.
+    Returns the pool of unique values that a list cycles through.
 
     :param jso: string to find the values, for example "[1,7]", "[1,7,2]" or "10"
     :return: list of unique ints
     """
     if not jso:
-        raise ValueError("No range for m")
-    if not jso.startswith("["):  # m10
+        raise ValueError("No range for i")
+    if not jso.startswith("["):  # i10
         jso = "[" + jso + "]"
     r = json.loads(jso)
-    if len(r) < 2:  # m[50]
+    if len(r) < 2:  # i[50]
         r.insert(0, 0)
     step = 1
-    if len(r) > 2:  # m[1,7,2]
+    if len(r) > 2:  # i[1,7,2]
         step = r[2]
     if step == 0:
-        raise ValueError("Zero step for m")
+        raise ValueError("Zero step for i")
     if abs(r[1] - r[0]) > 500:
-        raise ValueError(f"Too big range for m: {r[0]}-{r[1]}")
+        raise ValueError(f"Too big range for i: {r[0]}-{r[1]}")
     # Like s, both ends of the range belong to it.
     pool = list(range(r[0], r[1] + (1 if step > 0 else -1), step))
     if not pool:
-        raise ValueError(f"Empty range for m: {r[0]}-{r[1]}")
+        raise ValueError(f"Empty range for i: {r[0]}-{r[1]}")
     return pool
 
 
@@ -238,7 +238,7 @@ def shuffle_pool(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
     return ints
 
 
-def get_m_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
+def get_distinct_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
     """
     Returns the order in which one cycle uses the values of the pool.
 
@@ -263,7 +263,7 @@ def get_m_cycle(base_seed: SeedType, cycle: int, pool: list[int]) -> list[int]:
     return ints
 
 
-def get_m_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
+def get_distinct_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
     """
     Returns one attempt's worth of values from a shuffled pool.
 
@@ -277,7 +277,7 @@ def get_m_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
     :return: list of values for this attempt
     """
     n, jso = sep_n_and_range(jso)
-    pool = get_m_pool(jso)
+    pool = get_distinct_pool(jso)
     size = len(pool)
     cycles: dict[int, list[int]] = {}
     ret = []
@@ -285,7 +285,7 @@ def get_m_list(base_seed: SeedType, index: int, jso: str) -> list[int]:
         cycle, slot = divmod(pos, size)
         order = cycles.get(cycle)
         if order is None:
-            order = get_m_cycle(base_seed, cycle, pool)
+            order = get_distinct_cycle(base_seed, cycle, pool)
             cycles[cycle] = order
         ret.append(order[slot])
     return ret
@@ -377,14 +377,12 @@ def get_rnds(
         # seed_to_use = int(time.perf_counter() * 1000)
         seed_to_use = secrets.randbits(64)
 
-    # An m-list has to see the same pool on every attempt, so it seeds from the
-    # part that does not change. seed="answernr" mixes the attempt number into
-    # seed_to_use, which would put the pool in a new order every time and undo
-    # the point of walking it; for an m-list the attempt number is what picks
-    # the value out of the pool instead.
-    mlist_seed = seed_to_use
+    # An i-list has to see the same pool on every attempt. seed="answernr" mixes
+    # the attempt number into seed_to_use, which would put the pool in a new order
+    # every time and undo the point of walking it.
+    distinct_list_seed = seed_to_use
     if attrs_seed == "answernr" and isinstance(rnd_seed, SeedClass):
-        mlist_seed = rnd_seed.seed
+        distinct_list_seed = rnd_seed.seed
 
     myrandom = Random()
     myrandom.seed(a=seed_to_use)
@@ -400,9 +398,9 @@ def get_rnds(
             myrandom.getstate(),
         )
 
-    if jso.startswith("m"):  # m[1,7], m[1,7,2], m3:[1,20], m10
+    if jso.startswith("i"):  # i[1,7], i[1,7,2], i3:[1,20], i10
         return (
-            get_m_list(mlist_seed, index, jso[1:]),
+            get_distinct_list(distinct_list_seed, index, jso[1:]),
             seed_to_use,
             myrandom.getstate(),
         )


### PR DESCRIPTION
Lisää `rnd`:lle moodin `i`, joka tuottaa listan kokonaislukuja lukuväliltä siten, että mikään luku ei toistu. Käytetään mm. Kvanttiaakkosissa tehtävän vaihtoehtojen poimimiseen satunnaisesti rajatusta määrästä vaihtoehtoja, eli `i`:n tuottamat arvot toimivat indekseinä.
Kun tehtävästä annetaan käyttäjälle uusia versioita (`buttonNewTask`-attribuutilla), tavallinen
arvonta arpoo joka kerta uudestaan, jolloin sama arvo voi tulla monta kertaa peräkkäin
ja jokin arvo ei ehkä tule ollenkaan.  

Muodolla `i` arvot käydään läpi sotketussa järjestyksessä: sama arvo toistuu vasta kun kaikki muut on käyty läpi. Jos tehtäviä arvotaan niin monta kertaa, että kaikki arvot on käytetty, tuotetaan uusi lista arvoja niin, että samaa arvoa ei
tule peräkkäin edes listan 'vaihtuessa'. Uusi lista on uudessa sekoitetussa järjestyksessä, eli toistuvuutta ei ole myöskään kokonaisten listojen välillä.