### PR TITLE
Fix stackpeek not updating

### DIFF
--- a/timApp/modules/cs/js/stack.ts
+++ b/timApp/modules/cs/js/stack.ts
@@ -541,6 +541,7 @@ export class StackPluginComponent
         const r = await this.postAnswer<{web: {stackResult: StackResult}}>({
             input: {
                 nosave: true,
+                stackPeek: true,
                 type: "stack",
                 usercode: "",
                 stackData: {...data},

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -81,6 +81,8 @@ class Stack(Language):
         prev_answer = input.get("prevAnswer", False)
         hide_results = markup.get("hideResults", False)
 
+        stack_peek = input.get("stackPeek", False)
+
         q = stack_data.get("question", "")
         q_data = self.parse_stack_question(
             q, not self.query.jso.get("markup").get("stackjsx")
@@ -121,25 +123,26 @@ class Stack(Language):
         #
         # This is to prevent the correct answer from leaking prematurely via web -> stackResult.
         ucode = input.get("usercode", "")
-        if ucode:
-            # Stack tasks may have several answer fields, so we need to check each one
-            ucode = json.loads(ucode)
-            ucode = len("".join([str(v) for v in ucode.values()])) > 0
-        score = r["score"]
-        valid = info.get("valid", False)
-        max_tries = info.get("max_answers", 1)
-        num_tries = info.get("earlier_answers", 0)
-        # If max_tries is None the task does not have an answer limit
-        has_tries_left = True if max_tries is None else num_tries <= max_tries
+        if not stack_peek:
+            if ucode:
+                # Stack tasks may have several answer fields, so we need to check each one
+                ucode = json.loads(ucode)
+                ucode = len("".join([str(v) for v in ucode.values()])) > 0
+            score = r["score"]
+            valid = info.get("valid", False)
+            max_tries = info.get("max_answers", 1)
+            num_tries = info.get("earlier_answers", 0)
+            # If max_tries is None the task does not have an answer limit
+            has_tries_left = True if max_tries is None else num_tries <= max_tries
 
-        if (
-            (not has_tries_left)
-            or (not valid)
-            or (not ucode)
-            or (not score)
-            or (not has_tries_left and score <= 0)
-        ):
-            r["formatcorrectresponse"] = ""
+            if (
+                (not has_tries_left)
+                or (not valid)
+                or (not ucode)
+                or (not score)
+                or (not has_tries_left and score <= 0)
+            ):
+                r["formatcorrectresponse"] = ""
 
         if "score" in r:
             out = "Score: %s" % r.get("score", 0)
@@ -147,7 +150,7 @@ class Stack(Language):
 
         # r['questiontext'] = tim_sanitize(r['questiontext'])
 
-        if hide_results:
+        if hide_results and not stack_peek:
             # The information about points needs to be removed from the questiontext HTML
             question_text = r.get("questiontext", "")
             soup = BeautifulSoup(question_text, "html.parser")

--- a/timApp/modules/cs/stack.py
+++ b/timApp/modules/cs/stack.py
@@ -130,17 +130,18 @@ class Stack(Language):
                 ucode = len("".join([str(v) for v in ucode.values()])) > 0
             score = r["score"]
             valid = info.get("valid", False)
-            max_tries = info.get("max_answers", 1)
+            max_tries = info.get("max_answers")
             num_tries = info.get("earlier_answers", 0)
-            # If max_tries is None the task does not have an answer limit
-            has_tries_left = True if max_tries is None else num_tries <= max_tries
+            answer_limit_exceeded = (
+                True if max_tries is None else num_tries >= max_tries
+            )
 
             if (
-                (not has_tries_left)
+                (not answer_limit_exceeded)
                 or (not valid)
                 or (not ucode)
                 or (not score)
-                or (not has_tries_left and score <= 0)
+                or (not answer_limit_exceeded and score <= 0)
             ):
                 r["formatcorrectresponse"] = ""
 


### PR DESCRIPTION
###  Purpose
Currently there is a bug in STACK, where the stackpeek does not display at all. This is caused by an uncaught exception happening in stack.py. '

### The fix
This pull request adds a new parameter (stackPeek) when calling the stack from frontend. This is used for checking if removal of `formatcorrectresponse` is needed. The removal of correct response is not needed in stackpeek as the stack server does not include correct answers, when processing inputs.

### Other changes
The parsing connected to the hideResults option is not done when doing stackPeek. Reason: The `stackpartmark` is not in the response, when doing stackPeek. Without this change the beatifulsoup parsing runs every time user inputs something in the input fields.